### PR TITLE
Add support for Python 3.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 **/__pycache__/
 
 # Development
-env/
+env*/
 .vscode/
 .DS_Store
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     install_requires=[
         'ethereum==2.3.0',
-        'web3==4.3.0',
+        'web3==4.5.0',
         'rlp==0.6.0',
         'py-solc==3.1.0'
     ]


### PR DESCRIPTION
Bumps Web3.py version to 4.5.0 for Python 3.7 support. Small change to gitignore to handle multiple `env*` folders.