### PR TITLE
Rework priority queue as library

### DIFF
--- a/contracts/PriorityQueue.sol
+++ b/contracts/PriorityQueue.sol
@@ -9,15 +9,6 @@ import "./PriorityQueueLib.sol";
 contract PriorityQueue {
     using PriorityQueueLib for PriorityQueueLib.Queue;
 
-    /* 
-     *  Storage
-     */
-
-    address owner;
-    uint256[] heapList;
-    uint256 public currentSize;
-
-
     /*
      *  Modifiers
      */
@@ -41,6 +32,13 @@ contract PriorityQueue {
         public
     {
         queue.init();
+
+    function currentSize()
+        external
+        view
+        returns (uint256)
+    {
+        queue.getCurrentSize();
     }
 
     function insert(uint256 _element)
@@ -76,7 +74,6 @@ contract PriorityQueue {
      */
     function delMin()
         public
-        view
         returns (uint256)
     {
         return queue.delMin();

--- a/contracts/PriorityQueue.sol
+++ b/contracts/PriorityQueue.sol
@@ -28,10 +28,11 @@ contract PriorityQueue {
      *  Public functions
      */
 
-    constructor()
+    constructor(address _owner)
         public
     {
-        queue.init();
+        queue.init(_owner);
+    }
 
     function currentSize()
         external

--- a/contracts/PriorityQueue.sol
+++ b/contracts/PriorityQueue.sol
@@ -1,14 +1,13 @@
 pragma solidity ^0.4.0;
 
-import "./SafeMath.sol";
-
+import "./PriorityQueueLib.sol";
 
 /**
  * @title PriorityQueue
  * @dev Min-heap priority queue implementation.
  */
 contract PriorityQueue {
-    using SafeMath for uint256;
+    using PriorityQueueLib for PriorityQueueLib.Queue;
 
     /* 
      *  Storage
@@ -24,39 +23,39 @@ contract PriorityQueue {
      */
 
     modifier onlyOwner() {
-        require(msg.sender == owner);
+        require(queue.isOwner());
         _;
     }
 
+    /*
+     *  Storage
+     */
+
+    PriorityQueueLib.Queue queue;
 
     /*
-     * Constructor
+     *  Public functions
      */
 
     constructor()
         public
     {
-        owner = msg.sender;
-        heapList = [0];
-        currentSize = 0;
+        queue.init();
     }
 
-
-    /*
-     * Internal functions
-     */
-
-    /**
-     * @dev Inserts an element into the priority queue.
-     * @param _element Integer to insert.
-     */
-    function insert(uint256 _element) 
-        public
+    function insert(uint256 _element)
         onlyOwner
+        public
     {
-        heapList.push(_element);
-        currentSize = currentSize.add(1);
-        _percUp(currentSize);
+        queue.insert(_element);
+    }
+
+    function minChild(uint256 i)
+        public
+        view
+        returns (uint256)
+    {
+        return queue.minChild(i);
     }
 
     /**
@@ -68,7 +67,7 @@ contract PriorityQueue {
         view
         returns (uint256)
     {
-        return heapList[1];
+        return queue.getMin();
     }
 
     /**
@@ -77,75 +76,10 @@ contract PriorityQueue {
      */
     function delMin()
         public
-        onlyOwner
-        returns (uint256)
-    {
-        uint256 retVal = heapList[1];
-        heapList[1] = heapList[currentSize];
-        delete heapList[currentSize];
-        currentSize = currentSize.sub(1);
-        _percDown(1);
-        heapList.length = heapList.length.sub(1);
-        return retVal;
-    }
-
-
-    /*
-     * Private functions
-     */
-
-    /**
-     * @dev Determines the minimum child of a given node in the tree.
-     * @param _index Index of the node in the tree.
-     * @return The smallest child node.
-     */
-    function _minChild(uint256 _index)
-        private
         view
         returns (uint256)
     {
-        if (_index.mul(2).add(1) > currentSize) {
-            return _index.mul(2);
-        } else {
-            if (heapList[_index.mul(2)] < heapList[_index.mul(2).add(1)]) {
-                return _index.mul(2);
-            } else {
-                return _index.mul(2).add(1);
-            }
-        }
+        return queue.delMin();
     }
 
-    /**
-     * @dev Bubbles the element at some index up.
-     */
-    function _percUp(uint256 _index)
-        private
-    {
-        uint256 index = _index;
-        uint256 j = index;
-        uint256 newVal = heapList[index];
-        while (newVal < heapList[index.div(2)]) {
-            heapList[index] = heapList[index.div(2)];
-            index = index.div(2);
-        }
-        if (index != j) heapList[index] = newVal;
-    }
-
-    /**
-     * @dev Bubbles the element at some index down.
-     */
-    function _percDown(uint256 _index)
-        private
-    {
-        uint256 index = _index;
-        uint256 j = index;
-        uint256 newVal = heapList[index];
-        uint256 mc = _minChild(index);
-        while (mc <= currentSize && newVal > heapList[mc]) {
-            heapList[index] = heapList[mc];
-            index = mc;
-            mc = _minChild(index);
-        }
-        if (index != j) heapList[index] = newVal;
-    }
 }

--- a/contracts/PriorityQueue.sol
+++ b/contracts/PriorityQueue.sol
@@ -39,7 +39,7 @@ contract PriorityQueue {
         view
         returns (uint256)
     {
-        queue.getCurrentSize();
+        return queue.getCurrentSize();
     }
 
     function insert(uint256 _element)

--- a/contracts/PriorityQueueFactory.sol
+++ b/contracts/PriorityQueueFactory.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.4.0;
+
+import "./PriorityQueue.sol";
+
+/**
+ * @title PriorityQueueFactory
+ * @dev Used solely to deploy new instances of a particular PriorityQueue implementation. Allows cheaper deployments
+ */
+library PriorityQueueFactory {
+    function deploy(address _forOwner)
+        returns (address)
+    {
+        return address(new PriorityQueue(_forOwner));
+    }
+}

--- a/contracts/PriorityQueueLib.sol
+++ b/contracts/PriorityQueueLib.sol
@@ -30,7 +30,6 @@ library PriorityQueueLib {
     }
 
     function init(Queue storage self)
-        internal
     {
         self.owner = msg.sender;
         self.heapList = [0];
@@ -38,7 +37,6 @@ library PriorityQueueLib {
     }
 
     function insert(Queue storage self, uint256 k)
-        internal
     {
         self.heapList.push(k);
         self.currentSize = self.currentSize.add(1);
@@ -47,7 +45,6 @@ library PriorityQueueLib {
 
     function minChild(Queue storage self, uint256 i)
         view
-        internal
         returns (uint256)
     {
         if (i.mul(2).add(1) > self.currentSize) {
@@ -70,7 +67,6 @@ library PriorityQueueLib {
     }
 
     function delMin(Queue storage self)
-        internal
         returns (uint256)
     {
         uint256 retVal = self.heapList[1];
@@ -83,6 +79,7 @@ library PriorityQueueLib {
     }
 
     function getCurrentSize(Queue storage self)
+        view
         internal
         returns (uint256)
     {
@@ -118,4 +115,3 @@ library PriorityQueueLib {
         if (i != j) self.heapList[i] = newVal;
     }
 }
-

--- a/contracts/PriorityQueueLib.sol
+++ b/contracts/PriorityQueueLib.sol
@@ -29,9 +29,9 @@ library PriorityQueueLib {
         return msg.sender == self.owner;
     }
 
-    function init(Queue storage self)
+    function init(Queue storage self, address _owner)
     {
-        self.owner = msg.sender;
+        self.owner = _owner;
         self.heapList = [0];
         self.currentSize = 0;
     }

--- a/contracts/PriorityQueueLib.sol
+++ b/contracts/PriorityQueueLib.sol
@@ -1,0 +1,121 @@
+pragma solidity ^0.4.0;
+
+import "./SafeMath.sol";
+
+/**
+ * @title PriorityQueueLib
+ * @dev A priority queue library implementation
+ */
+library PriorityQueueLib {
+    using SafeMath for uint256;
+
+    /*
+     *  Storage definition
+     */
+    struct Queue {
+        address owner;
+        uint256[] heapList;
+        uint256 currentSize;
+    }
+
+    /*
+     *  Public functions
+     */
+
+    function isOwner(Queue storage self)
+        internal
+        returns (bool)
+    {
+        return msg.sender == self.owner;
+    }
+
+    function init(Queue storage self)
+        internal
+    {
+        self.owner = msg.sender;
+        self.heapList = [0];
+        self.currentSize = 0;
+    }
+
+    function insert(Queue storage self, uint256 k)
+        internal
+    {
+        self.heapList.push(k);
+        self.currentSize = self.currentSize.add(1);
+        percUp(self, self.currentSize);
+    }
+
+    function minChild(Queue storage self, uint256 i)
+        view
+        internal
+        returns (uint256)
+    {
+        if (i.mul(2).add(1) > self.currentSize) {
+            return i.mul(2);
+        } else {
+            if (self.heapList[i.mul(2)] < self.heapList[i.mul(2).add(1)]) {
+                return i.mul(2);
+            } else {
+                return i.mul(2).add(1);
+            }
+        }
+    }
+
+    function getMin(Queue storage self)
+        view
+        internal
+        returns (uint256)
+    {
+        return self.heapList[1];
+    }
+
+    function delMin(Queue storage self)
+        internal
+        returns (uint256)
+    {
+        uint256 retVal = self.heapList[1];
+        self.heapList[1] = self.heapList[self.currentSize];
+        delete self.heapList[self.currentSize];
+        self.currentSize = self.currentSize.sub(1);
+        percDown(self, 1);
+        self.heapList.length = self.heapList.length.sub(1);
+        return retVal;
+    }
+
+    function getCurrentSize(Queue storage self)
+        internal
+        returns (uint256)
+    {
+        return self.currentSize;
+    }
+
+    /*
+     *  Private functions
+     */
+    function percUp(Queue storage self, uint256 i)
+        private
+    {
+        uint256 j = i;
+        uint256 newVal = self.heapList[i];
+        while (newVal < self.heapList[i.div(2)]) {
+            self.heapList[i] = self.heapList[i.div(2)];
+            i = i.div(2);
+        }
+        if (i != j) self.heapList[i] = newVal;
+    }
+
+    function percDown(Queue storage self, uint256 i)
+        private
+    {
+        uint256 j = i;
+        uint256 newVal = self.heapList[i];
+        uint256 mc = minChild(self, i);
+        while (mc <= self.currentSize && newVal > self.heapList[mc]) {
+            self.heapList[i] = self.heapList[mc];
+            i = mc;
+            mc = minChild(self, i);
+        }
+        if (i != j) self.heapList[i] = newVal;
+    }
+}
+

--- a/contracts/RootChain.sol
+++ b/contracts/RootChain.sol
@@ -8,6 +8,7 @@ import "./Merkle.sol";
 import "./RLP.sol";
 import "./PlasmaCore.sol";
 import "./PriorityQueue.sol";
+import "./PriorityQueueFactory.sol";
 
 import "./ERC20.sol";
 
@@ -175,7 +176,7 @@ contract RootChain {
 
       // Support only ETH on deployment; other tokens need
       // to be added explicitly.
-      exitsQueues[address(0)] = address(new PriorityQueue());
+      exitsQueues[address(0)] = PriorityQueueFactory.deploy(this);
 
       // Pre-compute some hashes to save gas later.
       bytes32 zeroHash = keccak256(abi.encodePacked(uint256(0)));
@@ -191,7 +192,7 @@ contract RootChain {
         public
     {
         require(!hasToken(_token));
-        exitsQueues[_token] = address(new PriorityQueue());
+        exitsQueues[_token] = PriorityQueueFactory.deploy(this);
         TokenAdded(_token);
     }
 

--- a/tests/contracts/priority_queue/test_priority_queue.py
+++ b/tests/contracts/priority_queue/test_priority_queue.py
@@ -92,7 +92,7 @@ def op_cost(n):
     tx_base_cost = 21000
     # Numbers were discovered experimentally. They represent upper bound of
     # gas cost of execution of delMin or insert operations.
-    return tx_base_cost + 26538 + 6638 * math.floor(math.log(n, 2))
+    return tx_base_cost + 26677 + 6638 * math.floor(math.log(n, 2))
 
 
 def test_priority_queue_worst_case_gas_cost(ethtester, priority_queue):

--- a/tests/contracts/priority_queue/test_priority_queue.py
+++ b/tests/contracts/priority_queue/test_priority_queue.py
@@ -1,11 +1,16 @@
 import pytest
 from ethereum.tools.tester import TransactionFailed
+from plasma_core.utils.address import address_to_hex
 import math
 
 
 @pytest.fixture
-def priority_queue(get_contract):
-    return get_contract('PriorityQueue')
+def priority_queue(get_contract, ethtester):
+    pql = get_contract('PriorityQueueLib')
+    return get_contract(
+        'PriorityQueue',
+        args=[address_to_hex(ethtester.a0)], libraries={'PriorityQueueLib': pql.address}
+    )
 
 
 def test_priority_queue_get_min_empty_should_fail(priority_queue):
@@ -92,7 +97,7 @@ def op_cost(n):
     tx_base_cost = 21000
     # Numbers were discovered experimentally. They represent upper bound of
     # gas cost of execution of delMin or insert operations.
-    return tx_base_cost + 26677 + 6638 * math.floor(math.log(n, 2))
+    return tx_base_cost + 28677 + 6638 * math.floor(math.log(n, 2))
 
 
 def test_priority_queue_worst_case_gas_cost(ethtester, priority_queue):

--- a/tests/contracts/root_chain/test_init.py
+++ b/tests/contracts/root_chain/test_init.py
@@ -2,15 +2,10 @@ import pytest
 from ethereum.tools.tester import TransactionFailed
 
 
-def test_cant_ever_init_twice(ethtester, get_contract):
-    root_chain = get_contract('RootChain')
+def test_cant_ever_init_twice(ethtester, root_chain):
     ethtester.chain.mine()
-    root_chain.init(sender=ethtester.k1)
-    ethtester.chain.mine()
+    with pytest.raises(TransactionFailed):
+        root_chain.init(sender=ethtester.k0)
 
     with pytest.raises(TransactionFailed):
         root_chain.init(sender=ethtester.k1)
-
-    ethtester.chain.mine()
-    with pytest.raises(TransactionFailed):
-        root_chain.init(sender=ethtester.k2)

--- a/tests/contracts/root_chain/test_tokens.py
+++ b/tests/contracts/root_chain/test_tokens.py
@@ -11,6 +11,17 @@ def test_token_adding(token, root_chain):
         root_chain.addToken(token.address)
 
 
+def test_token_adding_gas_cost(ethtester, root_chain):
+    ADDRESS_A = b'\x00' * 19 + b'\x01'
+    ADDRESS_B = b'\x00' * 19 + b'\x02'
+    root_chain.addToken(ADDRESS_A)
+    gas = ethtester.chain.last_gas_used()
+    print("PriorityQueue first deployment costs {} gas".format(gas))
+    root_chain.addToken(ADDRESS_B)
+    gas = ethtester.chain.last_gas_used()
+    print("PriorityQueue second deployment costs {} gas".format(gas))
+
+
 def test_token_adding_eth_token_should_fail(root_chain):
     assert root_chain.hasToken(NULL_ADDRESS)
     with pytest.raises(TransactionFailed):


### PR DESCRIPTION
Our main contract no longer deploys - it reaches gas limit. Breaking up PriorityQueue into library that is deployed independently will help decrease RootChain's deployment gas cost.

TODO: actually deploy library in separate transaction. This probably requires changes in our building process.