### PR TITLE
tests: require explicit token in outputs

### DIFF
--- a/plasma_core/transaction.py
+++ b/plasma_core/transaction.py
@@ -57,6 +57,7 @@ class Transaction(rlp.Serializable):
                  inputs=[DEFAULT_INPUT] * NUM_TXOS,
                  outputs=[DEFAULT_OUTPUT] * NUM_TXOS,
                  signatures=[NULL_SIGNATURE] * NUM_TXOS):
+        assert all(len(o) == 3 for o in outputs)
         padded_inputs = pad_list(inputs, self.DEFAULT_INPUT, self.NUM_TXOS)
         padded_outputs = pad_list(outputs, self.DEFAULT_OUTPUT, self.NUM_TXOS)
 

--- a/tests/contracts/root_chain/test_challenge_in_flight_exit_input_spent.py
+++ b/tests/contracts/root_chain/test_challenge_in_flight_exit_input_spent.py
@@ -1,12 +1,13 @@
 import pytest
 from ethereum.tools.tester import TransactionFailed
+from plasma_core.constants import NULL_ADDRESS
 
 
 def test_challenge_in_flight_exit_input_spent_should_succeed(testlang):
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)], force_invalid=True)
+    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
     testlang.start_in_flight_exit(spend_id)
     testlang.piggyback_in_flight_exit_input(spend_id, 0, owner_1.key)
     testlang.forward_to_period(2)
@@ -21,7 +22,7 @@ def test_challenge_in_flight_exit_input_spent_wrong_period_should_fail(testlang)
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)], force_invalid=True)
+    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
     testlang.start_in_flight_exit(spend_id)
     testlang.piggyback_in_flight_exit_input(spend_id, 0, owner_1.key)
     testlang.forward_to_period(1)
@@ -34,7 +35,7 @@ def test_challenge_in_flight_exit_input_spent_not_piggybacked_should_fail(testla
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)], force_invalid=True)
+    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
     testlang.start_in_flight_exit(spend_id)
     testlang.forward_to_period(2)
 
@@ -59,7 +60,7 @@ def test_challenge_in_flight_exit_input_spent_unrelated_tx_should_fail(testlang)
     deposit_id_1 = testlang.deposit(owner_1, amount)
     deposit_id_2 = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id_1], [owner_1.key])
-    unrelated_spend_id = testlang.spend_utxo([deposit_id_2], [owner_1.key], [(owner_1.address, 100)])
+    unrelated_spend_id = testlang.spend_utxo([deposit_id_2], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)])
     testlang.start_in_flight_exit(spend_id)
     testlang.piggyback_in_flight_exit_input(spend_id, 0, owner_1.key)
     testlang.forward_to_period(2)
@@ -72,7 +73,7 @@ def test_challenge_in_flight_exit_input_spent_invalid_signature_should_fail(test
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_2.key], [(owner_1.address, 100)], force_invalid=True)
+    double_spend_id = testlang.spend_utxo([deposit_id], [owner_2.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
     testlang.start_in_flight_exit(spend_id)
     testlang.piggyback_in_flight_exit_input(spend_id, 0, owner_1.key)
     testlang.forward_to_period(2)

--- a/tests/contracts/root_chain/test_challenge_in_flight_exit_not_canonical.py
+++ b/tests/contracts/root_chain/test_challenge_in_flight_exit_not_canonical.py
@@ -1,12 +1,13 @@
 import pytest
 from ethereum.tools.tester import TransactionFailed
+from plasma_core.constants import NULL_ADDRESS
 
 
 def test_challenge_in_flight_exit_not_canonical_should_succeed(testlang):
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)], force_invalid=True)
+    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
 
     testlang.start_in_flight_exit(spend_id)
 
@@ -22,7 +23,7 @@ def test_challenge_in_flight_exit_not_canonical_wrong_period_should_fail(testlan
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)], force_invalid=True)
+    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
 
     testlang.start_in_flight_exit(spend_id)
     testlang.forward_to_period(2)
@@ -65,7 +66,7 @@ def test_challenge_in_flight_exit_not_canonical_wrong_index_should_fail(testlang
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)], force_invalid=True)
+    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
     spend_tx = testlang.child_chain.get_transaction(spend_id)
     double_spend_tx = testlang.child_chain.get_transaction(double_spend_id)
 
