### PR TITLE
Switch to rlp 1.0.0

### DIFF
--- a/plasma_core/block.py
+++ b/plasma_core/block.py
@@ -1,5 +1,5 @@
-import rlp
-from rlp.sedes import binary, CountableList, big_endian_int
+from rlp.sedes import CountableList, big_endian_int
+from rlp.sedes.serializable import Serializable
 from ethereum import utils
 from plasma_core.utils.signatures import sign, get_signer
 from plasma_core.utils.merkle.fixed_merkle import FixedMerkle
@@ -7,13 +7,14 @@ from plasma_core.transaction import Transaction
 from plasma_core.constants import NULL_SIGNATURE
 
 
-class Block(rlp.Serializable):
-
+class UnsignedBlockRLP(Serializable):
     fields = [
         ('transaction_set', CountableList(Transaction)),
-        ('sig', binary),
         ('number', big_endian_int)
     ]
+
+
+class Block():
 
     def __init__(self, transaction_set=[], sig=NULL_SIGNATURE, number=0):
         self.transaction_set = transaction_set
@@ -39,7 +40,7 @@ class Block(rlp.Serializable):
 
     @property
     def encoded(self):
-        return rlp.encode(self, UnsignedBlock)
+        return UnsignedBlockRLP.serialize(UnsignedBlockRLP(self.transaction_set, self.number))
 
     @property
     def is_deposit_block(self):
@@ -47,6 +48,3 @@ class Block(rlp.Serializable):
 
     def sign(self, key):
         self.sig = sign(self.hash, key)
-
-
-UnsignedBlock = Block.exclude(['sig'])

--- a/plasma_core/constants.py
+++ b/plasma_core/constants.py
@@ -2,45 +2,45 @@ from ethereum import utils as u
 
 AUTHORITY = {
     'address': '0xfd02EcEE62797e75D86BCff1642EB0844afB28c7',
-    'key': u.normalize_key(b'3bb369fecdc16b93b99514d8ed9c2e87c5824cf4a6a98d2e8e91b7dd0c063304')
+    'key': u.normalize_key("3bb369fecdc16b93b99514d8ed9c2e87c5824cf4a6a98d2e8e91b7dd0c063304")
 }
 
 ACCOUNTS = [
     {
         'address': '0x4B3eC6c9dC67079E82152d6D55d8dd96a8e6AA26',
-        'key': u.normalize_key(b'b937b2c6a606edf1a4d671485f0fa61dcc5102e1ebca392f5a8140b23a8ac04f')
+        'key': u.normalize_key("b937b2c6a606edf1a4d671485f0fa61dcc5102e1ebca392f5a8140b23a8ac04f")
     },
     {
         'address': '0xda20A48913f9031337a5e32325F743e8536860e2',
-        'key': u.normalize_key(b'999ba3f77899ba4802af5109221c64a9238a6772718f287a8bd3ca3d1b68187f')
+        'key': u.normalize_key("999ba3f77899ba4802af5109221c64a9238a6772718f287a8bd3ca3d1b68187f")
     },
     {
         'address': '0xF6d8982698dCC46b8E96e34bC2BF3c97302b9923',
-        'key': u.normalize_key(b'ef4134d11aa32bcbd314d3cd94b7a5f93bea2b809007d4307a4393cce0285652')
+        'key': u.normalize_key("ef4134d11aa32bcbd314d3cd94b7a5f93bea2b809007d4307a4393cce0285652")
     },
     {
         'address': '0x2d75468C0cafA9D41FC5BF3ccA6C292a3cC03d94',
-        'key': u.normalize_key(b'25c8620e5bd51caed1d2ff5e79b43dfbef17d0b4eb38d0db8d834da9de5a6120')
+        'key': u.normalize_key("25c8620e5bd51caed1d2ff5e79b43dfbef17d0b4eb38d0db8d834da9de5a6120")
     },
     {
         'address': '0xF05B4B746AAd830062505AD0cFd3619917484E46',
-        'key': u.normalize_key(b'e3d66a68573a85734e80d3de47b82e13374c2a026f219cb766978510a8b8697e')
+        'key': u.normalize_key("e3d66a68573a85734e80d3de47b82e13374c2a026f219cb766978510a8b8697e")
     },
     {
         'address': '0x81A9bfA79598f1536B4918A6556e9855c5E141d5',
-        'key': u.normalize_key(b'81e244b79cef097c187d9299a2fc3a680cf1d2637fb7463ca7aa70445a0a0410')
+        'key': u.normalize_key("81e244b79cef097c187d9299a2fc3a680cf1d2637fb7463ca7aa70445a0a0410")
     },
     {
         'address': '0xa669513ad878cC0891d8C305CC21903068a9AFe9',
-        'key': u.normalize_key(b'ebcaa9c519c2aaa27e7c1656451b9c72167cadf0fd30bc4bcc3bda6d6fcbd507')
+        'key': u.normalize_key("ebcaa9c519c2aaa27e7c1656451b9c72167cadf0fd30bc4bcc3bda6d6fcbd507")
     },
     {
         'address': '0xC3AaE3a9be258BD485105ef81EB0D5b677EE26fd',
-        'key': u.normalize_key(b'b991543d47829ea4f296d182dfa7088303fb3f04dd0c95a5cb7132397e4a008d')
+        'key': u.normalize_key("b991543d47829ea4f296d182dfa7088303fb3f04dd0c95a5cb7132397e4a008d")
     },
     {
         'address': '0xB9DB71c2D02a1B30dfE29C90738b3228Dd9d2ec2',
-        'key': u.normalize_key(b'484eb2f0465e7357575f05bf5af5e77cb4b678fb774dd127d9d99e3d31c5f80e')
+        'key': u.normalize_key("484eb2f0465e7357575f05bf5af5e77cb4b678fb774dd127d9d99e3d31c5f80e")
     }
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,9 @@ setup(
     keywords='plasma contracts ethereum development solidity',
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     install_requires=[
-        'ethereum==2.3.0',
-        'web3==4.5.0',
-        'rlp==0.6.0',
+        'ethereum==2.3.2',
+        'web3==4.7.2',
+        'rlp==1.0.3',
         'py-solc-simple==0.0.10'
     ]
 )

--- a/testlang/testlang.py
+++ b/testlang/testlang.py
@@ -2,7 +2,7 @@ from plasma_core.child_chain import ChildChain
 from plasma_core.account import EthereumAccount
 from plasma_core.block import Block
 from plasma_core.transaction import Transaction
-from plasma_core.constants import NULL_ADDRESS
+from plasma_core.constants import NULL_ADDRESS, NULL_SIGNATURE
 from plasma_core.utils.signatures import sign
 from plasma_core.utils.transactions import decode_utxo_id, encode_utxo_id
 from plasma_core.utils.address import address_to_hex
@@ -109,7 +109,8 @@ class TestingLanguage(object):
                                  0, 0, 0,
                                  NULL_ADDRESS,
                                  owner.address, amount,
-                                 NULL_ADDRESS, 0)
+                                 NULL_ADDRESS, 0,
+                                 NULL_SIGNATURE, NULL_SIGNATURE)
 
         blknum = self.root_chain.getDepositBlock()
         self.root_chain.deposit(value=amount, sender=owner.key)
