### PR TITLE
fix: process ife without piggybacked would fail

### DIFF
--- a/testlang/testlang.py
+++ b/testlang/testlang.py
@@ -90,6 +90,9 @@ class InFlightExit(object):
         self.inputs = {}
         self.outputs = {}
 
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
+
     @property
     def challenge_flag_set(self):
         return self.root_chain.flagged(self.exit_start_timestamp)
@@ -290,9 +293,12 @@ class TestingLanguage(object):
             token (address): Address of the token to be processed.
             exit_id (int): Identifier of an exit (optional, pass 0 to ignore the check)
             count (int): Maximum number of exits to be processed.
+
+        Returns:
+            int: number of exits that have been processed.
         """
 
-        self.root_chain.processExits(token, exit_id, count, **kwargs)
+        return self.root_chain.processExits(token, exit_id, count, **kwargs)
 
     def get_challenge_proof(self, utxo_id, spend_id):
         """Returns information required to submit a challenge.


### PR DESCRIPTION
### Note
This commit fixes the bug that an in-flight exit without piggybacked would
cause "processExits" to fail. This is because in in-flight exits, they are
put into priority queue only when they are piggybacked. And "processExits"
would crash on an empty queue.

Fix the issue by enabling "processExits" on an empty queue.

- issue: https://github.com/omisego/plasma-contracts/issues/73

### Test
Followed the `reproduce` step from the issue. Remove the piggyback and test works.

### Discussion
1. For the issue #73, It might possibly be a "feature" instead of "bug" though. As it was by design to fail when the queue is empty.  Would like to hear opinion shall we fix that or keep that as a feature.
1. No matter we fix it by enabling empty queue or not fix it, it would lead to a possibility of an unfinalized in-flight exit. Would this cause any problem? (I can't think of any but I might miss sth)
