### PR TITLE
feat: allow spent input, output challenges and `respondToNonCanonical` in first period

### DIFF
--- a/contracts/RootChain.sol
+++ b/contracts/RootChain.sol
@@ -603,9 +603,9 @@ contract RootChain {
     )
         public
     {
-        // Check that the exit is currently active and in period 2.
+        // Check that the exit is currently active and first two periods.
         InFlightExit storage inFlightExit = _getInFlightExit(_inFlightTx);
-        require(_getExitPeriod(inFlightExit) == 2);
+        require(_getExitPeriod(inFlightExit) < 3);
 
         // Check that the in-flight transaction was included.
         require(_transactionIncluded(_inFlightTx, _inFlightTxPos, _inFlightTxInclusionProof));
@@ -641,9 +641,9 @@ contract RootChain {
     )
         public
     {
-        // Check that the exit is currently active and in period 2.
+        // Check that the exit is currently active and in first two periods.
         InFlightExit storage inFlightExit = _getInFlightExit(_inFlightTx);
-        require(_getExitPeriod(inFlightExit) == 2);
+        require(_getExitPeriod(inFlightExit) < 3);
 
         // Check that the input is piggybacked.
         require(inFlightExit.exitMap.bitSet(_inFlightTxInputIndex));
@@ -685,9 +685,9 @@ contract RootChain {
     )
         public
     {
-        // Check that the exit is currently active and in period 2.
+        // Check that the exit is currently active and in first two periods.
         InFlightExit storage inFlightExit = _getInFlightExit(_inFlightTx);
-        require(_getExitPeriod(inFlightExit) == 2);
+        require(_getExitPeriod(inFlightExit) < 3);
 
         // Check that the output is piggybacked.
         uint8 oindex = _inFlightTxOutputId.getOindex();

--- a/tests/contracts/root_chain/test_challenge_in_flight_exit_input_spent.py
+++ b/tests/contracts/root_chain/test_challenge_in_flight_exit_input_spent.py
@@ -17,19 +17,6 @@ def test_challenge_in_flight_exit_input_spent_should_succeed(testlang):
     assert not in_flight_exit.input_piggybacked(0)
 
 
-def test_challenge_in_flight_exit_input_spent_wrong_period_should_fail(testlang):
-    owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
-    deposit_id = testlang.deposit(owner_1, amount)
-    spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)], force_invalid=True)
-    testlang.start_in_flight_exit(spend_id)
-    testlang.piggyback_in_flight_exit_input(spend_id, 0, owner_1.key)
-    testlang.forward_to_period(1)
-
-    with pytest.raises(TransactionFailed):
-        testlang.challenge_in_flight_exit_input_spent(spend_id, double_spend_id, owner_2.key)
-
-
 def test_challenge_in_flight_exit_input_spent_not_piggybacked_should_fail(testlang):
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)

--- a/tests/contracts/root_chain/test_challenge_in_flight_exit_output_spent.py
+++ b/tests/contracts/root_chain/test_challenge_in_flight_exit_output_spent.py
@@ -17,19 +17,6 @@ def test_challenge_in_flight_exit_output_spent_should_succeed(testlang):
     assert not in_flight_exit.output_piggybacked(0)
 
 
-def test_challenge_in_flight_exit_output_spent_wrong_period_should_fail(testlang):
-    owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
-    deposit_id = testlang.deposit(owner_1, amount)
-    spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)])
-    double_spend_id = testlang.spend_utxo([spend_id], [owner_1.key], force_invalid=True)
-    testlang.start_in_flight_exit(spend_id)
-    testlang.piggyback_in_flight_exit_output(spend_id, 0, owner_1.key)
-    testlang.forward_to_period(1)
-
-    with pytest.raises(TransactionFailed):
-        testlang.challenge_in_flight_exit_output_spent(spend_id, double_spend_id, 0, owner_2.key)
-
-
 def test_challenge_in_flight_exit_output_spent_not_piggybacked_should_fail(testlang):
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)

--- a/tests/contracts/root_chain/test_respond_to_non_canonical_challenge.py
+++ b/tests/contracts/root_chain/test_respond_to_non_canonical_challenge.py
@@ -20,18 +20,6 @@ def test_respond_to_non_canonical_challenge_should_succeed(testlang):
     assert not in_flight_exit.challenge_flag_set
 
 
-def test_respond_to_non_canonical_challenge_wrong_period_should_fail(testlang):
-    owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
-    deposit_id = testlang.deposit(owner_1, amount)
-    spend_id = testlang.spend_utxo([deposit_id], [owner_1.key])
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1.key], [(owner_1.address, 100)], force_invalid=True)
-    testlang.start_in_flight_exit(spend_id)
-    testlang.challenge_in_flight_exit_not_canonical(spend_id, double_spend_id, key=owner_2.key)
-
-    with pytest.raises(TransactionFailed):
-        testlang.respond_to_non_canonical_challenge(spend_id, owner_1.key)
-
-
 def test_respond_to_non_canonical_challenge_not_older_should_fail(testlang):
     owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
     deposit_id = testlang.deposit(owner_1, amount)


### PR DESCRIPTION
While all of those constitute reckless behavior and can be overridden by their first-period-only counterparts, the limitation is superfluous and makes testing harder.