### PR TITLE
Interaction between MVP and MoreVP exits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,12 +30,17 @@ lint:
 
 .PHONY: test
 test:
-	python -m pytest
+	python -W ignore::DeprecationWarning -m pytest
+	rm -fr .pytest_cache
+
+.PHONY: conctest
+conctest:
+	python -W ignore::DeprecationWarning -m pytest --concmode=mproc
 	rm -fr .pytest_cache
 
 .PHONY: runslow
 runslow:
-	python -m pytest -s --runslow
+	python -W ignore::DeprecationWarning -m pytest -s --runslow
 	rm -fr .pytest_cache
 
 .PHONY: dev

--- a/contracts/PlasmaCore.sol
+++ b/contracts/PlasmaCore.sol
@@ -81,55 +81,55 @@ library PlasmaCore {
     }
 
     /**
-     * @dev Given an output ID, returns the block number.
-     * @param _outputId Output identifier to decode.
+     * @dev Given an UTXO position, returns the block number.
+     * @param _utxoPos Output identifier to decode.
      * @return The output's block number.
      */
-    function getBlknum(uint256 _outputId)
+    function getBlknum(uint256 _utxoPos)
         internal
         pure
         returns (uint256)
     {
-        return _outputId / BLOCK_OFFSET;
+        return _utxoPos / BLOCK_OFFSET;
     }
 
     /**
-     * @dev Given an output ID, returns the transaction index.
-     * @param _outputId Output identifier to decode.
+     * @dev Given an UTXO position, returns the transaction index.
+     * @param _utxoPos Output identifier to decode.
      * @return The output's transaction index.
      */
-    function getTxindex(uint256 _outputId)
+    function getTxIndex(uint256 _utxoPos)
         internal
         pure
         returns (uint256)
     {
-        return (_outputId % BLOCK_OFFSET) / TX_OFFSET;
+        return (_utxoPos % BLOCK_OFFSET) / TX_OFFSET;
     }
 
     /**
-     * @dev Given an output ID, returns the output index.
-     * @param _outputId Output identifier to decode.
+     * @dev Given an UTXO position, returns the output index.
+     * @param _utxoPos Output identifier to decode.
      * @return The output's index.
      */
-    function getOindex(uint256 _outputId)
+    function getOindex(uint256 _utxoPos)
         internal
         pure
         returns (uint8)
     {
-        return uint8(_outputId % TX_OFFSET);
+        return uint8(_utxoPos % TX_OFFSET);
     }
 
     /**
-     * @dev Given an output ID, returns transaction position.
-     * @param _outputId Output identifier to decode.
+     * @dev Given an UTXO position, returns transaction position.
+     * @param _utxoPos Output identifier to decode.
      * @return The transaction position.
      */
-    function getTxpos(uint256 _outputId)
+    function getTxPos(uint256 _utxoPos)
         internal
         pure
         returns (uint256)
     {
-        return _outputId / TX_OFFSET;
+        return _utxoPos / TX_OFFSET;
     }
 
     /**
@@ -138,7 +138,7 @@ library PlasmaCore {
      * @param _inputIndex Index of the input to return.
      * @return A combined identifier.
      */
-    function getInputId(bytes memory _tx, uint256 _inputIndex)
+    function getInputUtxoPosition(bytes memory _tx, uint8 _inputIndex)
         internal
         view
         returns (uint256)
