### PR TITLE
Break out builder for contracts into separate package

### DIFF
--- a/plasma_core/utils/deployer.py
+++ b/plasma_core/utils/deployer.py
@@ -1,102 +1,12 @@
-import json
-import os
-from solc import compile_standard
 from web3.contract import ConciseContract
 from web3 import Web3, HTTPProvider
 
 
-OUTPUT_DIR = 'contract_data'
-
-
 class Deployer(object):
 
-    def __init__(self, contracts_dir, provider=HTTPProvider('http://localhost:8545')):
-        self.contracts_dir = contracts_dir
+    def __init__(self, builder, provider=HTTPProvider('http://localhost:8545')):
+        self.builder = builder
         self.w3 = Web3(provider)
-
-    def get_solc_input(self):
-        """Walks the contract directory and returns a Solidity input dict
-
-        Learn more about Solidity input JSON here: https://goo.gl/7zKBvj
-
-        Returns:
-            dict: A Solidity input JSON object as a dict
-        """
-
-        solc_input = {
-            'language': 'Solidity',
-            'sources': {
-                file_name: {
-                    'urls': [os.path.realpath(os.path.join(r, file_name))]
-                } for r, d, f in os.walk(self.contracts_dir) for file_name in f
-            },
-            'settings': {
-                'outputSelection': {
-                    "*": {
-                        "": [
-                            "legacyAST",
-                            "ast"
-                        ],
-                        "*": [
-                            "abi",
-                            "evm.bytecode.object",
-                            "evm.bytecode.sourceMap",
-                            "evm.deployedBytecode.object",
-                            "evm.deployedBytecode.sourceMap"
-                        ]
-                    }
-                }
-            }
-        }
-
-        return solc_input
-
-    def compile_all(self):
-        """Compiles all of the contracts in the /contracts directory
-
-        Creates {contract name}.json files in /build that contain
-        the build output for each contract.
-        """
-
-        # Solidity input JSON
-        solc_input = self.get_solc_input()
-
-        # Compile the contracts
-        compilation_result = compile_standard(solc_input, allow_paths=self.contracts_dir)
-
-        # Create the output folder if it doesn't already exist
-        os.makedirs(OUTPUT_DIR, exist_ok=True)
-
-        # Write the contract ABI to output files
-        compiled_contracts = compilation_result['contracts']
-        for contract_file in compiled_contracts:
-            for contract in compiled_contracts[contract_file]:
-                contract_name = contract.split('.')[0]
-                contract_data = compiled_contracts[contract_file][contract_name]
-
-                contract_data_path = OUTPUT_DIR + '/{0}.json'.format(contract_name)
-                with open(contract_data_path, "w+") as contract_data_file:
-                    json.dump(contract_data, contract_data_file)
-
-    @staticmethod
-    def get_contract_data(contract_name):
-        """Returns the contract data for a given contract
-
-        Args:
-            contract_name (str): Name of the contract to return.
-
-        Returns:
-            str, str: ABI and bytecode of the contract
-        """
-
-        contract_data_path = OUTPUT_DIR + '/{0}.json'.format(contract_name)
-        with open(contract_data_path, 'r') as contract_data_file:
-            contract_data = json.load(contract_data_file)
-
-        abi = contract_data['abi']
-        bytecode = contract_data['evm']['bytecode']['object']
-
-        return abi, bytecode
 
     def deploy_contract(self, contract_name, gas=5000000, args=(), concise=True):
         """Deploys a contract to the given Ethereum network using Web3
@@ -112,7 +22,7 @@ class Deployer(object):
             Contract: A Web3 contract instance.
         """
 
-        abi, bytecode = self.get_contract_data(contract_name)
+        abi, bytecode = self.builder.get_contract_data(contract_name)
 
         contract = self.w3.eth.contract(abi=abi, bytecode=bytecode)
 
@@ -144,7 +54,7 @@ class Deployer(object):
             Contract: A Web3 contract instance.
         """
 
-        abi, _ = self.get_contract_data(contract_name)
+        abi, _ = self.builder.get_contract_data(contract_name)
 
         contract_instance = self.w3.eth.contract(abi=abi, address=address)
 

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup(
         'ethereum==2.3.0',
         'web3==4.5.0',
         'rlp==0.6.0',
-        'py-solc==3.1.0'
+        'py-solc-simple==0.0.10'
     ]
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from ethereum.tools import tester
 from ethereum.abi import ContractTranslator
 from ethereum.config import config_metropolis
 from plasma_core.utils.deployer import Deployer
+from solc_simple import Builder
 from testlang.testlang import TestingLanguage
 
 
@@ -16,8 +17,10 @@ config_metropolis['BLOCK_GAS_LIMIT'] = GAS_LIMIT
 # Compile contracts before testing
 OWN_DIR = os.path.dirname(os.path.realpath(__file__))
 CONTRACTS_DIR = os.path.abspath(os.path.realpath(os.path.join(OWN_DIR, '../contracts')))
-deployer = Deployer(CONTRACTS_DIR)
-deployer.compile_all()
+OUTPUT_DIR = os.path.abspath(os.path.realpath(os.path.join(OWN_DIR, '../build')))
+builder = Builder(CONTRACTS_DIR, OUTPUT_DIR)
+builder.compile_all()
+deployer = Deployer(builder)
 
 
 @pytest.fixture
@@ -34,7 +37,7 @@ def ethutils():
 @pytest.fixture
 def get_contract(ethtester, ethutils):
     def create_contract(path, args=(), sender=ethtester.k0):
-        abi, hexcode = deployer.get_contract_data(path)
+        abi, hexcode = deployer.builder.get_contract_data(path)
         bytecode = ethutils.decode_hex(hexcode)
         encoded_args = (ContractTranslator(abi).encode_constructor_arguments(args) if args else b'')
         code = bytecode + encoded_args


### PR DESCRIPTION
Main idea - to use single building tool for both contract tests and production node.

In PR for use in production plasma chain, also is likely to be used in fee-burner.

package: https://pypi.org/project/py-solc-simple/
source: https://github.com/paulperegud/py_solc_simple/