### PR TITLE
feat: glue components into PlasmaFramework.sol

### DIFF
--- a/plasma_framework/contracts/src/framework/ExitGameController.sol
+++ b/plasma_framework/contracts/src/framework/ExitGameController.sol
@@ -20,6 +20,12 @@ contract ExitGameController is ExitGameRegistry {
         address token
     );
 
+    constructor() public {
+        address ethToken = address(0);
+        address queueOwner = address(this);
+        _exitsQueues[ethToken] = new PriorityQueue(queueOwner);
+    }
+
     function exitQueueNonce() public view returns (uint64) {
         return _exitQueueNonce;
     }
@@ -38,6 +44,7 @@ contract ExitGameController is ExitGameRegistry {
 
     /**
      * @notice Add token to the plasma framework and initiate the priority queue.
+     * @notice ETH token is supported by default on deployment.
      * @dev the queue is created as a new contract instance.
      * @param _token Address of the token.
      */

--- a/plasma_framework/contracts/src/framework/PlasmaFramework.sol
+++ b/plasma_framework/contracts/src/framework/PlasmaFramework.sol
@@ -1,0 +1,20 @@
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+import "./BlockController.sol";
+import "./ExitGameController.sol";
+import "./registries/VaultRegistry.sol";
+import "./registries/ExitGameRegistry.sol";
+import "./utils/Operated.sol";
+
+contract PlasmaFramework is Operated, VaultRegistry, ExitGameRegistry, ExitGameController, BlockController {
+    uint256 constant CHILD_BLOCK_INTERVAL = 1000;
+
+    // NOTE: this is the "middle" period.
+    // Exit period for fresh utxos is double of that while IFE phase is half of that
+    uint256 public minExitPeriod;
+
+    constructor(uint256 _minExitPeriod) public BlockController(CHILD_BLOCK_INTERVAL) {
+        minExitPeriod = _minExitPeriod;
+    }
+}

--- a/plasma_framework/test/src/framework/ExitGameController.test.js
+++ b/plasma_framework/test/src/framework/ExitGameController.test.js
@@ -20,7 +20,15 @@ contract('ExitGameController', () => {
         this.dummyTxType = 1;
         this.controller.registerExitGame(this.dummyTxType, this.dummyExitGame.address);
 
-        this.dummyToken = constants.ZERO_ADDRESS;
+        // take any random contract address as token
+        this.dummyToken = (await DummyExitGame.new()).address;
+    });
+
+    describe('constructor', () => {
+        it('should init the queue for ETH', async () => {
+            const ETH_TOKEN = constants.ZERO_ADDRESS;
+            expect(await this.controller.hasToken(ETH_TOKEN)).to.be.true;
+        });
     });
 
     describe('exitQueueNonce', () => {

--- a/plasma_framework/test/src/framework/PlasmaFramework.test.js
+++ b/plasma_framework/test/src/framework/PlasmaFramework.test.js
@@ -1,0 +1,20 @@
+const PlasmaFramework = artifacts.require('PlasmaFramework');
+const PriorityQueueLib = artifacts.require('PriorityQueueLib');
+
+const { BN } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
+
+contract('PlasmaFramework', () => {
+    before('link library', async () => {
+        const priorityQueueLib = await PriorityQueueLib.new();
+        await PlasmaFramework.link("PriorityQueueLib", priorityQueueLib.address);
+    });
+
+    describe('constructor', () => {
+        it('should set the min exit period', async () => {
+            const testMinExitPeriod = 1000;
+            const framework = await PlasmaFramework.new(testMinExitPeriod);
+            expect(await framework.minExitPeriod()).to.be.bignumber.equal(new BN(testMinExitPeriod));
+        });
+    });
+});


### PR DESCRIPTION
### Note
This commit combines all existing compoenents into the final
PlasmaFramework code. Also add a missing feature in constructor
of ExitGameController.

### Test
truffle test
```
  Contract: ExitGameController
    constructor
      ✓ inits the queue for ETH
  Contract: PlasmaFramework
    constructor
      ✓ can set the min exit period (182ms)
```