@@ -134,7 +135,8 @@ class TestingLanguage(object):
                                  0, 0, 0,
                                  token.address,
                                  owner.address, amount,
-                                 NULL_ADDRESS, 0)
+                                 NULL_ADDRESS, 0,
+                                 NULL_SIGNATURE, NULL_SIGNATURE)
 
         token.mint(owner.address, amount)
         self.ethtester.chain.mine()
@@ -167,7 +169,8 @@ class TestingLanguage(object):
                                0, 0, 0,
                                utxo.cur12,
                                new_owner.address, amount,
-                               NULL_ADDRESS, 0)
+                               NULL_ADDRESS, 0,
+                               NULL_SIGNATURE, NULL_SIGNATURE)
         spend_tx.sign1(signer.key)
         blknum = self.submit_block([spend_tx], force_invalid=force_invalid)
         tx_id = encode_utxo_id(blknum, 0, 0)
@@ -178,7 +181,9 @@ class TestingLanguage(object):
     def submit_block(self, transactions, signer=None, force_invalid=False):
         signer = signer or self.operator
         blknum = self.root_chain.currentChildBlock()
+        print("creating Block")
         block = Block(transactions, number=blknum)
+        print("creating Block ... DONE")
         block.sign(signer.key)
         self.root_chain.submitBlock(block.root, sender=signer.key)
         if force_invalid:

--- a/tests/contracts/priority_queue/test_priority_queue.py
+++ b/tests/contracts/priority_queue/test_priority_queue.py
@@ -84,7 +84,7 @@ def op_cost(n):
     tx_base_cost = 21000
     # Numbers were discovered experimentally. They represent upper bound of
     # gas cost of execution of delMin or insert operations.
-    return tx_base_cost + 26538 + 6638 * math.floor(math.log(n, 2))
+    return tx_base_cost + 26588 + 6638 * math.floor(math.log(n, 2))
 
 
 def test_priority_queue_worst_case_gas_cost(ethtester, priority_queue):

--- a/tests/contracts/rlp/test_rlp.py
+++ b/tests/contracts/rlp/test_rlp.py
@@ -23,16 +23,6 @@ class Eight(rlp.Serializable):
         ('f7', utils.address)
     ]
 
-    def __init__(self, f0, f1, f2, f3, f4, f5, f6, f7):
-        self.f0 = f0
-        self.f1 = f1
-        self.f2 = f2
-        self.f3 = f3
-        self.f4 = f4
-        self.f5 = f5
-        self.f6 = f6
-        self.f7 = f7
-
 
 class Eleven(rlp.Serializable):
     fields = [
@@ -48,19 +38,6 @@ class Eleven(rlp.Serializable):
         ('f9', utils.address),
         ('f10', utils.address)
     ]
-
-    def __init__(self, f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10):
-        self.f0 = f0
-        self.f1 = f1
-        self.f2 = f2
-        self.f3 = f3
-        self.f4 = f4
-        self.f5 = f5
-        self.f6 = f6
-        self.f7 = f7
-        self.f8 = f8
-        self.f9 = f9
-        self.f10 = f10
 
 
 @pytest.fixture


### PR DESCRIPTION
This switch will be required if we are to stay with pyethereum tester. Alternatively, we can just go with Ganache and ignore pyrlp 1.0.0.