### PR TITLE
style: provide consistent names

### DIFF
--- a/contracts/PlasmaCore.sol
+++ b/contracts/PlasmaCore.sol
@@ -81,55 +81,55 @@ library PlasmaCore {
     }
 
     /**
-     * @dev Given an output ID, returns the block number.
-     * @param _outputId Output identifier to decode.
+     * @dev Given an UTXO position, returns the block number.
+     * @param _utxoPos Output identifier to decode.
      * @return The output's block number.
      */
-    function getBlknum(uint256 _outputId)
+    function getBlknum(uint256 _utxoPos)
         internal
         pure
         returns (uint256)
     {
-        return _outputId / BLOCK_OFFSET;
+        return _utxoPos / BLOCK_OFFSET;
     }
 
     /**
-     * @dev Given an output ID, returns the transaction index.
-     * @param _outputId Output identifier to decode.
+     * @dev Given an UTXO position, returns the transaction index.
+     * @param _utxoPos Output identifier to decode.
      * @return The output's transaction index.
      */
-    function getTxindex(uint256 _outputId)
+    function getTxIndex(uint256 _utxoPos)
         internal
         pure
         returns (uint256)
     {
-        return (_outputId % BLOCK_OFFSET) / TX_OFFSET;
+        return (_utxoPos % BLOCK_OFFSET) / TX_OFFSET;
     }
 
     /**
-     * @dev Given an output ID, returns the output index.
-     * @param _outputId Output identifier to decode.
+     * @dev Given an UTXO position, returns the output index.
+     * @param _utxoPos Output identifier to decode.
      * @return The output's index.
      */
-    function getOindex(uint256 _outputId)
+    function getOindex(uint256 _utxoPos)
         internal
         pure
         returns (uint8)
     {
-        return uint8(_outputId % TX_OFFSET);
+        return uint8(_utxoPos % TX_OFFSET);
     }
 
     /**
-     * @dev Given an output ID, returns transaction position.
-     * @param _outputId Output identifier to decode.
+     * @dev Given an UTXO position, returns transaction position.
+     * @param _utxoPos Output identifier to decode.
      * @return The transaction position.
      */
-    function getTxpos(uint256 _outputId)
+    function getTxPos(uint256 _utxoPos)
         internal
         pure
         returns (uint256)
     {
-        return _outputId / TX_OFFSET;
+        return _utxoPos / TX_OFFSET;
     }
 
     /**
@@ -138,7 +138,7 @@ library PlasmaCore {
      * @param _inputIndex Index of the input to return.
      * @return A combined identifier.
      */
-    function getInputId(bytes memory _tx, uint256 _inputIndex)
+    function getInputUtxoPosition(bytes memory _tx, uint8 _inputIndex)
         internal
         view
         returns (uint256)
@@ -154,7 +154,7 @@ library PlasmaCore {
      * @param _outputIndex Index of the output to return.
      * @return The transaction output.
      */
-    function getOutput(bytes memory _tx, uint256 _outputIndex)
+    function getOutput(bytes memory _tx, uint8 _outputIndex)
         internal
         view
         returns (TransactionOutput)

--- a/contracts/PlasmaCoreTest.sol
+++ b/contracts/PlasmaCoreTest.sol
@@ -26,7 +26,7 @@ contract PlasmaCoreTest {
         return PlasmaCore.sliceSignature(_signatures, _index);
     }
 
-    function getOutput(bytes _tx, uint256 _outputIndex)
+    function getOutput(bytes _tx, uint8 _outputIndex)
         public
         view
         returns (address, address, uint256)
@@ -35,43 +35,43 @@ contract PlasmaCoreTest {
         return (output.owner, output.token, output.amount);
     }
 
-    function getInputId(bytes _tx, uint256 _inputIndex)
+    function getInputUtxoPosition(bytes _tx, uint8 _inputIndex)
         public
         view
         returns (uint256)
     {
-        return PlasmaCore.getInputId(_tx, _inputIndex);
+        return PlasmaCore.getInputUtxoPosition(_tx, _inputIndex);
     }
 
-    function getOindex(uint256 _outputId)
+    function getOindex(uint256 _utxoPos)
         public
         pure
         returns (uint8)
     {
-        return PlasmaCore.getOindex(_outputId);
+        return PlasmaCore.getOindex(_utxoPos);
     }
 
-    function getTxpos(uint256 _outputId)
+    function getTxPos(uint256 _utxoPos)
         public
         pure
         returns (uint256)
     {
-        return PlasmaCore.getTxpos(_outputId);
+        return PlasmaCore.getTxPos(_utxoPos);
     }
 
-    function getTxindex(uint256 _outputId)
+    function getTxIndex(uint256 _utxoPos)
         public
         pure
         returns (uint256)
     {
-        return PlasmaCore.getTxindex(_outputId);
+        return PlasmaCore.getTxIndex(_utxoPos);
     }
 
-    function getBlknum(uint256 _outputId)
+    function getBlknum(uint256 _utxoPos)
         public
         pure
         returns (uint256)
     {
-        return PlasmaCore.getBlknum(_outputId);
+        return PlasmaCore.getBlknum(_utxoPos);
     }
 }

--- a/tests/contracts/rlp/test_plasma_core.py
+++ b/tests/contracts/rlp/test_plasma_core.py
@@ -46,10 +46,10 @@ def test_decode_mallability(testlang, plasma_core_test):
 def test_get_input_id(plasma_core_test):
     input_id = (2, 2, 2)
     tx = Transaction(inputs=[input_id])
-    assert plasma_core_test.getInputId(tx.encoded, 0) == tx.inputs[0].identifier
-    assert plasma_core_test.getInputId(tx.encoded, 1) == 0
-    assert plasma_core_test.getInputId(tx.encoded, 2) == 0
-    assert plasma_core_test.getInputId(tx.encoded, 3) == 0
+    assert plasma_core_test.getInputUtxoPosition(tx.encoded, 0) == tx.inputs[0].identifier
+    assert plasma_core_test.getInputUtxoPosition(tx.encoded, 1) == 0
+    assert plasma_core_test.getInputUtxoPosition(tx.encoded, 2) == 0
+    assert plasma_core_test.getInputUtxoPosition(tx.encoded, 3) == 0
 
 
 def test_get_output_index(plasma_core_test):
@@ -59,7 +59,7 @@ def test_get_output_index(plasma_core_test):
 
 def test_get_tx_index(plasma_core_test):
     output_id = 1000020003
-    assert plasma_core_test.getTxindex(output_id) == 2
+    assert plasma_core_test.getTxIndex(output_id) == 2
 
 
 def test_get_blknum(plasma_core_test):
@@ -69,4 +69,4 @@ def test_get_blknum(plasma_core_test):
 
 def test_get_txpos_index(plasma_core_test):
     output_id = 1000020003
-    assert plasma_core_test.getTxpos(output_id) == 100002
+    assert plasma_core_test.getTxPos(output_id) == 100002


### PR DESCRIPTION
outputId is now UTXO position, which makes a clear distinction
between, what was previously called,  outputId and outputIndex