@@ -82,7 +83,7 @@ def test_challenge_in_flight_exit_not_canonical_invalid_signature_should_fail(te
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_2.key], [(owner_1.address, 100)], force_invalid=True)
+    double_spend_id = testlang.spend_utxo([deposit_id], [owner_2.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
 
     testlang.start_in_flight_exit(spend_id)
 
@@ -94,7 +95,7 @@ def test_challenge_in_flight_exit_not_canonical_invalid_proof_should_fail(testla
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)], force_invalid=True)
+    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
     spend_tx = testlang.child_chain.get_transaction(spend_id)
     double_spend_tx = testlang.child_chain.get_transaction(double_spend_id)
 
@@ -111,7 +112,7 @@ def test_challenge_in_flight_exit_not_canonical_same_tx_twice_should_fail(testla
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)], force_invalid=True)
+    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
 
     testlang.start_in_flight_exit(spend_id)
 
@@ -125,8 +126,8 @@ def test_challenge_in_flight_exit_twice_older_position_should_succeed(testlang):
     owner_1, owner_2, owner_3, amount = testlang.accounts[0], testlang.accounts[1], testlang.accounts[2], 100
     deposit_id = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id_1 = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)], force_invalid=True)
-    double_spend_id_2 = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 50)], force_invalid=True)
+    double_spend_id_1 = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
+    double_spend_id_2 = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 50)], force_invalid=True)
 
     testlang.start_in_flight_exit(spend_id)
 
@@ -143,8 +144,8 @@ def test_challenge_in_flight_exit_twice_younger_position_should_fail(testlang):
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id_1 = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)], force_invalid=True)
-    double_spend_id_2 = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 50)], force_invalid=True)
+    double_spend_id_1 = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
+    double_spend_id_2 = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 50)], force_invalid=True)
 
     testlang.start_in_flight_exit(spend_id)
 

--- a/tests/contracts/root_chain/test_challenge_in_flight_exit_output_spent.py
+++ b/tests/contracts/root_chain/test_challenge_in_flight_exit_output_spent.py
@@ -1,11 +1,12 @@
 import pytest
 from ethereum.tools.tester import TransactionFailed
+from plasma_core.constants import NULL_ADDRESS
 
 
 def test_challenge_in_flight_exit_output_spent_should_succeed(testlang):
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
-    spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)])
+    spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)])
     double_spend_id = testlang.spend_utxo([spend_id], [owner_1.key], force_invalid=True)
     testlang.start_in_flight_exit(spend_id)
     testlang.piggyback_in_flight_exit_output(spend_id, 0, owner_1.key)
@@ -20,7 +21,7 @@ def test_challenge_in_flight_exit_output_spent_should_succeed(testlang):
 def test_challenge_in_flight_exit_output_spent_wrong_period_should_fail(testlang):
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
-    spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)])
+    spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)])
     double_spend_id = testlang.spend_utxo([spend_id], [owner_1.key], force_invalid=True)
     testlang.start_in_flight_exit(spend_id)
     testlang.piggyback_in_flight_exit_output(spend_id, 0, owner_1.key)
@@ -33,7 +34,7 @@ def test_challenge_in_flight_exit_output_spent_wrong_period_should_fail(testlang
 def test_challenge_in_flight_exit_output_spent_not_piggybacked_should_fail(testlang):
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
-    spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)])
+    spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)])
     double_spend_id = testlang.spend_utxo([spend_id], [owner_1.key], force_invalid=True)
     testlang.start_in_flight_exit(spend_id)
     testlang.forward_to_period(2)
@@ -46,7 +47,7 @@ def test_challenge_in_flight_exit_output_spent_unrelated_tx_should_fail(testlang
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id_1 = testlang.deposit(owner_1, amount)
     deposit_id_2 = testlang.deposit(owner_1, amount)
-    spend_id = testlang.spend_utxo([deposit_id_1], [owner_1.key], [(owner_1.address, 100)])
+    spend_id = testlang.spend_utxo([deposit_id_1], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)])
     unrelated_spend_id = testlang.spend_utxo([deposit_id_2], [owner_1.key])
     testlang.start_in_flight_exit(spend_id)
     testlang.piggyback_in_flight_exit_output(spend_id, 0, owner_1.key)
@@ -59,7 +60,7 @@ def test_challenge_in_flight_exit_output_spent_unrelated_tx_should_fail(testlang
 def test_challenge_in_flight_exit_output_spent_invalid_signature_should_fail(testlang):
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
-    spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)])
+    spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)])
     double_spend_id = testlang.spend_utxo([spend_id], [owner_2.key], force_invalid=True)
     testlang.start_in_flight_exit(spend_id)
     testlang.piggyback_in_flight_exit_output(spend_id, 0, owner_1.key)