@@ -154,7 +154,7 @@ library PlasmaCore {
      * @param _outputIndex Index of the output to return.
      * @return The transaction output.
      */
-    function getOutput(bytes memory _tx, uint256 _outputIndex)
+    function getOutput(bytes memory _tx, uint8 _outputIndex)
         internal
         view
         returns (TransactionOutput)

--- a/contracts/PlasmaCore.sol
+++ b/contracts/PlasmaCore.sol
@@ -120,6 +120,19 @@ library PlasmaCore {
     }
 
     /**
+     * @dev Given an output ID, returns transaction position.
+     * @param _outputId Output identifier to decode.
+     * @return The transaction position.
+     */
+    function getTxpos(uint256 _outputId)
+        internal
+        pure
+        returns (uint256)
+    {
+        return _outputId / TX_OFFSET;
+    }
+
+    /**
      * @dev Returns the identifier for an input to a transaction.
      * @param _tx RLP encoded input.
      * @param _inputIndex Index of the input to return.

--- a/contracts/PlasmaCoreTest.sol
+++ b/contracts/PlasmaCoreTest.sol
@@ -26,7 +26,7 @@ contract PlasmaCoreTest {
         return PlasmaCore.sliceSignature(_signatures, _index);
     }
 
-    function getOutput(bytes _tx, uint256 _outputIndex)
+    function getOutput(bytes _tx, uint8 _outputIndex)
         public
         view
         returns (address, address, uint256)
@@ -35,43 +35,43 @@ contract PlasmaCoreTest {
         return (output.owner, output.token, output.amount);
     }
 
-    function getInputId(bytes _tx, uint256 _inputIndex)
+    function getInputUtxoPosition(bytes _tx, uint8 _inputIndex)
         public
         view
         returns (uint256)
     {
-        return PlasmaCore.getInputId(_tx, _inputIndex);
+        return PlasmaCore.getInputUtxoPosition(_tx, _inputIndex);
     }
 
-    function getOindex(uint256 _outputId)
+    function getOindex(uint256 _utxoPos)
         public
         pure
         returns (uint8)
     {
-        return PlasmaCore.getOindex(_outputId);
+        return PlasmaCore.getOindex(_utxoPos);
     }
 
-    function getTxpos(uint256 _outputId)
+    function getTxPos(uint256 _utxoPos)
         public
         pure
         returns (uint256)
     {
-        return PlasmaCore.getTxpos(_outputId);
+        return PlasmaCore.getTxPos(_utxoPos);
     }
 
-    function getTxindex(uint256 _outputId)
+    function getTxIndex(uint256 _utxoPos)
         public
         pure
         returns (uint256)
     {
-        return PlasmaCore.getTxindex(_outputId);
+        return PlasmaCore.getTxIndex(_utxoPos);
     }
 
-    function getBlknum(uint256 _outputId)
+    function getBlknum(uint256 _utxoPos)
         public
         pure
         returns (uint256)
     {
-        return PlasmaCore.getBlknum(_outputId);
+        return PlasmaCore.getBlknum(_utxoPos);
     }
 }

--- a/contracts/PlasmaCoreTest.sol
+++ b/contracts/PlasmaCoreTest.sol
@@ -51,6 +51,14 @@ contract PlasmaCoreTest {
         return PlasmaCore.getOindex(_outputId);
     }
 
+    function getTxpos(uint256 _outputId)
+        public
+        pure
+        returns (uint256)
+    {
+        return PlasmaCore.getTxpos(_outputId);
+    }
+
     function getTxindex(uint256 _outputId)
         public
         pure

--- a/contracts/RootChain.sol
+++ b/contracts/RootChain.sol
@@ -492,17 +492,17 @@ contract RootChain {
         // Separate the inputs transactions.
         RLP.RLPItem[] memory splitInputTxs = _inputTxs.toRLPItem().toList();
 
+        // `vars` is an ugly hack - workaround for "stack too deep" error
         uint256[3] memory vars;
-        // Get information about the inputs.
-        // uint256 inputId; // vars[0]
-        // uint256 inputSum; // vars[1]
-        // uint256 mostRecentInput = 0; // vars[2]
         bool finalized;
         bool any_finalized;
         for (uint8 i = 0; i < numInputs; i++) {
+            // vars[0] contains inputId
             (inFlightExit.inputs[i], vars[0], finalized) = _getInputInfo(_inFlightTx, splitInputTxs[i].toBytes(), _inputTxsInclusionProofs, _inFlightTxSigs.sliceSignature(i), i);
             require(inFlightExit.inputs[i].token == address(0));
+            // vars[1] tracks sum of the inputs
             vars[1] += inFlightExit.inputs[i].amount;
+            // vars[2] tracks youngest of inputs for this in-flight exit
             vars[2] = Math.max(vars[2], vars[0]);
             any_finalized = any_finalized || finalized;
         }

--- a/contracts/RootChain.sol
+++ b/contracts/RootChain.sol
@@ -546,6 +546,10 @@ contract RootChain {
         payable
         onlyWithValue(piggybackBond)
     {
+        bytes32 txhash = keccak256(_inFlightTx);
+        // Check if SE is not started nor finalized
+        require(exits[getStandardExitId(txhash, _outputIndex)].amount == 0);
+
         // Check that the in-flight exit is currently active and in period 1.
         InFlightExit storage inFlightExit = _getInFlightExit(_inFlightTx);
         require(_getExitPeriod(inFlightExit) == 1);
@@ -571,7 +575,7 @@ contract RootChain {
         // Set the output as piggybacked.
         inFlightExit.exitMap = inFlightExit.exitMap.setBit(_outputIndex);
 
-        emit InFlightExitPiggybacked(msg.sender, keccak256(_inFlightTx), _outputIndex);
+        emit InFlightExitPiggybacked(msg.sender, txhash, _outputIndex);
     }
 
 

--- a/contracts/RootChain.sol
+++ b/contracts/RootChain.sol
@@ -390,8 +390,23 @@ contract RootChain {
         bytes32 txHash = keccak256(_challengeTx);
         require(owner == ECRecovery.recover(txHash, _challengeTxSig));
 
+        processChallengeStandardExit(_outputId, exitId);
+    }
+
+    function maybeChallengeStandardExitOnInput(uint256 _inputId)
+        internal
+    {
+        uint192 standardExitId = getStandardExitId(_inputId);
+        if (exits[standardExitId].owner != address(0)) {
+            processChallengeStandardExit(_inputId, standardExitId);
+        }
+    }
+
+    function processChallengeStandardExit(uint256 _outputId, uint192 _exitId)
+        internal
+    {
         // Delete the exit.
-        delete exits[exitId];
+        delete exits[_exitId];
 
         // Send a bond to the challenger.
         msg.sender.transfer(standardExitBond);
@@ -474,6 +489,8 @@ contract RootChain {
             require(inFlightExit.inputs[i].token == address(0));
             inputSum += inFlightExit.inputs[i].amount;
             mostRecentInput = Math.max(mostRecentInput, inputId);
+            // Challenge exiting standard exits from inputs
+            maybeChallengeStandardExitOnInput(inputId);
         }
 
         // Make sure the sums are valid.

--- a/contracts/RootChain.sol
+++ b/contracts/RootChain.sol
@@ -809,13 +809,16 @@ contract RootChain {
      * @dev Given an RLP encoded transaction, returns its exit ID.
      * @param _tx RLP encoded transaction.
      * @return _uniqueId A unique identifier of an in-flight exit.
+     *     Anatomy of returned value, most significant bits first:
+     *     8 bits - set to zero
+     *     1 bit - in-flight flag
+     *     151 bit - tx hash
      */
     function getInFlightExitId(bytes _tx)
         public
         pure
         returns (uint192)
     {
-        // uses 160 least significant bits, where most significant 8 are all zero
         return uint192((uint256(keccak256(_tx)) >> 151).setBit(152));
     }
 
@@ -824,6 +827,10 @@ contract RootChain {
      * @param _txhash Transaction hash.
      * @param _oindex Output index.
      * @return _standardExitId Unique standard exit id.
+     *     Anatomy of returned value, most significant bits first:
+     *     8 bits - oindex
+     *     1 bit - in-flight flag
+     *     151 bit - tx hash
      */
 
     function getStandardExitId(bytes32 _txhash, uint8 _oindex)
@@ -831,7 +838,6 @@ contract RootChain {
         pure
         returns (uint192)
     {
-        // uses 160 least significant bits
         return uint192((uint256(_txhash) >> 105) | (uint256(_oindex) << 152));
     }
 
@@ -1003,6 +1009,12 @@ contract RootChain {
      * @param _exitId Unique exit identifier.
      * @param _outputId Position of the exit in the blockchain.
      * @return An exit priority.
+     *   Anatomy of returned value, most significant bits first
+     *   42 bits - timestamp (exitable_at); unix timestamp fits into 32 bits
+     *   54 bits - blknum * 10^9 + txindex; to represent all utxo for 10 years we need only 54 bits
+     *   8 bits - oindex; set to zero for in-flight tx
+     *   1 bit - in-flight flag
+     *   151 bit - tx hash
      */
     function getStandardExitPriority(uint192 _exitId, uint256 _outputId)
         public

--- a/contracts/RootChain.sol
+++ b/contracts/RootChain.sol
@@ -347,9 +347,13 @@ contract RootChain {
         require(output.amount > 0);
         require(exits[exitId].amount == 0);
 
-        // Check if this output was piggybacked or exited in in-flight exit
         InFlightExit storage inFlightExit = _getInFlightExit(_outputTx);
-        require(!inFlightExit.exitMap.bitSet(oindex + 4) && !inFlightExit.exitMap.bitSet(oindex + 4 + 8));
+        if (inFlightExit.exitStartTimestamp != 0) {
+            // Check if this output was piggybacked or exited in in-flight exit
+            require(!inFlightExit.exitMap.bitSet(oindex + 4) && !inFlightExit.exitMap.bitSet(oindex + 4 + 8));
+            // Prevent future piggybacks on this output
+            inFlightExit.exitMap = inFlightExit.exitMap.setBit(oindex + 4 + 8);
+        }
 
         // Make sure queue for this token exists.
         require(hasToken(output.token));

--- a/contracts/RootChain.sol
+++ b/contracts/RootChain.sol
@@ -901,7 +901,7 @@ contract RootChain {
         pure
         returns (bool)
     {
-        return _value.bitSet(255);
+        return _value.bitSet(255) || _value.bitSet(254);
     }
 
     function setFlag(uint256 _value)
@@ -918,6 +918,14 @@ contract RootChain {
         returns (uint256)
     {
         return _value.clearBit(255);
+    }
+
+    function flagSpentInput(uint256 _value)
+        public
+        pure
+        returns (uint256)
+    {
+        return _value.setBit(254);
     }
 
     /*

--- a/contracts/RootChain.sol
+++ b/contracts/RootChain.sol
@@ -138,7 +138,7 @@ contract RootChain {
     event InFlightExitOutputBlocked(
         address indexed challenger,
         bytes32 txHash,
-        uint256 outputId
+        uint256 outputIndex
     );
 
     event InFlightExitFinalized(

--- a/contracts/RootChain.sol
+++ b/contracts/RootChain.sol
@@ -102,7 +102,7 @@ contract RootChain {
 
     event ExitStarted(
         address indexed owner,
-        uint256 outputId,
+        uint256 utxoPos,
         uint256 amount,
         address token
     );
@@ -123,7 +123,7 @@ contract RootChain {
     event InFlightExitPiggybacked(
         address indexed owner,
         bytes32 txHash,
-        uint256 outputIndex
+        uint8 outputIndex
     );
 
     event InFlightExitChallenged(
@@ -141,12 +141,12 @@ contract RootChain {
     event InFlightExitOutputBlocked(
         address indexed challenger,
         bytes32 txHash,
-        uint256 outputIndex
+        uint8 outputIndex
     );
 
     event InFlightExitFinalized(
         uint192 inFlightExitId,
-        uint256 outputId
+        uint8 outputIndex
     );
 
     /*
@@ -324,20 +324,20 @@ contract RootChain {
     /**
      * @dev Starts a standard withdrawal of a given output. Uses output-age priority.
             Crosschecks in-flight exit existence.
-     * @param _outputId Identifier of the exiting output.
+     * @param _utxoPos Position of the exiting output.
      * @param _outputTx RLP encoded transaction that created the exiting output.
      * @param _outputTxInclusionProof A Merkle proof showing that the transaction was included.
      */
-    function startStandardExit(uint192 _outputId, bytes _outputTx, bytes _outputTxInclusionProof)
+    function startStandardExit(uint192 _utxoPos, bytes _outputTx, bytes _outputTxInclusionProof)
         public
         payable
         onlyWithValue(standardExitBond)
     {
         // Check that the output transaction actually created the output.
-        require(_transactionIncluded(_outputTx, _outputId, _outputTxInclusionProof));
+        require(_transactionIncluded(_outputTx, _utxoPos, _outputTxInclusionProof));
 
         // Decode the output ID.
-        uint8 oindex = uint8(_outputId.getOindex());
+        uint8 oindex = uint8(_utxoPos.getOindex());
 
         // Parse outputTx.
         PlasmaCore.TransactionOutput memory output = _outputTx.getOutput(oindex);
@@ -363,7 +363,7 @@ contract RootChain {
         require(hasToken(output.token));
 
         // Determine the exit's priority.
-        uint256 exitPriority = getStandardExitPriority(exitId, _outputId);
+        uint256 exitPriority = getStandardExitPriority(exitId, _utxoPos);
 
         // Insert the exit into the queue and update the exit mapping.
         PriorityQueue queue = PriorityQueue(exitsQueues[output.token]);
@@ -372,25 +372,25 @@ contract RootChain {
             owner: output.owner,
             token: output.token,
             amount: output.amount,
-            position: _outputId
+            position: _utxoPos
         });
 
-        emit ExitStarted(output.owner, _outputId, output.amount, output.token);
+        emit ExitStarted(output.owner, _utxoPos, output.amount, output.token);
     }
 
     /**
      * @dev Blocks a standard exit by showing the exiting output was spent.
      * @param _standardExitId Identifier of the standard exit to challenge.
      * @param _challengeTx RLP encoded transaction that spends the exiting output.
-     * @param _inputIndex Which input to the challenging tx corresponds to the exiting output.
+     * @param _inputIndex Which input of the challenging tx corresponds to the exiting output.
      * @param _challengeTxSig Signature from the exiting output owner over the spend.
      */
-    function challengeStandardExit(uint192 _standardExitId, bytes _challengeTx, uint256 _inputIndex, bytes _challengeTxSig)
+    function challengeStandardExit(uint192 _standardExitId, bytes _challengeTx, uint8 _inputIndex, bytes _challengeTxSig)
         public
     {
         // Check that the output is being used as an input to the challenging tx.
-        uint256 inputId = _challengeTx.getInputId(_inputIndex);
-        require(inputId == exits[_standardExitId].position);
+        uint256 challengedUtxoPos = _challengeTx.getInputUtxoPosition(_inputIndex);
+        require(challengedUtxoPos == exits[_standardExitId].position);
 
         // Check if exit exists.
         address owner = exits[_standardExitId].owner;
@@ -398,23 +398,23 @@ contract RootChain {
         bytes32 txHash = keccak256(_challengeTx);
         require(owner == ECRecovery.recover(txHash, _challengeTxSig));
 
-        processChallengeStandardExit(inputId, _standardExitId);
+        processChallengeStandardExit(challengedUtxoPos, _standardExitId);
     }
 
-    function cleanupDoublespendingStandardExits(uint256 _outputId, bytes _txbytes)
+    function cleanupDoubleSpendingStandardExits(uint256 _utxoPos, bytes _txbytes)
         internal
         returns (bool)
     {
-        uint8 oindex = _outputId.getOindex();
+        uint8 oindex = _utxoPos.getOindex();
         uint192 standardExitId = getStandardExitId(keccak256(_txbytes), oindex);
         if (exits[standardExitId].owner != address(0)) {
-            processChallengeStandardExit(_outputId, standardExitId);
+            processChallengeStandardExit(_utxoPos, standardExitId);
             return false;
         }
         return exits[standardExitId].amount != 0;
     }
 
-    function processChallengeStandardExit(uint256 _outputId, uint192 _exitId)
+    function processChallengeStandardExit(uint256 _utxoPos, uint192 _exitId)
         internal
     {
         // Delete the exit.
@@ -423,7 +423,7 @@ contract RootChain {
         // Send a bond to the challenger.
         msg.sender.transfer(standardExitBond);
 
-        emit ExitChallenged(_outputId);
+        emit ExitChallenged(_utxoPos);
     }
 
     /**
@@ -497,7 +497,7 @@ contract RootChain {
         bool finalized;
         bool any_finalized;
         for (uint8 i = 0; i < numInputs; i++) {
-            // vars[0] contains inputId
+            // vars[0] contains txo position of the input
             (inFlightExit.inputs[i], vars[0], finalized) = _getInputInfo(_inFlightTx, splitInputTxs[i].toBytes(), _inputTxsInclusionProofs, _inFlightTxSigs.sliceSignature(i), i);
             require(inFlightExit.inputs[i].token == address(0));
             // vars[1] tracks sum of the inputs
@@ -524,10 +524,10 @@ contract RootChain {
         emit InFlightExitStarted(msg.sender, keccak256(_inFlightTx));
     }
 
-    function _enqueueInFlightExit(uint256 _outputId, bytes _tx)
+    function _enqueueInFlightExit(uint256 _txoPos, bytes _tx)
         private
     {
-        uint256 exitPriority = getInFlightExitPriority(_tx, _outputId);
+        uint256 exitPriority = getInFlightExitPriority(_tx, _txoPos);
 
         // Insert the exit into the queue.
         // TODO: in-flight exits for tokens other than ETH
@@ -593,7 +593,7 @@ contract RootChain {
      * @param _inFlightTxInputIndex Index of the double-spent input in the in-flight transaction.
      * @param _competingTx RLP encoded transaction that spent the input.
      * @param _competingTxInputIndex Index of the double-spent input in the competing transaction.
-     * @param _competingTxId Position of the competing transaction.
+     * @param _competingTxPos Position of the competing transaction.
      * @param _competingTxInclusionProof Proof that the competing transaction was included.
      * @param _competingTxSig Signature proving that the owner of the input signed the competitor.
      */
@@ -602,7 +602,7 @@ contract RootChain {
         uint8 _inFlightTxInputIndex,
         bytes _competingTx,
         uint8 _competingTxInputIndex,
-        uint256 _competingTxId,
+        uint256 _competingTxPos,
         bytes _competingTxInclusionProof,
         bytes _competingTxSig
     )
@@ -619,8 +619,8 @@ contract RootChain {
         require(keccak256(_inFlightTx) != keccak256(_competingTx));
 
         // Check that the two transactions share an input.
-        uint256 inputId = _inFlightTx.getInputId(_inFlightTxInputIndex);
-        require(inputId == _competingTx.getInputId(_competingTxInputIndex));
+        uint256 inFlightTxInputPos = _inFlightTx.getInputUtxoPosition(_inFlightTxInputIndex);
+        require(inFlightTxInputPos == _competingTx.getInputUtxoPosition(_competingTxInputIndex));
 
         // Check that the competing transaction is correctly signed.
         PlasmaCore.TransactionOutput memory input = inFlightExit.inputs[_inFlightTxInputIndex];
@@ -628,10 +628,10 @@ contract RootChain {
 
         // Determine the position of the competing transaction.
         uint256 competitorPosition = ~uint256(0);
-        if (_competingTxId != 0) {
+        if (_competingTxPos != 0) {
             // Check that the competing transaction was included in a block.
-            require(_transactionIncluded(_competingTx, _competingTxId, _competingTxInclusionProof));
-            competitorPosition = _competingTxId;
+            require(_transactionIncluded(_competingTx, _competingTxPos, _competingTxInclusionProof));
+            competitorPosition = _competingTxPos;
         }
 
         // Competitor must first or must be in the chain before the current oldest competitor.
@@ -712,8 +712,8 @@ contract RootChain {
         require(keccak256(_inFlightTx) != keccak256(_spendingTx));
 
         // Check that the two transactions share an input.
-        uint256 inputId = _inFlightTx.getInputId(_inFlightTxInputIndex);
-        require(inputId == _spendingTx.getInputId(_spendingTxInputIndex));
+        uint256 inFlightTxInputPos = _inFlightTx.getInputUtxoPosition(_inFlightTxInputIndex);
+        require(inFlightTxInputPos == _spendingTx.getInputUtxoPosition(_spendingTxInputIndex));
 
         // Check that the spending transaction is signed by the input owner.
         PlasmaCore.TransactionOutput memory input = inFlightExit.inputs[_inFlightTxInputIndex];
@@ -723,13 +723,13 @@ contract RootChain {
         inFlightExit.exitMap = inFlightExit.exitMap.clearBit(_inFlightTxInputIndex);
         msg.sender.transfer(piggybackBond);
 
-        emit InFlightExitOutputBlocked(msg.sender, keccak256(_inFlightTx), inputId);
+        emit InFlightExitOutputBlocked(msg.sender, keccak256(_inFlightTx), _inFlightTxInputIndex);
     }
 
     /**
      * @dev Removes an output from list of exitable outputs in an in-flight transaction.
      * @param _inFlightTx RLP encoded in-flight transaction being exited.
-     * @param _inFlightTxOutputId Output that's been spent.
+     * @param _inFlightTxOutputPos Output that's been spent.
      * @param _inFlightTxInclusionProof Proof that the in-flight transaction was included.
      * @param _spendingTx RLP encoded transaction that spends the input.
      * @param _spendingTxInputIndex Which input to the spending transaction spends the input.
@@ -737,10 +737,10 @@ contract RootChain {
      */
     function challengeInFlightExitOutputSpent(
         bytes _inFlightTx,
-        uint256 _inFlightTxOutputId,
+        uint256 _inFlightTxOutputPos,
         bytes _inFlightTxInclusionProof,
         bytes _spendingTx,
-        uint256 _spendingTxInputIndex,
+        uint8 _spendingTxInputIndex,
         bytes _spendingTxSig
     )
         public
@@ -750,14 +750,14 @@ contract RootChain {
         require(_getExitPeriod(inFlightExit) < 3);
 
         // Check that the output is piggybacked.
-        uint8 oindex = _inFlightTxOutputId.getOindex();
+        uint8 oindex = _inFlightTxOutputPos.getOindex();
         require(inFlightExit.exitMap.bitSet(oindex + MAX_INPUTS));
 
         // Check that the in-flight transaction is included.
-        require(_transactionIncluded(_inFlightTx, _inFlightTxOutputId, _inFlightTxInclusionProof));
+        require(_transactionIncluded(_inFlightTx, _inFlightTxOutputPos, _inFlightTxInclusionProof));
 
         // Check that the spending transaction spends the output.
-        require(_inFlightTxOutputId == _spendingTx.getInputId(_spendingTxInputIndex));
+        require(_inFlightTxOutputPos == _spendingTx.getInputUtxoPosition(_spendingTxInputIndex));
 
         // Check that the spending transaction is signed by the input owner.
         PlasmaCore.TransactionOutput memory output = _inFlightTx.getOutput(oindex);
@@ -767,7 +767,7 @@ contract RootChain {
         inFlightExit.exitMap = inFlightExit.exitMap.clearBit(oindex + MAX_INPUTS);
         msg.sender.transfer(piggybackBond);
 
-        emit InFlightExitOutputBlocked(msg.sender, keccak256(_inFlightTx), _inFlightTxOutputId);
+        emit InFlightExitOutputBlocked(msg.sender, keccak256(_inFlightTx), oindex);
     }
 
     /**
@@ -974,17 +974,17 @@ contract RootChain {
      */
 
     /**
-     * @dev Given an output ID, determines when it's exitable, if it were to be exited now.
-     * @param _outputId Output identifier.
+     * @dev Given an utxo position, determines when it's exitable, if it were to be exited now.
+     * @param _utxoPos Output identifier.
      * @return uint256 Timestamp after which this output is exitable.
      */
 
-    function getExitableTimestamp(uint256 _outputId)
+    function getExitableTimestamp(uint256 _utxoPos)
         public
         view
         returns (uint256)
     {
-        uint256 blknum = _outputId.getBlknum();
+        uint256 blknum = _utxoPos.getBlknum();
         if (blknum % CHILD_BLOCK_INTERVAL == 0) {
             return Math.max(blocks[blknum].timestamp + (minExitPeriod * 2), block.timestamp + minExitPeriod);
         }
@@ -1009,9 +1009,9 @@ contract RootChain {
 
 
     /**
-     * @dev Given a output ID and a unique ID, returns an exit priority.
+     * @dev Given a utxo position and a unique ID, returns an exit priority.
      * @param _exitId Unique exit identifier.
-     * @param _outputId Position of the exit in the blockchain.
+     * @param _utxoPos Position of the exit in the blockchain.
      * @return An exit priority.
      *   Anatomy of returned value, most significant bits first
      *   42 bits - timestamp (exitable_at); unix timestamp fits into 32 bits
@@ -1020,43 +1020,43 @@ contract RootChain {
      *   1 bit - in-flight flag
      *   151 bit - tx hash
      */
-    function getStandardExitPriority(uint192 _exitId, uint256 _outputId)
+    function getStandardExitPriority(uint192 _exitId, uint256 _utxoPos)
         public
         view
         returns (uint256)
     {
-        uint256 tx_pos = _outputId.getTxpos();
-        return ((getExitableTimestamp(_outputId) << 214) | (tx_pos << 160)) | _exitId;
+        uint256 tx_pos = _utxoPos.getTxPos();
+        return ((getExitableTimestamp(_utxoPos) << 214) | (tx_pos << 160)) | _exitId;
     }
 
     /**
      * @dev Given a transaction and the ID for a output in the transaction, returns an exit priority.
-     * @param _outputId Identifier of an output in the transaction.
+     * @param _txoPos Identifier of an output in the transaction.
      * @param _tx RLP encoded transaction.
      * @return An exit priority.
      */
-    function getInFlightExitPriority(bytes _tx, uint256 _outputId)
+    function getInFlightExitPriority(bytes _tx, uint256 _txoPos)
         view
         returns (uint256)
     {
-        return getStandardExitPriority(getInFlightExitId(_tx), _outputId);
+        return getStandardExitPriority(getInFlightExitId(_tx), _txoPos);
     }
 
     /**
      * @dev Checks that a given transaction was included in a block and created a specified output.
      * @param _tx RLP encoded transaction to verify.
-     * @param _transactionId Unique transaction identifier for the encoded transaction.
+     * @param _transactionPos Transaction position for the encoded transaction.
      * @param _txInclusionProof Proof that the transaction was in a block.
      * @return True if the transaction was in a block and created the output. False otherwise.
      */
-    function _transactionIncluded(bytes _tx, uint256 _transactionId, bytes _txInclusionProof)
+    function _transactionIncluded(bytes _tx, uint256 _transactionPos, bytes _txInclusionProof)
         internal
         view
         returns (bool)
     {
         // Decode the transaction ID.
-        uint256 blknum = _transactionId.getBlknum();
-        uint256 txindex = _transactionId.getTxindex();
+        uint256 blknum = _transactionPos.getBlknum();
+        uint256 txindex = _transactionPos.getTxIndex();
 
         // Check that the transaction was correctly included.
         bytes32 blockRoot = blocks[blknum].root;
@@ -1105,7 +1105,7 @@ contract RootChain {
         uint8 numInputs = 0;
         uint256 outputSum = 0;
         for (uint8 i = 0; i < MAX_INPUTS; i++) {
-            if (_tx.getInputId(i) > 0) {
+            if (_tx.getInputUtxoPosition(i) > 0) {
                 numInputs++;
             }
             outputSum += _tx.getOutput(i).amount;
@@ -1137,17 +1137,17 @@ contract RootChain {
         bool already_finalized;
 
         // Pull information about the the input.
-        uint256 inputId = _tx.getInputId(_inputIndex);
-        PlasmaCore.TransactionOutput memory input = _inputTx.getOutput(inputId.getOindex());
+        uint256 inputUtxoPos = _tx.getInputUtxoPosition(_inputIndex);
+        PlasmaCore.TransactionOutput memory input = _inputTx.getOutput(inputUtxoPos.getOindex());
 
         // Check that the transaction is valid.
-        require(_transactionIncluded(_inputTx, inputId, _txInputTxsInclusionProofs.sliceProof(_inputIndex)));
+        require(_transactionIncluded(_inputTx, inputUtxoPos, _txInputTxsInclusionProofs.sliceProof(_inputIndex)));
         require(input.owner == ECRecovery.recover(keccak256(_tx), _inputSig));
 
         // Challenge exiting standard exits from inputs
-        already_finalized = cleanupDoublespendingStandardExits(inputId, _inputTx);
+        already_finalized = cleanupDoubleSpendingStandardExits(inputUtxoPos, _inputTx);
 
-        return (input, inputId, already_finalized);
+        return (input, inputUtxoPos, already_finalized);
     }
 
     /**

--- a/contracts/RootChain.sol
+++ b/contracts/RootChain.sol
@@ -608,6 +608,9 @@ contract RootChain {
         InFlightExit storage inFlightExit = _getInFlightExit(_inFlightTx);
         require(_getExitPeriod(inFlightExit) == 1);
 
+        // Check if exit's input were spent via MVP exit
+        require(!isSpentInput(inFlightExit.exitStartTimestamp));
+
         // Check that the two transactions are not the same.
         require(keccak256(_inFlightTx) != keccak256(_competingTx));
 
@@ -656,6 +659,9 @@ contract RootChain {
         // Check that the exit is currently active and first two periods.
         InFlightExit storage inFlightExit = _getInFlightExit(_inFlightTx);
         require(_getExitPeriod(inFlightExit) < 3);
+
+        // Check if exit's input were spent via MVP exit
+        require(!isSpentInput(inFlightExit.exitStartTimestamp));
 
         // Check that the in-flight transaction was included.
         require(_transactionIncluded(_inFlightTx, _inFlightTxPos, _inFlightTxInclusionProof));
@@ -943,6 +949,14 @@ contract RootChain {
         returns (uint256)
     {
         return _value.setBit(254);
+    }
+
+    function isSpentInput(uint256 _value)
+        public
+        pure
+        returns (bool)
+    {
+        return _value.bitSet(254);
     }
 
     /*

--- a/contracts/RootChain.sol
+++ b/contracts/RootChain.sol
@@ -1144,7 +1144,7 @@ contract RootChain {
             transferAmount = piggybackBond;
             if ((i < 4 && inputsExitable) || (i >= 4 && !inputsExitable)) {
                 transferAmount += output.amount;
-                emit InFlightExitFinalized(uint192(0), i);
+                emit InFlightExitFinalized(_inFlightExitId, i);
             }
             output.owner.transfer(transferAmount);
         }

--- a/contracts/RootChain.sol
+++ b/contracts/RootChain.sol
@@ -395,12 +395,15 @@ contract RootChain {
 
     function maybeChallengeStandardExitOnInput(uint256 _outputId, bytes _txbytes)
         internal
+        returns (bool)
     {
         uint8 oindex = _outputId.getOindex();
         uint192 standardExitId = getStandardExitId(keccak256(_txbytes), oindex);
         if (exits[standardExitId].owner != address(0)) {
             processChallengeStandardExit(_outputId, standardExitId);
+            return false;
         }
+        return exits[standardExitId].amount != 0;
     }
 
     function processChallengeStandardExit(uint256 _outputId, uint192 _exitId)
@@ -481,25 +484,34 @@ contract RootChain {
         // Separate the inputs transactions.
         RLP.RLPItem[] memory splitInputTxs = _inputTxs.toRLPItem().toList();
 
+        uint256[3] memory vars;
         // Get information about the inputs.
-        uint256 inputId;
-        uint256 inputSum;
-        uint256 mostRecentInput = 0;
+        // uint256 inputId; // vars[0]
+        // uint256 inputSum; // vars[1]
+        // uint256 mostRecentInput = 0; // vars[2]
+        bool finalized;
+        bool any_finalized;
         for (uint8 i = 0; i < numInputs; i++) {
-            (inFlightExit.inputs[i], inputId) = _getInputInfo(_inFlightTx, splitInputTxs[i].toBytes(), _inputTxsInclusionProofs, _inFlightTxSigs.sliceSignature(i), i);
+            (inFlightExit.inputs[i], vars[0], finalized) = _getInputInfo(_inFlightTx, splitInputTxs[i].toBytes(), _inputTxsInclusionProofs, _inFlightTxSigs.sliceSignature(i), i);
             require(inFlightExit.inputs[i].token == address(0));
-            inputSum += inFlightExit.inputs[i].amount;
-            mostRecentInput = Math.max(mostRecentInput, inputId);
+            vars[1] += inFlightExit.inputs[i].amount;
+            vars[2] = Math.max(vars[2], vars[0]);
+            any_finalized = any_finalized || finalized;
         }
 
         // Make sure the sums are valid.
-        require(inputSum >= outputSum);
+        require(vars[1] >= outputSum);
 
         // Determine when the exit can be processed.
-        _enqueueInFlightExit(mostRecentInput, _inFlightTx);
+        _enqueueInFlightExit(vars[2], _inFlightTx);
         // Update the exit mapping.
-        inFlightExit.exitStartTimestamp = block.timestamp;
         inFlightExit.bondOwner = msg.sender;
+        inFlightExit.exitStartTimestamp = block.timestamp;
+        // If any of the inputs were finalized via standard exit, consider it non-canonical
+        // and flag as not taking part in further canonicity game.
+        if (any_finalized) {
+            inFlightExit.exitStartTimestamp = flagSpentInput(inFlightExit.exitStartTimestamp);
+        }
 
         emit InFlightExitStarted(msg.sender, keccak256(_inFlightTx));
     }
@@ -1087,8 +1099,10 @@ contract RootChain {
     )
         internal
         view
-        returns (PlasmaCore.TransactionOutput, uint256)
+        returns (PlasmaCore.TransactionOutput, uint256, bool)
     {
+        bool finalized;
+
         // Pull information about the the input.
         uint256 inputId = _tx.getInputId(_inputIndex);
         PlasmaCore.TransactionOutput memory input = _inputTx.getOutput(inputId.getOindex());
@@ -1098,9 +1112,9 @@ contract RootChain {
         require(input.owner == ECRecovery.recover(keccak256(_tx), _inputSig));
 
         // Challenge exiting standard exits from inputs
-        maybeChallengeStandardExitOnInput(inputId, _inputTx);
+        finalized = maybeChallengeStandardExitOnInput(inputId, _inputTx);
 
-        return (input, inputId);
+        return (input, inputId, finalized);
     }
 
     /**

--- a/contracts/RootChain.sol
+++ b/contracts/RootChain.sol
@@ -1066,16 +1066,11 @@ contract RootChain {
         // Loop through each input.
         uint8 numInputs = 0;
         uint256 outputSum = 0;
-        PlasmaCore.TransactionOutput memory output;
-        PlasmaCore.TransactionOutput[] memory outputs = new PlasmaCore.TransactionOutput[](4);
         for (uint8 i = 0; i < 4; i++) {
             if (_tx.getInputId(i) > 0) {
                 numInputs++;
             }
-
-            output = _tx.getOutput(i);
-            outputSum += output.amount;
-            outputs[i] = output;
+            outputSum += _tx.getOutput(i).amount;
         }
 
         return (numInputs, outputSum);

--- a/contracts/RootChain.sol
+++ b/contracts/RootChain.sol
@@ -34,6 +34,9 @@ contract RootChain {
      */
     uint256 constant public CHILD_BLOCK_INTERVAL = 1000;
 
+    // Applies to outputs too
+    uint8 constant public MAX_INPUTS = 4;
+
     // WARNING: These placeholder bond values are entirely arbitrary.
     uint256 public standardExitBond = 31415926535 wei;
     uint256 public inFlightExitBond = 31415926535 wei;
@@ -71,8 +74,8 @@ contract RootChain {
     struct InFlightExit {
         uint256 exitStartTimestamp;
         uint256 exitMap;
-        PlasmaCore.TransactionOutput[4] inputs;
-        PlasmaCore.TransactionOutput[4] outputs;
+        PlasmaCore.TransactionOutput[MAX_INPUTS] inputs;
+        PlasmaCore.TransactionOutput[MAX_INPUTS] outputs;
         address bondOwner;
         uint256 oldestCompetitor;
     }
@@ -291,7 +294,7 @@ contract RootChain {
         require(nextDepositBlock < CHILD_BLOCK_INTERVAL);
 
         // Check that all but first inputs are 0.
-        for (uint i = 1; i < 4; i++) {
+        for (uint i = 1; i < MAX_INPUTS; i++) {
             require(decodedTx.outputs[i].amount == 0);
         }
 
@@ -350,9 +353,9 @@ contract RootChain {
         InFlightExit storage inFlightExit = _getInFlightExit(_outputTx);
         if (inFlightExit.exitStartTimestamp != 0) {
             // Check if this output was piggybacked or exited in in-flight exit
-            require(!inFlightExit.exitMap.bitSet(oindex + 4) && !inFlightExit.exitMap.bitSet(oindex + 4 + 8));
+            require(!inFlightExit.exitMap.bitSet(oindex + MAX_INPUTS) && !inFlightExit.exitMap.bitSet(oindex + MAX_INPUTS + MAX_INPUTS*2));
             // Prevent future piggybacks on this output
-            inFlightExit.exitMap = inFlightExit.exitMap.setBit(oindex + 4 + 8);
+            inFlightExit.exitMap = inFlightExit.exitMap.setBit(oindex + MAX_INPUTS + MAX_INPUTS*2);
         }
 
         // Make sure queue for this token exists.
@@ -566,13 +569,13 @@ contract RootChain {
 
         // Check that the message sender owns the output.
         PlasmaCore.TransactionOutput memory output;
-        if (_outputIndex < 4) {
+        if (_outputIndex < MAX_INPUTS) {
             output = inFlightExit.inputs[_outputIndex];
         } else {
-            output = _inFlightTx.getOutput(_outputIndex - 4);
+            output = _inFlightTx.getOutput(_outputIndex - MAX_INPUTS);
 
             // Set the output so it can be exited later.
-            inFlightExit.outputs[_outputIndex - 4] = output;
+            inFlightExit.outputs[_outputIndex - MAX_INPUTS] = output;
         }
         require(output.owner == msg.sender);
 
@@ -747,7 +750,7 @@ contract RootChain {
 
         // Check that the output is piggybacked.
         uint8 oindex = _inFlightTxOutputId.getOindex();
-        require(inFlightExit.exitMap.bitSet(oindex + 4));
+        require(inFlightExit.exitMap.bitSet(oindex + MAX_INPUTS));
 
         // Check that the in-flight transaction is included.
         require(_transactionIncluded(_inFlightTx, _inFlightTxOutputId, _inFlightTxInclusionProof));
@@ -760,7 +763,7 @@ contract RootChain {
         require(output.owner == ECRecovery.recover(keccak256(_spendingTx), _spendingTxSig));
 
         // Remove the output from the piggyback map and pay out the bond.
-        inFlightExit.exitMap = inFlightExit.exitMap.clearBit(oindex + 4);
+        inFlightExit.exitMap = inFlightExit.exitMap.clearBit(oindex + MAX_INPUTS);
         msg.sender.transfer(piggybackBond);
 
         emit InFlightExitOutputBlocked(msg.sender, keccak256(_inFlightTx), _inFlightTxOutputId);
@@ -900,10 +903,10 @@ contract RootChain {
     {
         InFlightExit memory inFlightExit = _getInFlightExit(_tx);
         PlasmaCore.TransactionOutput memory output;
-        if (_outputIndex < 4) {
+        if (_outputIndex < MAX_INPUTS) {
             output = inFlightExit.inputs[_outputIndex];
         } else {
-            output = inFlightExit.outputs[_outputIndex - 4];
+            output = inFlightExit.outputs[_outputIndex - MAX_INPUTS];
         }
         return (output.owner, output.token, output.amount);
     }
@@ -1100,7 +1103,7 @@ contract RootChain {
         // Loop through each input.
         uint8 numInputs = 0;
         uint256 outputSum = 0;
-        for (uint8 i = 0; i < 4; i++) {
+        for (uint8 i = 0; i < MAX_INPUTS; i++) {
             if (_tx.getInputId(i) > 0) {
                 numInputs++;
             }
@@ -1192,15 +1195,15 @@ contract RootChain {
             }
             _inFlightExit.exitMap = _inFlightExit.exitMap.clearBit(i).setBit(i + 8);
 
-            if (i < 4) {
+            if (i < MAX_INPUTS) {
                 output = _inFlightExit.inputs[i];
             } else {
-                output = _inFlightExit.outputs[i - 4];
+                output = _inFlightExit.outputs[i - MAX_INPUTS];
             }
 
             // Pay out any unchallenged and exitable inputs or outputs, refund the rest.
             transferAmount = piggybackBond;
-            if ((i < 4 && inputsExitable) || (i >= 4 && !inputsExitable)) {
+            if ((i < MAX_INPUTS && inputsExitable) || (i >= MAX_INPUTS && !inputsExitable)) {
                 transferAmount += output.amount;
                 emit InFlightExitFinalized(_inFlightExitId, i);
             }

--- a/contracts/RootChain.sol
+++ b/contracts/RootChain.sol
@@ -332,7 +332,7 @@ contract RootChain {
         require(_transactionIncluded(_outputTx, _outputId, _outputTxInclusionProof));
 
         // Decode the output ID.
-        uint256 oindex = _outputId.getOindex();
+        uint8 oindex = uint8(_outputId.getOindex());
 
         // Parse outputTx.
         PlasmaCore.TransactionOutput memory output = _outputTx.getOutput(oindex);
@@ -345,6 +345,10 @@ contract RootChain {
         // Make sure this exit is valid.
         require(output.amount > 0);
         require(exits[exitId].amount == 0);
+
+        // Check if this output was piggybacked or exited in in-flight exit
+        InFlightExit storage inFlightExit = _getInFlightExit(_outputTx);
+        require(!inFlightExit.exitMap.bitSet(oindex + 4) && !inFlightExit.exitMap.bitSet(oindex + 4 + 8));
 
         // Make sure queue for this token exists.
         require(hasToken(output.token));

--- a/plasma_core/constants.py
+++ b/plasma_core/constants.py
@@ -51,7 +51,6 @@ NULL_ADDRESS = NULL_BYTE * 20
 NULL_ADDRESS_HEX = '0x' + NULL_ADDRESS.hex()
 
 MINUTE = 60
-WEEK = 60 * 60 * 24 * 7
 DAY = 60 * 60 * 24
 
 # used for suitable test contract instantiation

--- a/plasma_core/transaction.py
+++ b/plasma_core/transaction.py
@@ -58,6 +58,7 @@ class Transaction(rlp.Serializable):
                  outputs=[DEFAULT_OUTPUT] * NUM_TXOS,
                  metadata="",
                  signatures=[NULL_SIGNATURE] * NUM_TXOS):
+        assert all(len(o) == 3 for o in outputs)
         padded_inputs = pad_list(inputs, self.DEFAULT_INPUT, self.NUM_TXOS)
         padded_outputs = pad_list(outputs, self.DEFAULT_OUTPUT, self.NUM_TXOS)
 

--- a/testlang/testlang.py
+++ b/testlang/testlang.py
@@ -370,6 +370,10 @@ class TestingLanguage(object):
         encoded_inputs = rlp.encode(input_txs, rlp.sedes.CountableList(Transaction, 4))
         return (spend_tx.encoded, encoded_inputs, proofs, signatures)
 
+    def get_in_flight_exit_id(self, tx_id):
+        spend_tx = self.child_chain.get_transaction(tx_id)
+        return self.root_chain.getInFlightExitId(spend_tx.encoded)
+
     def get_merkle_proof(self, tx_id):
         tx = self.child_chain.get_transaction(tx_id)
         (blknum, _, _) = decode_utxo_id(tx_id)

--- a/testlang/testlang.py
+++ b/testlang/testlang.py
@@ -108,6 +108,12 @@ class InFlightExit(object):
     def output_piggybacked(self, index):
         return self.input_piggybacked(index + 4)
 
+    def input_blocked(self, index):
+        return self.input_piggybacked(index + 8)
+
+    def output_blocked(self, index):
+        return self.input_blocked(index + 4)
+
 
 class TestingLanguage(object):
     """Represents the testing language.

--- a/testlang/testlang.py
+++ b/testlang/testlang.py
@@ -359,8 +359,9 @@ class TestingLanguage(object):
 
         self.ethtester.chain.head_state.timestamp += amount
 
-    def get_in_flight_exit_info(self, tx_id):
-        spend_tx = self.child_chain.get_transaction(tx_id)
+    def get_in_flight_exit_info(self, tx_id, spend_tx=None):
+        if spend_tx is None:
+            spend_tx = self.child_chain.get_transaction(tx_id)
         input_txs = []
         proofs = b''
         signatures = b''

--- a/testlang/testlang.py
+++ b/testlang/testlang.py
@@ -38,13 +38,28 @@ class StandardExit(object):
         owner (str): Address of the exit's owner.
         token (str): Address of the token being exited.
         amount (int): How much value is being exited.
+        position (int): UTXO position.
     """
 
-    def __init__(self, owner, token, amount):
+    def __init__(self, owner, token, amount, position=0):
         self.owner = owner
         self.token = token
         self.amount = amount
+        self.position = position
 
+    def to_list(self):
+        return [self.owner, self.token, self.amount, self.position]
+
+    def __str__(self):
+        return self.to_list().__str__()
+
+    def __repr__(self):
+        return self.to_list().__repr__()
+
+    def __eq__(self, other):
+        if hasattr(other, "to_list"):
+            return self.to_list() == other.to_list()
+        return (self.to_list() == other) or (self.to_list()[:3] == other)
 
 class PlasmaBlock(object):
     """Represents a Plasma block.
@@ -293,10 +308,12 @@ class TestingLanguage(object):
             utxo_pos (int): position of utxo being exited
 
         Returns:
-            StandardExit: Formatted plasma exit information.
+            tuple: (owner (address), token (address), amount (int))
         """
 
-        exit_id = self.root_chain.getStandardExitId(utxo_pos)
+        tx = self.child_chain.get_transaction(utxo_pos)
+        _, _, oindex = decode_utxo_id(utxo_pos)
+        exit_id = self.root_chain.getStandardExitId(tx.hash, oindex)
         exit_info = self.root_chain.exits(exit_id)
         return StandardExit(*exit_info)
 

--- a/testlang/testlang.py
+++ b/testlang/testlang.py
@@ -61,6 +61,7 @@ class StandardExit(object):
             return self.to_list() == other.to_list()
         return (self.to_list() == other) or (self.to_list()[:3] == other)
 
+
 class PlasmaBlock(object):
     """Represents a Plasma block.
 
@@ -199,16 +200,20 @@ class TestingLanguage(object):
         bond = bond if bond is not None else self.root_chain.standardExitBond()
         self.root_chain.startStandardExit(output_id, output_tx.encoded, proof, value=bond, sender=key)
 
-    def challenge_standard_exit(self, output_id, spend_id):
+    def challenge_standard_exit(self, output_id, spend_id, input_index=None):
         spend_tx = self.child_chain.get_transaction(spend_id)
-        input_index = None
         signature = NULL_SIGNATURE
-        for i in range(0, 4):
-            input_index = i
-            signature = spend_tx.signatures[i]
-            if (spend_tx.inputs[i].identifier == output_id and signature != NULL_SIGNATURE):
-                break
-        self.root_chain.challengeStandardExit(output_id, spend_tx.encoded, input_index, signature)
+        if input_index is None:
+            for i in range(0, 4):
+                signature = spend_tx.signatures[i]
+                if (spend_tx.inputs[i].identifier == output_id and signature != NULL_SIGNATURE):
+                    input_index = i
+                    break
+        if input_index is None:
+            input_index = 3
+        output_tx = self.child_chain.get_transaction(output_id)
+        exit_id = self.root_chain.getStandardExitId(output_tx.hash, input_index)
+        self.root_chain.challengeStandardExit(exit_id, spend_tx.encoded, input_index, signature)
 
     def start_in_flight_exit(self, tx_id, bond=None, sender=None):
         if sender is None:
@@ -249,21 +254,21 @@ class TestingLanguage(object):
             int: Unique identifier of the exit.
         """
 
-        fee_exit_id = self.root_chain.nextFeeExit()
+        fee_exit_id = self.root_chain.getFeeExitId(self.root_chain.nextFeeExit())
         bond = bond if bond is not None else self.root_chain.standardExitBond()
         self.root_chain.startFeeExit(token, amount, value=bond, sender=operator.key)
         return fee_exit_id
 
-    def process_exits(self, token, utxo_id, count, **kwargs):
+    def process_exits(self, token, exit_id, count, **kwargs):
         """Finalizes exits that have completed the exit period.
 
         Args:
             token (address): Address of the token to be processed.
-            utxo_id (int): Identifier of the UTXO being exited.
+            exit_id (int): Identifier of an exit (optional, pass 0 to ignore the check)
             count (int): Maximum number of exits to be processed.
         """
 
-        self.root_chain.processExits(token, utxo_id, count, **kwargs)
+        self.root_chain.processExits(token, exit_id, count, **kwargs)
 
     def get_challenge_proof(self, utxo_id, spend_id):
         """Returns information required to submit a challenge.
@@ -311,11 +316,14 @@ class TestingLanguage(object):
             tuple: (owner (address), token (address), amount (int))
         """
 
-        tx = self.child_chain.get_transaction(utxo_pos)
-        _, _, oindex = decode_utxo_id(utxo_pos)
-        exit_id = self.root_chain.getStandardExitId(tx.hash, oindex)
+        exit_id = self.get_standard_exit_id(utxo_pos)
         exit_info = self.root_chain.exits(exit_id)
         return StandardExit(*exit_info)
+
+    def get_standard_exit_id(self, utxo_pos):
+        tx = self.child_chain.get_transaction(utxo_pos)
+        _, _, oindex = decode_utxo_id(utxo_pos)
+        return self.root_chain.getStandardExitId(tx.hash, oindex)
 
     def get_balance(self, account, token=NULL_ADDRESS):
         """Queries ETH or token balance of an account.

--- a/testlang/testlang.py
+++ b/testlang/testlang.py
@@ -195,10 +195,12 @@ class TestingLanguage(object):
                 break
         self.root_chain.challengeStandardExit(output_id, spend_tx.encoded, input_index, signature)
 
-    def start_in_flight_exit(self, tx_id, bond=None):
+    def start_in_flight_exit(self, tx_id, bond=None, sender=None):
+        if sender is None:
+            sender = self.accounts[0]
         (encoded_spend, encoded_inputs, proofs, signatures) = self.get_in_flight_exit_info(tx_id)
         bond = bond if bond is not None else self.root_chain.inFlightExitBond()
-        self.root_chain.startInFlightExit(encoded_spend, encoded_inputs, proofs, signatures, value=bond)
+        self.root_chain.startInFlightExit(encoded_spend, encoded_inputs, proofs, signatures, value=bond, sender=sender.key)
 
     def create_utxo(self, token=NULL_ADDRESS):
         class Utxo(object):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from solc import link_code
 
 
 EXIT_PERIOD = 4 * 60  # 4 minutes
-GAS_LIMIT = 8000000
+GAS_LIMIT = 10000000
 START_GAS = GAS_LIMIT - 1000000
 config_metropolis['BLOCK_GAS_LIMIT'] = GAS_LIMIT
 

--- a/tests/contracts/rlp/test_plasma_core.py
+++ b/tests/contracts/rlp/test_plasma_core.py
@@ -45,10 +45,10 @@ def test_decode_mallability(testlang, plasma_core_test):
 def test_get_input_id(plasma_core_test):
     input_id = (2, 2, 2)
     tx = Transaction(inputs=[input_id])
-    assert plasma_core_test.getInputId(tx.encoded, 0) == tx.inputs[0].identifier
-    assert plasma_core_test.getInputId(tx.encoded, 1) == 0
-    assert plasma_core_test.getInputId(tx.encoded, 2) == 0
-    assert plasma_core_test.getInputId(tx.encoded, 3) == 0
+    assert plasma_core_test.getInputUtxoPosition(tx.encoded, 0) == tx.inputs[0].identifier
+    assert plasma_core_test.getInputUtxoPosition(tx.encoded, 1) == 0
+    assert plasma_core_test.getInputUtxoPosition(tx.encoded, 2) == 0
+    assert plasma_core_test.getInputUtxoPosition(tx.encoded, 3) == 0
 
 
 def test_get_output_index(plasma_core_test):
@@ -58,7 +58,7 @@ def test_get_output_index(plasma_core_test):
 
 def test_get_tx_index(plasma_core_test):
     output_id = 1000020003
-    assert plasma_core_test.getTxindex(output_id) == 2
+    assert plasma_core_test.getTxIndex(output_id) == 2
 
 
 def test_get_blknum(plasma_core_test):
@@ -68,4 +68,4 @@ def test_get_blknum(plasma_core_test):
 
 def test_get_txpos_index(plasma_core_test):
     output_id = 1000020003
-    assert plasma_core_test.getTxpos(output_id) == 100002
+    assert plasma_core_test.getTxPos(output_id) == 100002

--- a/tests/contracts/rlp/test_plasma_core.py
+++ b/tests/contracts/rlp/test_plasma_core.py
@@ -27,7 +27,6 @@ def test_get_output(plasma_core_test):
     owner = b'0x82a978b3f5962a5b0957d9ee9eef472ee55b42f1'
     amount = 100
     tx = Transaction(outputs=[(owner, null, amount)])
-    tx = Transaction(outputs=[(owner, null, amount)])
     assert plasma_core_test.getOutput(tx.encoded, 0) == [owner.decode("utf-8"), null, amount]
     assert plasma_core_test.getOutput(tx.encoded, 1) == [null, null, 0]
 
@@ -47,7 +46,9 @@ def test_get_input_id(plasma_core_test):
     input_id = (2, 2, 2)
     tx = Transaction(inputs=[input_id])
     assert plasma_core_test.getInputId(tx.encoded, 0) == tx.inputs[0].identifier
-    assert plasma_core_test.getInputId(tx.encoded, 1) == tx.inputs[1].identifier
+    assert plasma_core_test.getInputId(tx.encoded, 1) == 0
+    assert plasma_core_test.getInputId(tx.encoded, 2) == 0
+    assert plasma_core_test.getInputId(tx.encoded, 3) == 0
 
 
 def test_get_output_index(plasma_core_test):
@@ -63,3 +64,8 @@ def test_get_tx_index(plasma_core_test):
 def test_get_blknum(plasma_core_test):
     output_id = 1000020003
     assert plasma_core_test.getBlknum(output_id) == 1
+
+
+def test_get_txpos_index(plasma_core_test):
+    output_id = 1000020003
+    assert plasma_core_test.getTxpos(output_id) == 100002

--- a/tests/contracts/root_chain/test_challenge_in_flight_exit_input_spent.py
+++ b/tests/contracts/root_chain/test_challenge_in_flight_exit_input_spent.py
@@ -1,12 +1,13 @@
 import pytest
 from ethereum.tools.tester import TransactionFailed
+from plasma_core.constants import NULL_ADDRESS
 
 
 def test_challenge_in_flight_exit_input_spent_should_succeed(testlang):
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)], "", force_invalid=True)
+    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
     testlang.start_in_flight_exit(spend_id)
     testlang.piggyback_in_flight_exit_input(spend_id, 0, owner_1.key)
     testlang.forward_to_period(2)
@@ -21,7 +22,7 @@ def test_challenge_in_flight_exit_input_spent_not_piggybacked_should_fail(testla
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)], force_invalid=True)
+    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
     testlang.start_in_flight_exit(spend_id)
     testlang.forward_to_period(2)
 
@@ -46,7 +47,7 @@ def test_challenge_in_flight_exit_input_spent_unrelated_tx_should_fail(testlang)
     deposit_id_1 = testlang.deposit(owner_1, amount)
     deposit_id_2 = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id_1], [owner_1.key])
-    unrelated_spend_id = testlang.spend_utxo([deposit_id_2], [owner_1.key], [(owner_1.address, 100)])
+    unrelated_spend_id = testlang.spend_utxo([deposit_id_2], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)])
     testlang.start_in_flight_exit(spend_id)
     testlang.piggyback_in_flight_exit_input(spend_id, 0, owner_1.key)
     testlang.forward_to_period(2)
@@ -59,7 +60,7 @@ def test_challenge_in_flight_exit_input_spent_invalid_signature_should_fail(test
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_2.key], [(owner_1.address, 100)], force_invalid=True)
+    double_spend_id = testlang.spend_utxo([deposit_id], [owner_2.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
     testlang.start_in_flight_exit(spend_id)
     testlang.piggyback_in_flight_exit_input(spend_id, 0, owner_1.key)
     testlang.forward_to_period(2)

--- a/tests/contracts/root_chain/test_challenge_in_flight_exit_not_canonical.py
+++ b/tests/contracts/root_chain/test_challenge_in_flight_exit_not_canonical.py
@@ -1,6 +1,6 @@
 import pytest
 from ethereum.tools.tester import TransactionFailed
-from plasma_core.constants import NULL_ADDRESS
+from plasma_core.constants import NULL_ADDRESS, MIN_EXIT_PERIOD
 
 
 def test_challenge_in_flight_exit_not_canonical_should_succeed(testlang):
@@ -153,3 +153,20 @@ def test_challenge_in_flight_exit_twice_younger_position_should_fail(testlang):
 
     with pytest.raises(TransactionFailed):
         testlang.challenge_in_flight_exit_not_canonical(spend_id, double_spend_id_2, key=owner_2.key)
+
+
+def test_challenge_in_flight_exit_not_canonical_with_inputs_spent_should_fail(testlang):
+    owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
+    deposit_id = testlang.deposit(owner_1, amount)
+    testlang.start_standard_exit(deposit_id, owner_1.key)
+    spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
+    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
+
+    testlang.forward_timestamp(2 * MIN_EXIT_PERIOD + 1)
+    testlang.process_exits(NULL_ADDRESS, 0, 1)
+
+    testlang.start_in_flight_exit(spend_id)
+
+    # Since IFE can be exited only from inputs, no further canonicity game required
+    with pytest.raises(TransactionFailed):
+        testlang.challenge_in_flight_exit_not_canonical(spend_id, double_spend_id, key=owner_2.key)

--- a/tests/contracts/root_chain/test_challenge_in_flight_exit_not_canonical.py
+++ b/tests/contracts/root_chain/test_challenge_in_flight_exit_not_canonical.py
@@ -1,12 +1,13 @@
 import pytest
 from ethereum.tools.tester import TransactionFailed
+from plasma_core.constants import NULL_ADDRESS
 
 
 def test_challenge_in_flight_exit_not_canonical_should_succeed(testlang):
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)], force_invalid=True)
+    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
 
     testlang.start_in_flight_exit(spend_id)
 
@@ -22,7 +23,7 @@ def test_challenge_in_flight_exit_not_canonical_wrong_period_should_fail(testlan
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)], force_invalid=True)
+    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
 
     testlang.start_in_flight_exit(spend_id)
     testlang.forward_to_period(2)
@@ -65,7 +66,7 @@ def test_challenge_in_flight_exit_not_canonical_wrong_index_should_fail(testlang
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)], force_invalid=True)
+    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
     spend_tx = testlang.child_chain.get_transaction(spend_id)
     double_spend_tx = testlang.child_chain.get_transaction(double_spend_id)
 
@@ -82,7 +83,7 @@ def test_challenge_in_flight_exit_not_canonical_invalid_signature_should_fail(te
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_2.key], [(owner_1.address, 100)], force_invalid=True)
+    double_spend_id = testlang.spend_utxo([deposit_id], [owner_2.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
 
     testlang.start_in_flight_exit(spend_id)
 
@@ -94,7 +95,7 @@ def test_challenge_in_flight_exit_not_canonical_invalid_proof_should_fail(testla
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)], force_invalid=True)
+    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
     spend_tx = testlang.child_chain.get_transaction(spend_id)
     double_spend_tx = testlang.child_chain.get_transaction(double_spend_id)
 
@@ -111,7 +112,7 @@ def test_challenge_in_flight_exit_not_canonical_same_tx_twice_should_fail(testla
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)], force_invalid=True)
+    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
 
     testlang.start_in_flight_exit(spend_id)
 
@@ -125,8 +126,8 @@ def test_challenge_in_flight_exit_twice_older_position_should_succeed(testlang):
     owner_1, owner_2, owner_3, amount = testlang.accounts[0], testlang.accounts[1], testlang.accounts[2], 100
     deposit_id = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id_1 = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)], force_invalid=True)
-    double_spend_id_2 = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 50)], force_invalid=True)
+    double_spend_id_1 = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
+    double_spend_id_2 = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 50)], force_invalid=True)
 
     testlang.start_in_flight_exit(spend_id)
 
@@ -143,8 +144,8 @@ def test_challenge_in_flight_exit_twice_younger_position_should_fail(testlang):
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id_1 = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)], force_invalid=True)
-    double_spend_id_2 = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 50)], force_invalid=True)
+    double_spend_id_1 = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
+    double_spend_id_2 = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 50)], force_invalid=True)
 
     testlang.start_in_flight_exit(spend_id)
 

--- a/tests/contracts/root_chain/test_challenge_in_flight_exit_output_spent.py
+++ b/tests/contracts/root_chain/test_challenge_in_flight_exit_output_spent.py
@@ -1,11 +1,12 @@
 import pytest
 from ethereum.tools.tester import TransactionFailed
+from plasma_core.constants import NULL_ADDRESS
 
 
 def test_challenge_in_flight_exit_output_spent_should_succeed(testlang):
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
-    spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)])
+    spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)])
     double_spend_id = testlang.spend_utxo([spend_id], [owner_1.key], force_invalid=True)
     testlang.start_in_flight_exit(spend_id)
     testlang.piggyback_in_flight_exit_output(spend_id, 0, owner_1.key)
@@ -20,7 +21,7 @@ def test_challenge_in_flight_exit_output_spent_should_succeed(testlang):
 def test_challenge_in_flight_exit_output_spent_not_piggybacked_should_fail(testlang):
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
-    spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)])
+    spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)])
     double_spend_id = testlang.spend_utxo([spend_id], [owner_1.key], force_invalid=True)
     testlang.start_in_flight_exit(spend_id)
     testlang.forward_to_period(2)
@@ -33,7 +34,7 @@ def test_challenge_in_flight_exit_output_spent_unrelated_tx_should_fail(testlang
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id_1 = testlang.deposit(owner_1, amount)
     deposit_id_2 = testlang.deposit(owner_1, amount)
-    spend_id = testlang.spend_utxo([deposit_id_1], [owner_1.key], [(owner_1.address, 100)])
+    spend_id = testlang.spend_utxo([deposit_id_1], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)])
     unrelated_spend_id = testlang.spend_utxo([deposit_id_2], [owner_1.key])
     testlang.start_in_flight_exit(spend_id)
     testlang.piggyback_in_flight_exit_output(spend_id, 0, owner_1.key)
@@ -46,7 +47,7 @@ def test_challenge_in_flight_exit_output_spent_unrelated_tx_should_fail(testlang
 def test_challenge_in_flight_exit_output_spent_invalid_signature_should_fail(testlang):
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
-    spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)])
+    spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)])
     double_spend_id = testlang.spend_utxo([spend_id], [owner_2.key], force_invalid=True)
     testlang.start_in_flight_exit(spend_id)
     testlang.piggyback_in_flight_exit_output(spend_id, 0, owner_1.key)
@@ -59,7 +60,7 @@ def test_challenge_in_flight_exit_output_spent_invalid_signature_should_fail(tes
 def test_challenge_in_flight_exit_output_spent_invalid_proof_should_fail(testlang):
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
-    spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)])
+    spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)])
     double_spend_id = testlang.spend_utxo([spend_id], [owner_1.key], force_invalid=True)
     testlang.start_in_flight_exit(spend_id)
     testlang.piggyback_in_flight_exit_output(spend_id, 0, owner_1.key)

--- a/tests/contracts/root_chain/test_challenge_standard_exit.py
+++ b/tests/contracts/root_chain/test_challenge_standard_exit.py
@@ -13,7 +13,7 @@ def test_challenge_standard_exit_valid_spend_should_succeed(testlang):
 
     testlang.challenge_standard_exit(spend_id, doublespend_id)
 
-    assert testlang.root_chain.exits(spend_id) == [NULL_ADDRESS_HEX, NULL_ADDRESS_HEX, 0]
+    assert testlang.get_standard_exit(spend_id) == [NULL_ADDRESS_HEX, NULL_ADDRESS_HEX, 0]
 
 
 def test_challenge_standard_exit_if_successful_awards_the_bond(testlang):
@@ -42,7 +42,7 @@ def test_challenge_standard_exit_mature_valid_spend_should_succeed(testlang):
 
     testlang.challenge_standard_exit(spend_id, doublespend_id)
 
-    assert testlang.root_chain.exits(spend_id) == [NULL_ADDRESS_HEX, NULL_ADDRESS_HEX, 0]
+    assert testlang.get_standard_exit(spend_id) == [NULL_ADDRESS_HEX, NULL_ADDRESS_HEX, 0]
 
 
 def test_challenge_standard_exit_invalid_spend_should_fail(testlang):

--- a/tests/contracts/root_chain/test_challenge_standard_exit.py
+++ b/tests/contracts/root_chain/test_challenge_standard_exit.py
@@ -10,7 +10,6 @@ def test_challenge_standard_exit_valid_spend_should_succeed(testlang):
 
     testlang.start_standard_exit(spend_id, owner.key)
     doublespend_id = testlang.spend_utxo([spend_id], [owner.key], outputs=[(owner.address, NULL_ADDRESS, amount)])
-
     testlang.challenge_standard_exit(spend_id, doublespend_id)
 
     assert testlang.get_standard_exit(spend_id) == [NULL_ADDRESS_HEX, NULL_ADDRESS_HEX, 0]
@@ -41,7 +40,6 @@ def test_challenge_standard_exit_mature_valid_spend_should_succeed(testlang):
     testlang.forward_timestamp(2 * MIN_EXIT_PERIOD + 1)
 
     testlang.challenge_standard_exit(spend_id, doublespend_id)
-
     assert testlang.get_standard_exit(spend_id) == [NULL_ADDRESS_HEX, NULL_ADDRESS_HEX, 0]
 
 
@@ -102,11 +100,15 @@ def test_challenge_standard_exit_wrong_oindex_should_fail(testlang):
     bob_utxo = encode_utxo_id(blknum, 0, 1)
 
     testlang.start_standard_exit(alice_utxo, alice.key)
+    testlang.start_standard_exit(bob_utxo, bob.key)
 
     bob_spend_id = testlang.spend_utxo([bob_utxo], [bob.key], outputs=[(bob.address, NULL_ADDRESS, bob_money)])
     alice_spend_id = testlang.spend_utxo([alice_utxo], [alice.key], outputs=[(alice.address, NULL_ADDRESS, alice_money)])
 
     with pytest.raises(TransactionFailed):
         testlang.challenge_standard_exit(alice_utxo, bob_spend_id)
+
+    with pytest.raises(TransactionFailed):
+        testlang.challenge_standard_exit(bob_utxo, alice_spend_id)
 
     testlang.challenge_standard_exit(alice_utxo, alice_spend_id)

--- a/tests/contracts/root_chain/test_challenge_standard_exit.py
+++ b/tests/contracts/root_chain/test_challenge_standard_exit.py
@@ -117,6 +117,7 @@ def test_challenge_standard_exit_wrong_oindex_should_fail(testlang):
 
 
 def test_challenge_standard_exit_with_in_flight_exit_tx_should_succeed(ethtester, testlang):
+    # exit cross-spend test, cases 3 and 4
     owner, amount = testlang.accounts[0], 100
     deposit_id = testlang.deposit(owner, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner.key], outputs=[(owner.address, NULL_ADDRESS, amount)])

--- a/tests/contracts/root_chain/test_challenge_standard_exit.py
+++ b/tests/contracts/root_chain/test_challenge_standard_exit.py
@@ -1,6 +1,8 @@
 import pytest
 from ethereum.tools.tester import TransactionFailed
 from plasma_core.constants import NULL_ADDRESS, NULL_ADDRESS_HEX, MIN_EXIT_PERIOD, NULL_SIGNATURE
+from plasma_core.transaction import Transaction
+from plasma_core.utils.transactions import decode_utxo_id
 
 
 def test_challenge_standard_exit_valid_spend_should_succeed(testlang):
@@ -112,3 +114,25 @@ def test_challenge_standard_exit_wrong_oindex_should_fail(testlang):
         testlang.challenge_standard_exit(bob_utxo, alice_spend_id)
 
     testlang.challenge_standard_exit(alice_utxo, alice_spend_id)
+
+
+def test_challenge_standard_exit_with_in_flight_exit_tx_should_succeed(ethtester, testlang):
+    owner, amount = testlang.accounts[0], 100
+    deposit_id = testlang.deposit(owner, amount)
+    spend_id = testlang.spend_utxo([deposit_id], [owner.key], outputs=[(owner.address, NULL_ADDRESS, amount)])
+
+    ife_tx = Transaction(inputs=[decode_utxo_id(spend_id)], outputs=[(owner.address, NULL_ADDRESS, amount)])
+    ife_tx.sign(0, owner.key)
+
+    (encoded_spend, encoded_inputs, proofs, signatures) = testlang.get_in_flight_exit_info(None, spend_tx=ife_tx)
+    bond = testlang.root_chain.inFlightExitBond()
+    testlang.root_chain.startInFlightExit(encoded_spend, encoded_inputs, proofs, signatures, value=bond, sender=owner.key)
+
+    testlang.start_standard_exit(spend_id, owner.key)
+    assert testlang.get_standard_exit(spend_id).amount == 100
+
+    exit_id = testlang.get_standard_exit_id(spend_id)
+    # FIXME a proper way of getting encoded body of IFE tx is to get it out of generated events
+    testlang.root_chain.challengeStandardExit(exit_id, ife_tx.encoded, 0, ife_tx.signatures[0])
+
+    assert testlang.get_standard_exit(spend_id) == [NULL_ADDRESS_HEX, NULL_ADDRESS_HEX, 0, 0]

--- a/tests/contracts/root_chain/test_fee_exit.py
+++ b/tests/contracts/root_chain/test_fee_exit.py
@@ -7,13 +7,8 @@ from plasma_core.constants import NULL_ADDRESS, NULL_ADDRESS_HEX, MIN_EXIT_PERIO
 
 def test_start_fee_exit_should_succeed(testlang):
     operator, amount = testlang.accounts[0], 100
-
-    fee_exit_id = testlang.start_fee_exit(operator, amount)
-
-    plasma_exit = testlang.get_standard_exit(fee_exit_id)
-    assert plasma_exit.owner == operator.address
-    assert plasma_exit.token == NULL_ADDRESS_HEX
-    assert plasma_exit.amount == amount
+    exit_id = testlang.start_fee_exit(operator, amount)
+    assert testlang.root_chain.exits(exit_id) == [operator.address, NULL_ADDRESS_HEX, amount, 1]
 
 
 def test_start_fee_exit_non_operator_should_fail(testlang):
@@ -26,8 +21,8 @@ def test_start_fee_exit_non_operator_should_fail(testlang):
 def test_start_fee_exit_finalizes_after_two_MFPs(testlang):
     operator, amount = testlang.accounts[0], 100
     testlang.deposit(operator, amount)
-    fee_exit_id = testlang.start_fee_exit(operator, 100)
-    testlang.get_standard_exit(fee_exit_id)
+    testlang.start_fee_exit(operator, amount)
+
     balance = testlang.get_balance(testlang.root_chain)
 
     testlang.forward_timestamp(MIN_EXIT_PERIOD + 1)

--- a/tests/contracts/root_chain/test_piggyback_in_flight_exit.py
+++ b/tests/contracts/root_chain/test_piggyback_in_flight_exit.py
@@ -137,6 +137,7 @@ def test_piggyback_in_flight_exit_twice_should_fail(testlang):
 
 @pytest.mark.parametrize("num_outputs", [1, 2, 3, 4])
 def test_piggyback_in_flight_exit_output_with_preexisting_standard_exit_should_fail(testlang, num_outputs):
+    # exit cross-spend test, case 5
     owner_1, amount = testlang.accounts[0], 100
     deposit_id = testlang.deposit(owner_1, amount)
     outputs = []
@@ -162,6 +163,7 @@ def test_piggyback_in_flight_exit_output_with_preexisting_standard_exit_should_f
 
 @pytest.mark.parametrize("num_outputs", [1, 2, 3, 4])
 def test_piggyback_in_flight_exit_output_with_preexisting_finalized_standard_exit_should_fail(testlang, num_outputs):
+    # exit cross-spend test, case 6
     owner_1, amount = testlang.accounts[0], 100
     deposit_id = testlang.deposit(owner_1, amount)
     outputs = []

--- a/tests/contracts/root_chain/test_piggyback_in_flight_exit.py
+++ b/tests/contracts/root_chain/test_piggyback_in_flight_exit.py
@@ -30,7 +30,7 @@ def test_piggyback_in_flight_exit_valid_output_owner_should_succeed(testlang, nu
     deposit_id = testlang.deposit(owner_1, amount)
     outputs = []
     for i in range(0, num_outputs):
-        outputs.append((testlang.accounts[i].address, 1))
+        outputs.append((testlang.accounts[i].address, NULL_ADDRESS, 1))
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], outputs)
 
     testlang.start_in_flight_exit(spend_id)
@@ -56,7 +56,7 @@ def test_piggyback_in_flight_exit_invalid_owner_should_fail(testlang):
 def test_piggyback_in_flight_exit_different_exits_different_outputs_should_succeed(testlang):
     owner, amount = testlang.accounts[0], 100
     deposit_id = testlang.deposit(owner, amount)
-    spend_id = testlang.spend_utxo([deposit_id], [owner.key], [(owner.address, 50), (owner.address, 50)])
+    spend_id = testlang.spend_utxo([deposit_id], [owner.key], [(owner.address, NULL_ADDRESS, 50), (owner.address, NULL_ADDRESS, 50)])
 
     # First time should succeed
     testlang.start_in_flight_exit(spend_id)
@@ -75,7 +75,7 @@ def test_piggyback_in_flight_exit_different_exits_different_outputs_should_succe
 def test_piggyback_in_flight_exit_different_exits_same_output_should_fail(testlang):
     owner, amount = testlang.accounts[0], 100
     deposit_id = testlang.deposit(owner, amount)
-    spend_id = testlang.spend_utxo([deposit_id], [owner.key], [(owner.address, 50), (owner.address, 50)])
+    spend_id = testlang.spend_utxo([deposit_id], [owner.key], [(owner.address, NULL_ADDRESS, 50), (owner.address, NULL_ADDRESS, 50)])
 
     # First time should succeed
     testlang.start_in_flight_exit(spend_id)

--- a/tests/contracts/root_chain/test_piggyback_in_flight_exit.py
+++ b/tests/contracts/root_chain/test_piggyback_in_flight_exit.py
@@ -1,6 +1,7 @@
 import pytest
 from ethereum.tools.tester import TransactionFailed
 from plasma_core.constants import MIN_EXIT_PERIOD, NULL_ADDRESS
+from plasma_core.utils.transactions import decode_utxo_id, encode_utxo_id
 
 
 @pytest.mark.parametrize("num_inputs", [1, 2, 3, 4])
@@ -132,3 +133,56 @@ def test_piggyback_in_flight_exit_twice_should_fail(testlang):
     testlang.piggyback_in_flight_exit_input(spend_id, input_index, owner.key)
     with pytest.raises(TransactionFailed):
         testlang.piggyback_in_flight_exit_input(spend_id, input_index, owner.key)
+
+
+@pytest.mark.parametrize("num_outputs", [1, 2, 3, 4])
+def test_piggyback_in_flight_exit_output_with_preexisting_standard_exit_should_fail(testlang, num_outputs):
+    owner_1, amount = testlang.accounts[0], 100
+    deposit_id = testlang.deposit(owner_1, amount)
+    outputs = []
+    for i in range(0, num_outputs):
+        outputs.append((testlang.accounts[i].address, NULL_ADDRESS, 1))
+    spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], outputs)
+
+    blknum, txindex, _ = decode_utxo_id(spend_id)
+    exit_pos = encode_utxo_id(blknum, txindex, num_outputs - 1)
+    testlang.start_standard_exit(exit_pos, key=testlang.accounts[num_outputs - 1].key)
+
+    testlang.start_in_flight_exit(spend_id)
+
+    assert testlang.get_standard_exit(exit_pos).amount == 1
+    bond = testlang.root_chain.piggybackBond()
+
+    with pytest.raises(TransactionFailed):
+        testlang.piggyback_in_flight_exit_output(spend_id, 4 + num_outputs - 1, testlang.accounts[num_outputs - 1].key, bond)
+
+    in_flight_exit = testlang.get_in_flight_exit(spend_id)
+    assert not in_flight_exit.output_piggybacked(num_outputs - 1)
+
+
+@pytest.mark.parametrize("num_outputs", [1, 2, 3, 4])
+def test_piggyback_in_flight_exit_output_with_preexisting_finalized_standard_exit_should_fail(testlang, num_outputs):
+    owner_1, amount = testlang.accounts[0], 100
+    deposit_id = testlang.deposit(owner_1, amount)
+    outputs = []
+    for i in range(0, num_outputs):
+        outputs.append((testlang.accounts[i].address, NULL_ADDRESS, 1))
+    spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], outputs)
+
+    blknum, txindex, _ = decode_utxo_id(spend_id)
+    exit_pos = encode_utxo_id(blknum, txindex, num_outputs - 1)
+    testlang.start_standard_exit(exit_pos, key=testlang.accounts[num_outputs - 1].key)
+
+    testlang.forward_timestamp(2 * MIN_EXIT_PERIOD + 1)
+    testlang.process_exits(NULL_ADDRESS, 0, 1)
+
+    testlang.start_in_flight_exit(spend_id)
+
+    assert testlang.get_standard_exit(exit_pos).amount == 1
+    bond = testlang.root_chain.piggybackBond()
+
+    with pytest.raises(TransactionFailed):
+        testlang.piggyback_in_flight_exit_output(spend_id, 4 + num_outputs - 1, testlang.accounts[num_outputs - 1].key, bond)
+
+    in_flight_exit = testlang.get_in_flight_exit(spend_id)
+    assert not in_flight_exit.output_piggybacked(num_outputs - 1)

--- a/tests/contracts/root_chain/test_process_exits.py
+++ b/tests/contracts/root_chain/test_process_exits.py
@@ -258,7 +258,7 @@ def test_finalize_challenged_exit_will_not_send_funds(testlang):
     doublespend_id = testlang.spend_utxo([spend_id], [owner.key], [(owner.address, NULL_ADDRESS, 100)])
 
     testlang.challenge_standard_exit(spend_id, doublespend_id)
-    testlang.root_chain.exits(spend_id) == [NULL_ADDRESS_HEX, NULL_ADDRESS_HEX, 0]
+    testlang.get_standard_exit(spend_id) == [NULL_ADDRESS_HEX, NULL_ADDRESS_HEX, 0]
 
     testlang.forward_timestamp(2 * MIN_EXIT_PERIOD + 1)
 

--- a/tests/contracts/root_chain/test_respond_to_non_canonical_challenge.py
+++ b/tests/contracts/root_chain/test_respond_to_non_canonical_challenge.py
@@ -1,12 +1,13 @@
 import pytest
 from ethereum.tools.tester import TransactionFailed
+from plasma_core.constants import NULL_ADDRESS
 
 
 def test_respond_to_non_canonical_challenge_should_succeed(testlang):
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)], force_invalid=True)
+    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
     testlang.start_in_flight_exit(spend_id)
     testlang.challenge_in_flight_exit_not_canonical(spend_id, double_spend_id, key=owner_2.key)
 
@@ -23,7 +24,7 @@ def test_respond_to_non_canonical_challenge_should_succeed(testlang):
 def test_respond_to_non_canonical_challenge_not_older_should_fail(testlang):
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)], force_invalid=True)
+    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
     testlang.start_in_flight_exit(spend_id)
     testlang.challenge_in_flight_exit_not_canonical(spend_id, double_spend_id, key=owner_2.key)
@@ -38,7 +39,7 @@ def test_respond_to_non_canonical_challenge_invalid_proof_should_fail(testlang):
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)], force_invalid=True)
+    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
     testlang.start_in_flight_exit(spend_id)
     testlang.challenge_in_flight_exit_not_canonical(spend_id, double_spend_id, key=owner_2.key)
 

--- a/tests/contracts/root_chain/test_respond_to_non_canonical_challenge.py
+++ b/tests/contracts/root_chain/test_respond_to_non_canonical_challenge.py
@@ -1,6 +1,6 @@
 import pytest
 from ethereum.tools.tester import TransactionFailed
-from plasma_core.constants import NULL_ADDRESS
+from plasma_core.constants import NULL_ADDRESS, MIN_EXIT_PERIOD
 
 
 def test_respond_to_non_canonical_challenge_should_succeed(testlang):
@@ -49,3 +49,22 @@ def test_respond_to_non_canonical_challenge_invalid_proof_should_fail(testlang):
     proof = b''
     with pytest.raises(TransactionFailed):
         testlang.root_chain.respondToNonCanonicalChallenge(spend_tx.encoded, spend_id, proof)
+
+
+def test_respond_to_not_canonical_challenge_with_inputs_spent_should_fail(testlang):
+    owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
+    deposit_id = testlang.deposit(owner_1, amount)
+    testlang.start_standard_exit(deposit_id, owner_1.key)
+    spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
+    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, NULL_ADDRESS, 100)], force_invalid=True)
+
+    testlang.forward_timestamp(2 * MIN_EXIT_PERIOD + 1)
+    testlang.process_exits(NULL_ADDRESS, 0, 1)
+
+    testlang.start_in_flight_exit(spend_id)
+
+    testlang.forward_to_period(2)
+
+    # Since IFE can be exited only from inputs, no further canonicity game required
+    with pytest.raises(TransactionFailed):
+        testlang.challenge_in_flight_exit_not_canonical(spend_id, double_spend_id, key=owner_2.key)

--- a/tests/contracts/root_chain/test_start_in_flight_exit.py
+++ b/tests/contracts/root_chain/test_start_in_flight_exit.py
@@ -149,7 +149,7 @@ def test_start_in_flight_exit_cancelling_standard_exits_from_inputs(testlang, nu
         testlang.start_standard_exit(deposit_ids[i], owners[i].key)
 
     for i in range(0, num_inputs):
-        assert testlang.root_chain.exits(deposit_ids[i] << 1) == [owners[i].address, NULL_ADDRESS_HEX, 100]
+        assert testlang.get_standard_exit(deposit_ids[i]) == [owners[i].address, NULL_ADDRESS_HEX, 100]
 
     challenger = testlang.accounts[5]
     balance = testlang.get_balance(challenger)
@@ -158,4 +158,4 @@ def test_start_in_flight_exit_cancelling_standard_exits_from_inputs(testlang, nu
 
     # Standard exits are correctly challenged
     for i in range(0, num_inputs):
-        assert testlang.root_chain.exits(deposit_ids[i]) == [NULL_ADDRESS_HEX, NULL_ADDRESS_HEX, 0]
+        assert testlang.get_standard_exit(deposit_ids[i]) == [NULL_ADDRESS_HEX, NULL_ADDRESS_HEX, 0]

--- a/tests/contracts/root_chain/test_start_in_flight_exit.py
+++ b/tests/contracts/root_chain/test_start_in_flight_exit.py
@@ -1,6 +1,6 @@
 import pytest
 from ethereum.tools.tester import TransactionFailed
-from plasma_core.constants import NULL_ADDRESS, MIN_EXIT_PERIOD
+from plasma_core.constants import NULL_ADDRESS, NULL_ADDRESS_HEX, MIN_EXIT_PERIOD
 from testlang.testlang import address_to_hex
 
 
@@ -130,3 +130,32 @@ def test_start_in_flight_exit_with_ERC20_tokens_should_fail(testlang, token):
 
     with pytest.raises(TransactionFailed):
         testlang.start_in_flight_exit(spend_id)
+
+
+@pytest.mark.parametrize("num_inputs", [1, 2, 3, 4])
+def test_start_in_flight_exit_cancelling_standard_exits_from_inputs(testlang, num_inputs):
+    amount = 100
+    owners = []
+    deposit_ids = []
+    for i in range(0, num_inputs):
+        owners.append(testlang.accounts[i])
+        deposit_id = testlang.deposit(owners[i], amount)
+        deposit_ids.append(deposit_id)
+
+    owner_keys = [owner.key for owner in owners]
+    spend_id = testlang.spend_utxo(deposit_ids, owner_keys)
+
+    for i in range(0, num_inputs):
+        testlang.start_standard_exit(deposit_ids[i], owners[i].key)
+
+    for i in range(0, num_inputs):
+        assert testlang.root_chain.exits(deposit_ids[i] << 1) == [owners[i].address, NULL_ADDRESS_HEX, 100]
+
+    challenger = testlang.accounts[5]
+    balance = testlang.get_balance(challenger)
+    testlang.start_in_flight_exit(spend_id, sender=challenger)
+    assert testlang.get_balance(challenger) == balance + num_inputs * testlang.root_chain.standardExitBond() - testlang.root_chain.inFlightExitBond()
+
+    # Standard exits are correctly challenged
+    for i in range(0, num_inputs):
+        assert testlang.root_chain.exits(deposit_ids[i]) == [NULL_ADDRESS_HEX, NULL_ADDRESS_HEX, 0]

--- a/tests/contracts/root_chain/test_start_in_flight_exit.py
+++ b/tests/contracts/root_chain/test_start_in_flight_exit.py
@@ -134,6 +134,7 @@ def test_start_in_flight_exit_with_ERC20_tokens_should_fail(testlang, token):
 
 @pytest.mark.parametrize("num_inputs", [1, 2, 3, 4])
 def test_start_in_flight_exit_cancelling_standard_exits_from_inputs(testlang, num_inputs):
+    # exit cross-spend test, case 1
     amount = 100
     owners = []
     deposit_ids = []
@@ -163,6 +164,7 @@ def test_start_in_flight_exit_cancelling_standard_exits_from_inputs(testlang, nu
 
 @pytest.mark.parametrize("num_inputs", [1, 2, 3, 4])
 def test_start_in_flight_exit_with_finalized_standard_exits_from_inputs_flags_exit(testlang, num_inputs):
+    # exit cross-spend test, case 2
     amount = 100
     owners = []
     deposit_ids = []

--- a/tests/contracts/root_chain/test_start_in_flight_exit.py
+++ b/tests/contracts/root_chain/test_start_in_flight_exit.py
@@ -180,7 +180,7 @@ def test_start_in_flight_exit_with_finalized_standard_exits_from_inputs_flags_ex
     for i in range(0, num_inputs):
         assert testlang.get_standard_exit(deposit_ids[i]) == [owners[i].address, NULL_ADDRESS_HEX, 100]
 
-    testlang.forward_timestamp(2 * WEEK + 1)
+    testlang.forward_timestamp(2 * MIN_EXIT_PERIOD + 1)
     testlang.process_exits(NULL_ADDRESS, 0, 10)
 
     challenger = testlang.accounts[5]

--- a/tests/contracts/root_chain/test_start_standard_exit.py
+++ b/tests/contracts/root_chain/test_start_standard_exit.py
@@ -6,7 +6,7 @@ from plasma_core.utils.transactions import decode_utxo_id, encode_utxo_id
 
 def test_start_standard_exit_should_succeed(testlang, utxo):
     testlang.start_standard_exit(utxo.spend_id, utxo.owner.key)
-    assert testlang.root_chain.exits(utxo.spend_id << 1) == [utxo.owner.address, NULL_ADDRESS_HEX, utxo.amount]
+    assert testlang.get_standard_exit(utxo.spend_id) == [utxo.owner.address, NULL_ADDRESS_HEX, utxo.amount]
 
 
 @pytest.mark.parametrize("num_outputs", [1, 2, 3, 4])
@@ -21,7 +21,7 @@ def test_start_standard_exit_multiple_outputs_should_succeed(testlang, num_outpu
     output_index = num_outputs - 1
     output_id = spend_id + output_index
     testlang.start_standard_exit(output_id, owners[output_index].key)
-    assert testlang.root_chain.exits(output_id << 1) == [owners[output_index].address, NULL_ADDRESS_HEX, 1]
+    assert testlang.get_standard_exit(output_id) == [owners[output_index].address, NULL_ADDRESS_HEX, 1]
 
 
 def test_start_standard_exit_twice_should_fail(testlang, utxo):
@@ -122,7 +122,7 @@ def test_start_standard_exit_from_deposit_must_be_exitable_in_minimal_finalizati
     testlang.forward_timestamp(required_exit_period + 1)
     testlang.process_exits(NULL_ADDRESS, 0, 1)
 
-    assert testlang.root_chain.exits(deposit_id << 1) == [NULL_ADDRESS_HEX, NULL_ADDRESS_HEX, amount]
+    assert testlang.get_standard_exit(deposit_id) == [NULL_ADDRESS_HEX, NULL_ADDRESS_HEX, amount]
 
 
 @pytest.mark.parametrize("num_outputs", [1, 2, 3, 4])

--- a/tests/contracts/root_chain/test_start_standard_exit.py
+++ b/tests/contracts/root_chain/test_start_standard_exit.py
@@ -75,7 +75,8 @@ def test_start_standard_exit_old_utxo_has_required_exit_period_to_start_exit(tes
     testlang.start_standard_exit(utxo.spend_id, utxo.owner.key)
 
     [_, exitId, _] = testlang.root_chain.getNextExit(NULL_ADDRESS)
-    assert exitId >> 1 == utxo.spend_id
+    [_, _, _, position] = testlang.root_chain.exits(exitId)
+    assert position == utxo.spend_id
 
 
 def test_start_standard_exit_on_finalized_exit_should_fail(testlang, utxo):
@@ -83,7 +84,7 @@ def test_start_standard_exit_on_finalized_exit_should_fail(testlang, utxo):
     minimal_required_period = MIN_EXIT_PERIOD  # see tesuji blockchain design
     testlang.start_standard_exit(utxo.spend_id, utxo.owner.key)
     testlang.forward_timestamp(required_exit_period + minimal_required_period)
-    testlang.process_exits(NULL_ADDRESS, utxo.spend_id, 100)
+    testlang.process_exits(NULL_ADDRESS, 0, 100)
 
     with pytest.raises(TransactionFailed):
         testlang.start_standard_exit(utxo.spend_id, utxo.owner.key)

--- a/tests/contracts/root_chain/test_start_standard_exit.py
+++ b/tests/contracts/root_chain/test_start_standard_exit.py
@@ -1,6 +1,7 @@
 import pytest
 from ethereum.tools.tester import TransactionFailed
 from plasma_core.constants import NULL_ADDRESS, NULL_ADDRESS_HEX, MIN_EXIT_PERIOD
+from plasma_core.utils.transactions import decode_utxo_id, encode_utxo_id
 
 
 def test_start_standard_exit_should_succeed(testlang, utxo):
@@ -89,7 +90,6 @@ def test_start_standard_exit_on_finalized_exit_should_fail(testlang, utxo):
 
 
 def test_start_standard_exit_wrong_oindex_should_fail(testlang):
-    from plasma_core.utils.transactions import decode_utxo_id, encode_utxo_id
     from plasma_core.transaction import Transaction
     alice, bob, alice_money, bob_money = testlang.accounts[0], testlang.accounts[1], 10, 90
 
@@ -123,3 +123,27 @@ def test_start_standard_exit_from_deposit_must_be_exitable_in_minimal_finalizati
     testlang.process_exits(NULL_ADDRESS, 0, 1)
 
     assert testlang.root_chain.exits(deposit_id << 1) == [NULL_ADDRESS_HEX, NULL_ADDRESS_HEX, amount]
+
+
+@pytest.mark.parametrize("num_outputs", [1, 2, 3, 4])
+def test_start_standard_exit_on_piggyback_in_flight_exit_valid_output_owner_should_fail(testlang, num_outputs):
+    owner_1, amount = testlang.accounts[0], 100
+    deposit_id = testlang.deposit(owner_1, amount)
+    outputs = []
+    for i in range(0, num_outputs):
+        outputs.append((testlang.accounts[i].address, NULL_ADDRESS, 1))
+    spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], outputs)
+
+    testlang.start_in_flight_exit(spend_id)
+
+    output_index = num_outputs - 1
+    testlang.piggyback_in_flight_exit_output(spend_id, output_index, testlang.accounts[output_index].key)
+
+    in_flight_exit = testlang.get_in_flight_exit(spend_id)
+    assert in_flight_exit.output_piggybacked(output_index)
+
+    blknum, txindex, _ = decode_utxo_id(spend_id)
+    output_id = encode_utxo_id(blknum, txindex, output_index)
+
+    with pytest.raises(TransactionFailed):
+        testlang.start_standard_exit(output_id, testlang.accounts[output_index].key)

--- a/tests/contracts/root_chain/test_start_standard_exit.py
+++ b/tests/contracts/root_chain/test_start_standard_exit.py
@@ -128,6 +128,7 @@ def test_start_standard_exit_from_deposit_must_be_exitable_in_minimal_finalizati
 
 @pytest.mark.parametrize("num_outputs", [1, 2, 3, 4])
 def test_start_standard_exit_on_piggyback_in_flight_exit_valid_output_owner_should_fail(testlang, num_outputs):
+    # exit cross-spend test, case 9
     owner_1, amount = testlang.accounts[0], 100
     deposit_id = testlang.deposit(owner_1, amount)
     outputs = []
@@ -152,6 +153,7 @@ def test_start_standard_exit_on_piggyback_in_flight_exit_valid_output_owner_shou
 
 @pytest.mark.parametrize("num_outputs", [1, 2, 3, 4])
 def test_start_standard_exit_on_in_flight_exit_output_should_block_future_piggybacks(testlang, num_outputs):
+    # exit cross-spend test, case 7
     owner_1, amount = testlang.accounts[0], 100
     deposit_id = testlang.deposit(owner_1, amount)
     outputs = []


### PR DESCRIPTION
We need to prevent possibility of double-spend via combining standard exit with in-flight exit. Text below describes possible flows and proposed solutions.

Proposed solution preserves the rule "Honest me can SE provided data
availability".

SE = standard exit
IFE = in-flight exit

    1. SE on input -> IFE
    => contract: IFE challenges SE (~ +30k gas)

    2. SE on input, finalized -> IFE
    => contract: IFE is non-canonical and can't be canonized; input is marked
       as done (req. additional flag on IFE?)

    3. IFE -> SE on input
    => game: standard SE challenge using IFE as spend

    4. IFE, finalized input -> SE on input
    => game: standard SE challenge using IFE as spend

    5. SE on output -> IFE -> piggyback output
    -> exit game if data availability? must know which IFEs are incl. and where.
       Piggyback is challenged (take bond)
    -> if no data avail. IFE output exits but SE exits after all mass exits

    6. SE on output, finalized -> IFE -> piggyback output
    => exit game as in 5. Piggyback is challenged (take bond)

    7. IFE -> SE on output -> piggyback output
    => exit game as in 5. Piggyback challenged (take bond)

    8. IFE -> piggyback output -> SE on output
    => contract: check for IFE & piggyback (compute hash) (+2k gas)

    9. IFE -> piggyback output -> finalized -> SE on output
    => contract: check for IFE & piggyback (compute hash)
