### PR TITLE
fix: inputs of deposit not checked

### DIFF
--- a/contracts/RootChain.sol
+++ b/contracts/RootChain.sol
@@ -292,9 +292,14 @@ contract RootChain {
         // deposit with blknum ending with 000.
         require(nextDepositBlock < CHILD_BLOCK_INTERVAL);
 
-        // Check that all but first outputs are 0.
-        for (uint i = 1; i < MAX_INPUTS; i++) {
-            require(decodedTx.outputs[i].amount == 0);
+        for (uint i = 0; i < MAX_INPUTS; i++) {
+            // all inputs should be empty
+            require(decodedTx.inputs[i].blknum == 0);
+
+            // only first output should have value
+            if (i >= 1) {
+                require(decodedTx.outputs[i].amount == 0);
+            }
         }
 
         // Calculate the block root.
@@ -850,7 +855,6 @@ contract RootChain {
      *     1 bit - in-flight flag
      *     151 bit - tx hash
      */
-
     function getStandardExitId(bytes memory _txbytes, uint256 _utxoPos)
         public
         view
@@ -858,8 +862,6 @@ contract RootChain {
     {
         bytes memory toBeHashed = _txbytes;
 
-        // Only deposit can have empty first input
-        uint256 inputUtxoPos = _txbytes.getInputUtxoPosition(0);
         if (_isDeposit(_utxoPos.getBlknum())){
             toBeHashed = abi.encodePacked(_txbytes, _utxoPos);
         }

--- a/tests/contracts/root_chain/test_deposit.py
+++ b/tests/contracts/root_chain/test_deposit.py
@@ -37,9 +37,17 @@ def test_deposit_zero_amount_should_succeed(testlang):
     assert testlang.root_chain.nextDepositBlock() == 2
 
 
-def test_deposit_invalid_format_should_fail(testlang):
+def test_deposit_with_multiple_output_should_fail(testlang):
     owner, amount = testlang.accounts[0], 100
     deposit_tx = Transaction(outputs=[(owner.address, NULL_ADDRESS, amount), (owner.address, NULL_ADDRESS, amount)])
+
+    with pytest.raises(TransactionFailed):
+        testlang.root_chain.deposit(deposit_tx.encoded, value=amount)
+
+
+def test_deposit_with_input_should_fail(testlang):
+    owner, amount = testlang.accounts[0], 100
+    deposit_tx = Transaction(inputs=[(1, 0, 0)], outputs=[(owner.address, NULL_ADDRESS, amount)])
 
     with pytest.raises(TransactionFailed):
         testlang.root_chain.deposit(deposit_tx.encoded, value=amount)


### PR DESCRIPTION
Current contract does not check the input of deposit tx
should be empty. As a result, currently user can fake any input
data to the deposit tx. This may lead to some unexpected behaviour,
eg. making an IFE exit_id not unique by mimicing another existing
transaction with the same input. We did not separate deposit exit id
from regular tx for IFE because it is assumed that deposit tx cannot IFE
due to sum(inputs) would be 0 < sum(outputs). However, if fake input
is possible, then the assumption would be wrong. 

This commit add check to deposit tx inputs on `blknum` to be 0,
which should be enough as block start with 1.

issue: https://github.com/omisego/plasma-contracts/issues/88