### PR TITLE
[WIP] Identify use of implicit Solidity behavior when accessing unset values

### DIFF
--- a/contracts/PriorityQueue.sol
+++ b/contracts/PriorityQueue.sol
@@ -58,6 +58,10 @@ contract PriorityQueue {
         }
     }
 
+    /**
+     * @dev Determines the next exit to be processed.
+     * @return The min element of the priority queue, or reverts if empty queue.
+     */
     function getMin()
         public
         view

--- a/contracts/RootChain.sol
+++ b/contracts/RootChain.sol
@@ -279,6 +279,8 @@ contract RootChain {
         uint256 utxoPos;
         uint256 exitable_at;
         uint256 _exitsLeft = _exitsToProcess;
+
+        // Getting the next exit if any exists, if not, then revert
         (utxoPos, exitable_at) = getNextExit(_token);
         require(_topUtxoPos == utxoPos || _topUtxoPos == 0);
         Exit memory currentExit = exits[utxoPos];
@@ -438,6 +440,8 @@ contract RootChain {
 
         // Check exit is valid and doesn't already exist.
         require(_amount > 0);
+        // Maps in Solidity are complete, and lookups of
+        // missing elements return 0-initialized values
         require(exits[_utxoPos].amount == 0);
 
         PriorityQueue queue = PriorityQueue(exitsQueues[_token]);


### PR DESCRIPTION
[ This PR is a WIP. Not ready for merge yet. ]

Use of unset memory is dangerous. To ensure future maintainability, lets add explicit comments where such functionality is critical to operation.

Examples include:
* Use of unset array locations -- reverts. E.g., `getMin` of PriorityQueue reverts on empty queue. `finalizeExits` in RootChain.sol relies on that to abort early.
* Solidity maps are complete, and return 0-initialized when unknown keys are accessed. Used to check emptiness in `exits` map in RootChain.sol.