### PR TITLE
prevent exploitation of `deposit` and `depositFrom` via re-entrance attack

### DIFF
--- a/contracts/RootChain.sol
+++ b/contracts/RootChain.sol
@@ -394,6 +394,12 @@ contract RootChain {
     function writeDepositBlock(address _owner, address _token, uint256 _amount)
         private
     {
+        // Following check is needed since writeDepositBlock
+        // can be called on stack unwinding during re-entrance attack,
+        // with currentDepositBlock == 999, producing
+        // deposit with blknum ending with 000.
+        require(currentDepositBlock < CHILD_BLOCK_INTERVAL);
+
         bytes32 root = keccak256(_owner, _token, _amount);
         uint256 depositBlock = getDepositBlock();
         childChain[depositBlock] = ChildBlock({


### PR DESCRIPTION
Otherwise attacking token can be used to produce deposit block with blknum ending in 000. This can be exploited by attacker to create a situation when operator is spending the deposit which later disappears. Depending on implementation, this has a potential of invalidating of chain in eyes of client nodes.