@@ -72,7 +73,7 @@ def test_challenge_in_flight_exit_output_spent_invalid_signature_should_fail(tes
 def test_challenge_in_flight_exit_output_spent_invalid_proof_should_fail(testlang):
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
-    spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)])
+    spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)])
     double_spend_id = testlang.spend_utxo([spend_id], [owner_1.key], force_invalid=True)
     testlang.start_in_flight_exit(spend_id)
     testlang.piggyback_in_flight_exit_output(spend_id, 0, owner_1.key)

--- a/tests/contracts/root_chain/test_piggyback_in_flight_exit.py
+++ b/tests/contracts/root_chain/test_piggyback_in_flight_exit.py
@@ -30,7 +30,7 @@ def test_piggyback_in_flight_exit_valid_output_owner_should_succeed(testlang, nu
     deposit_id = testlang.deposit(owner_1, amount)
     outputs = []
     for i in range(0, num_outputs):
-        outputs.append((testlang.accounts[i].address, 1))
+        outputs.append((testlang.accounts[i].address, NULL_ADDRESS, 1))
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], outputs)
 
     testlang.start_in_flight_exit(spend_id)
@@ -56,7 +56,7 @@ def test_piggyback_in_flight_exit_invalid_owner_should_fail(testlang):
 def test_piggyback_in_flight_exit_different_exits_different_outputs_should_succeed(testlang):
     owner, amount = testlang.accounts[0], 100
     deposit_id = testlang.deposit(owner, amount)
-    spend_id = testlang.spend_utxo([deposit_id], [owner.key], [(owner.address, 50), (owner.address, 50)])
+    spend_id = testlang.spend_utxo([deposit_id], [owner.key], [(owner.address, NULL_ADDRESS, 50), (owner.address, NULL_ADDRESS, 50)])
 
     # First time should succeed
     testlang.start_in_flight_exit(spend_id)
@@ -75,7 +75,7 @@ def test_piggyback_in_flight_exit_different_exits_different_outputs_should_succe
 def test_piggyback_in_flight_exit_different_exits_same_output_should_fail(testlang):
     owner, amount = testlang.accounts[0], 100
     deposit_id = testlang.deposit(owner, amount)
-    spend_id = testlang.spend_utxo([deposit_id], [owner.key], [(owner.address, 50), (owner.address, 50)])
+    spend_id = testlang.spend_utxo([deposit_id], [owner.key], [(owner.address, NULL_ADDRESS, 50), (owner.address, NULL_ADDRESS, 50)])
 
     # First time should succeed
     testlang.start_in_flight_exit(spend_id)

--- a/tests/contracts/root_chain/test_respond_to_non_canonical_challenge.py
+++ b/tests/contracts/root_chain/test_respond_to_non_canonical_challenge.py
@@ -1,12 +1,13 @@
 import pytest
 from ethereum.tools.tester import TransactionFailed
+from plasma_core.constants import NULL_ADDRESS
 
 
 def test_respond_to_non_canonical_challenge_should_succeed(testlang):
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)], force_invalid=True)
+    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
     testlang.start_in_flight_exit(spend_id)
     testlang.challenge_in_flight_exit_not_canonical(spend_id, double_spend_id, key=owner_2.key)
 
@@ -24,7 +25,7 @@ def test_respond_to_non_canonical_challenge_wrong_period_should_fail(testlang):
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)], force_invalid=True)
+    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
     testlang.start_in_flight_exit(spend_id)
     testlang.challenge_in_flight_exit_not_canonical(spend_id, double_spend_id, key=owner_2.key)
 
@@ -35,7 +36,7 @@ def test_respond_to_non_canonical_challenge_wrong_period_should_fail(testlang):
 def test_respond_to_non_canonical_challenge_not_older_should_fail(testlang):
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)], force_invalid=True)
+    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
     testlang.start_in_flight_exit(spend_id)
     testlang.challenge_in_flight_exit_not_canonical(spend_id, double_spend_id, key=owner_2.key)
@@ -50,7 +51,7 @@ def test_respond_to_non_canonical_challenge_invalid_proof_should_fail(testlang):
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)], force_invalid=True)
+    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
     testlang.start_in_flight_exit(spend_id)
     testlang.challenge_in_flight_exit_not_canonical(spend_id, double_spend_id, key=owner_2.key)
 


### PR DESCRIPTION
Otherwise amount could be passed to contract as token. That introduced hard
to debug errors in test execution. Also, explicit > implicit.