### PR TITLE
Add current contract address to struct hashing 'eip_domain'

### DIFF
--- a/contracts/Eip712StructHash.sol
+++ b/contracts/Eip712StructHash.sol
@@ -13,9 +13,9 @@ library Eip712StructHash {
 
     bytes2  constant EIP191_PREFIX       = "\x19\x01";
     bytes32 constant EIP712_DOMAIN_HASH  = keccak256(abi.encodePacked("EIP712Domain(string name,string version,address verifyingContract,bytes32 salt)"));
-    bytes32 constant TX_TYPE_HASH        = keccak256(abi.encodePacked("Transaction(Input input0,Input input1,Input input2,Input input3,Output output0,Output output1,Output output2,Output output3,bytes32 metadata)Input(uint256 blknum,uint256 txindex,uint256 oindex)Output(address owner,address token,uint256 amount)"));
+    bytes32 constant TX_TYPE_HASH        = keccak256(abi.encodePacked("Transaction(Input input0,Input input1,Input input2,Input input3,Output output0,Output output1,Output output2,Output output3,bytes32 metadata)Input(uint256 blknum,uint256 txindex,uint256 oindex)Output(address owner,address currency,uint256 amount)"));
     bytes32 constant INPUT_TYPE_HASH     = keccak256(abi.encodePacked("Input(uint256 blknum,uint256 txindex,uint256 oindex)"));
-    bytes32 constant OUTPUT_TYPE_HASH    = keccak256(abi.encodePacked("Output(address owner,address token,uint256 amount)"));
+    bytes32 constant OUTPUT_TYPE_HASH    = keccak256(abi.encodePacked("Output(address owner,address currency,uint256 amount)"));
 
 
     address constant verifyingContract = 0x44de0Ec539b8C4a4b530c78620Fe8320167F2F74;

--- a/contracts/Eip712StructHash.sol
+++ b/contracts/Eip712StructHash.sol
@@ -18,7 +18,6 @@ library Eip712StructHash {
     bytes32 constant OUTPUT_TYPE_HASH    = keccak256(abi.encodePacked("Output(address owner,address currency,uint256 amount)"));
 
 
-    address constant verifyingContract = 0x44de0Ec539b8C4a4b530c78620Fe8320167F2F74;
     bytes32 constant salt = 0xfad5c7f626d80f9256ef01929f3beb96e058b8b4b0e3fe52d84f054c0e2a7a83;
 
 
@@ -26,7 +25,7 @@ library Eip712StructHash {
         EIP712_DOMAIN_HASH,
         keccak256("OMG Network"),
         keccak256("1"),
-        verifyingContract,
+        address(this),
         salt
     ));
 

--- a/contracts/Eip712StructHash.sol
+++ b/contracts/Eip712StructHash.sol
@@ -12,13 +12,12 @@ library Eip712StructHash {
     using PlasmaCore for bytes;
 
     bytes2  constant EIP191_PREFIX       = "\x19\x01";
-    bytes32 constant EIP712_DOMAIN_HASH  = keccak256(abi.encodePacked("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract,bytes32 salt)"));
+    bytes32 constant EIP712_DOMAIN_HASH  = keccak256(abi.encodePacked("EIP712Domain(string name,string version,address verifyingContract,bytes32 salt)"));
     bytes32 constant TX_TYPE_HASH        = keccak256(abi.encodePacked("Transaction(Input input0,Input input1,Input input2,Input input3,Output output0,Output output1,Output output2,Output output3,bytes32 metadata)Input(uint256 blknum,uint256 txindex,uint256 oindex)Output(address owner,address token,uint256 amount)"));
     bytes32 constant INPUT_TYPE_HASH     = keccak256(abi.encodePacked("Input(uint256 blknum,uint256 txindex,uint256 oindex)"));
     bytes32 constant OUTPUT_TYPE_HASH    = keccak256(abi.encodePacked("Output(address owner,address token,uint256 amount)"));
 
 
-    uint256 constant chainId = 4;
     address constant verifyingContract = 0x44de0Ec539b8C4a4b530c78620Fe8320167F2F74;
     bytes32 constant salt = 0xfad5c7f626d80f9256ef01929f3beb96e058b8b4b0e3fe52d84f054c0e2a7a83;
 
@@ -27,7 +26,6 @@ library Eip712StructHash {
         EIP712_DOMAIN_HASH,
         keccak256("OMG Network"),
         keccak256("1"),
-        chainId,
         verifyingContract,
         salt
     ));

--- a/plasma_core/utils/eip712_struct_hash.py
+++ b/plasma_core/utils/eip712_struct_hash.py
@@ -5,7 +5,7 @@ from plasma_core.constants import NULL_HASH
 
 def hash_struct(tx, domain=None):
     inputs = [Input(blknum=i.blknum, txindex=i.txindex, oindex=i.oindex) for i in tx.inputs]
-    outputs = [Output(owner=o.owner, token=o.token, amount=o.amount) for o in tx.outputs]
+    outputs = [Output(owner=o.owner, currency=o.token, amount=o.amount) for o in tx.outputs]
 
     domain = domain or make_domain(
         name='OMG Network',
@@ -37,7 +37,7 @@ class Input(EIP712Struct):
 
 class Output(EIP712Struct):
     owner = Address()
-    token = Address()
+    currency = Address()
     amount = Uint(256)
 
 

--- a/plasma_core/utils/eip712_struct_hash.py
+++ b/plasma_core/utils/eip712_struct_hash.py
@@ -1,16 +1,21 @@
 from eip712_structs import EIP712Struct, Address, Uint, Bytes, make_domain
 from eth_utils.crypto import keccak
-from plasma_core.constants import NULL_HASH
+from plasma_core.constants import NULL_HASH, NULL_ADDRESS
 
 
-def hash_struct(tx, domain=None):
+def hash_struct(tx, domain=None, verifyingContract=None):
+    if domain and verifyingContract:
+        raise "verifyingContract supplied but ignored"
+
+    verifying_address = verifyingContract.address if verifyingContract else NULL_ADDRESS
+
     inputs = [Input(blknum=i.blknum, txindex=i.txindex, oindex=i.oindex) for i in tx.inputs]
     outputs = [Output(owner=o.owner, currency=o.token, amount=o.amount) for o in tx.outputs]
 
     domain = domain or make_domain(
         name='OMG Network',
         version='1',
-        verifyingContract=bytes.fromhex('44de0Ec539b8C4a4b530c78620Fe8320167F2F74'),
+        verifyingContract=verifying_address,
         salt=bytes.fromhex('fad5c7f626d80f9256ef01929f3beb96e058b8b4b0e3fe52d84f054c0e2a7a83')
     )
 

--- a/plasma_core/utils/eip712_struct_hash.py
+++ b/plasma_core/utils/eip712_struct_hash.py
@@ -10,7 +10,6 @@ def hash_struct(tx, domain=None):
     domain = domain or make_domain(
         name='OMG Network',
         version='1',
-        chainId=4,
         verifyingContract=bytes.fromhex('44de0Ec539b8C4a4b530c78620Fe8320167F2F74'),
         salt=bytes.fromhex('fad5c7f626d80f9256ef01929f3beb96e058b8b4b0e3fe52d84f054c0e2a7a83')
     )

--- a/testlang/testlang.py
+++ b/testlang/testlang.py
@@ -209,7 +209,7 @@ class TestingLanguage(object):
         inputs = [decode_utxo_id(input_id) for input_id in input_ids]
         spend_tx = Transaction(inputs=inputs, outputs=outputs, metadata=metadata)
         for i in range(0, len(inputs)):
-            spend_tx.sign(i, keys[i])
+            spend_tx.sign(i, keys[i], verifyingContract=self.root_chain)
         blknum = self.submit_block([spend_tx], force_invalid=force_invalid)
         spend_id = encode_utxo_id(blknum, 0, 0)
         return spend_id

--- a/tests/contracts/root_chain/test_challenge_standard_exit.py
+++ b/tests/contracts/root_chain/test_challenge_standard_exit.py
@@ -96,7 +96,7 @@ def test_challenge_standard_exit_wrong_oindex_should_fail(testlang):
     deposit_blknum, _, _ = decode_utxo_id(deposit_id)
 
     spend_tx = Transaction(inputs=[decode_utxo_id(deposit_id)], outputs=[(alice.address, NULL_ADDRESS, alice_money), (bob.address, NULL_ADDRESS, bob_money)])
-    spend_tx.sign(0, alice.key)
+    spend_tx.sign(0, alice.key, verifyingContract=testlang.root_chain)
     blknum = testlang.submit_block([spend_tx])
     alice_utxo = encode_utxo_id(blknum, 0, 0)
     bob_utxo = encode_utxo_id(blknum, 0, 1)
@@ -123,7 +123,7 @@ def test_challenge_standard_exit_with_in_flight_exit_tx_should_succeed(ethtester
     spend_id = testlang.spend_utxo([deposit_id], [owner.key], outputs=[(owner.address, NULL_ADDRESS, amount)])
 
     ife_tx = Transaction(inputs=[decode_utxo_id(spend_id)], outputs=[(owner.address, NULL_ADDRESS, amount)])
-    ife_tx.sign(0, owner.key)
+    ife_tx.sign(0, owner.key, verifyingContract=testlang.root_chain)
 
     (encoded_spend, encoded_inputs, proofs, signatures) = testlang.get_in_flight_exit_info(None, spend_tx=ife_tx)
     bond = testlang.root_chain.inFlightExitBond()

--- a/tests/utils/test_eip712_vectors.py
+++ b/tests/utils/test_eip712_vectors.py
@@ -7,9 +7,8 @@ from plasma_core.utils.eip712_struct_hash import hash_struct
 test_domain = make_domain(
     name='OMG Network',
     version='1',
-    chainId=4,
-    verifyingContract=bytes.fromhex('1C56346CD2A2Bf3202F771f50d3D14a367B48070'),
-    salt=bytes.fromhex('f2d857f4a3edcb9b78b4d503bfe733db1e3f6cdc2b7971ee739626c97e86a558')
+    verifyingContract=bytes.fromhex('44de0ec539b8c4a4b530c78620fe8320167f2f74'),
+    salt=bytes.fromhex('fad5c7f626d80f9256ef01929f3beb96e058b8b4b0e3fe52d84f054c0e2a7a83')
 )
 owner = bytes.fromhex('2258a5279850f6fb78888a7e45ea2a5eb1b3c436')
 token = bytes.fromhex('0123456789abcdef000000000000000000000000')
@@ -31,14 +30,14 @@ outputs = [
 # NOTE: following test vectors were confirmed against contracts code
 def test_empty_transaction():
     empty_tx = Transaction(inputs=[], outputs=[])
-    assert hash_struct(empty_tx, test_domain).hex() == '0aa26a80d09f12d1f03b8bd0dcfd66fb5776554b326a56d21cfdfdc25254a9c4'
+    assert hash_struct(empty_tx, test_domain).hex() == 'c67dd6528c3f576a02369244960a19c9e09c4706938630a50e2eaf385d3a291b'
 
 
 def test_sample_transaction():
     tx = Transaction(inputs=inputs, outputs=outputs)
-    assert hash_struct(tx, test_domain).hex() == '71e72678fe793358b35855734a9987d4d377bb1f9b5d4b04b8f2554a34e51628'
+    assert hash_struct(tx, test_domain).hex() == '6ec5be1d778c6e5d56512b59e68c879cfd2efe27856081c19138ab8dd05d2a41'
 
 
 def test_transaction_with_metadata():
     tx = Transaction(inputs=inputs, outputs=outputs, metadata=metadata)
-    assert hash_struct(tx, test_domain).hex() == '78ddf5f81d7e9271bc125ae6590a8aa27a630135c4f0ba094cd7fd7943a8a2f4'
+    assert hash_struct(tx, test_domain).hex() == '24858ef969d1713414f4776626bcb8b6f5ce6aa4eab6dd4733172a14f547b153'

--- a/tests/utils/test_eip712_vectors.py
+++ b/tests/utils/test_eip712_vectors.py
@@ -30,14 +30,14 @@ outputs = [
 # NOTE: following test vectors were confirmed against contracts code
 def test_empty_transaction():
     empty_tx = Transaction(inputs=[], outputs=[])
-    assert hash_struct(empty_tx, test_domain).hex() == 'c67dd6528c3f576a02369244960a19c9e09c4706938630a50e2eaf385d3a291b'
+    assert hash_struct(empty_tx, test_domain).hex() == '992ac0f45bff7d9fb74636623e5d8b111b49b818cadcf3a91c035735a84d154f'
 
 
 def test_sample_transaction():
     tx = Transaction(inputs=inputs, outputs=outputs)
-    assert hash_struct(tx, test_domain).hex() == '6ec5be1d778c6e5d56512b59e68c879cfd2efe27856081c19138ab8dd05d2a41'
+    assert hash_struct(tx, test_domain).hex() == 'b42dc40570279af9faa05e64d62f54db0fd2b768a4a69646efba068cf88eb7a2'
 
 
 def test_transaction_with_metadata():
     tx = Transaction(inputs=inputs, outputs=outputs, metadata=metadata)
-    assert hash_struct(tx, test_domain).hex() == '24858ef969d1713414f4776626bcb8b6f5ce6aa4eab6dd4733172a14f547b153'
+    assert hash_struct(tx, test_domain).hex() == '5f9adeaaba8d2fa17de40f45eb12136c7e7f26ea56567226274314d0a563e81d'


### PR DESCRIPTION
With the assumption that on different Ethereum networks different deployer addresses will be used, this :pr: adds replay protection for plasma transactions.