### PR TITLE
RootChain: only token owner can make a deposit

### DIFF
--- a/contracts/RootChain.sol
+++ b/contracts/RootChain.sol
@@ -154,15 +154,15 @@ contract RootChain {
     /**
      * @dev Deposits approved amount of ERC20 token. Approve must be called first. Note: does not check if token was added.
      */
-    function depositFrom(address _owner, address _token, uint256 _amount)
+    function depositFrom(address _token, uint256 _amount)
         public
     {
         // Only allow up to CHILD_BLOCK_INTERVAL deposits per child block.
         require(currentDepositBlock < CHILD_BLOCK_INTERVAL);
 
         // Warning, check your ERC20 implementation. TransferFrom should return bool
-        require(ERC20(_token).transferFrom(_owner, address(this), _amount));
-        writeDepositBlock(_owner, _token, _amount);
+        require(ERC20(_token).transferFrom(msg.sender, address(this), _amount));
+        writeDepositBlock(msg.sender, _token, _amount);
     }
 
     /**

--- a/testlang/testlang.py
+++ b/testlang/testlang.py
@@ -146,7 +146,7 @@ class TestingLanguage(object):
         self.ethtester.chain.mine()
         blknum = self.root_chain.getDepositBlock()
         pre_balance = self.get_balance(self.root_chain, token)
-        self.root_chain.depositFrom(owner.address, token.address, amount, sender=owner.key)
+        self.root_chain.depositFrom(token.address, amount, sender=owner.key)
         balance = self.get_balance(self.root_chain, token)
         assert balance == pre_balance + amount
 

--- a/tests/contracts/root_chain/test_deposit.py
+++ b/tests/contracts/root_chain/test_deposit.py
@@ -60,7 +60,7 @@ def test_token_deposit_should_succeed(testlang, root_chain, token):
 def test_token_deposit_non_existing_token_should_fail(testlang):
     owner, amount = testlang.accounts[0], 100
     with pytest.raises(TransactionFailed):
-        testlang.root_chain.depositFrom(owner.address, NULL_ADDRESS, amount, sender=owner.key)
+        testlang.root_chain.depositFrom(NULL_ADDRESS, amount, sender=owner.key)
 
 
 def test_token_deposit_no_approve_should_fail(testlang, token):
@@ -69,7 +69,7 @@ def test_token_deposit_no_approve_should_fail(testlang, token):
     token.mint(owner.address, amount)
     testlang.ethtester.chain.mine()
     with pytest.raises(TransactionFailed):
-        testlang.root_chain.depositFrom(owner.address, token.address, amount, sender=owner.key)
+        testlang.root_chain.depositFrom(token.address, amount, sender=owner.key)
 
 
 def test_token_deposit_insufficient_approve_should_fail(testlang, token):
@@ -78,4 +78,4 @@ def test_token_deposit_insufficient_approve_should_fail(testlang, token):
     token.mint(owner.address, amount)
     token.approve(testlang.root_chain.address, amount, sender=owner.key)
     with pytest.raises(TransactionFailed):
-        testlang.root_chain.depositFrom(owner.address, token.address, amount * 5, sender=owner.key)
+        testlang.root_chain.depositFrom(token.address, amount * 5, sender=owner.key)


### PR DESCRIPTION
This closes griefing vector where attacker uses owner's allowance to create multiple utxos on plasma chain. Very mild attack.