### PR TITLE
Porting libraries: Merkle, UtxoPos

### DIFF
--- a/plasma_framework/contracts/mocks/utils/MerkleWrapper.sol
+++ b/plasma_framework/contracts/mocks/utils/MerkleWrapper.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.5.0;
+
+import "../../src/utils/Merkle.sol";
+
+contract MerkleWrapper {
+
+    function checkMembership(bytes32 leaf, uint256 index, bytes32 rootHash, bytes memory proof)
+        public
+        pure
+        returns (bool)
+    {
+        return Merkle.checkMembership(leaf, index, rootHash, proof);
+    }
+}

--- a/plasma_framework/contracts/mocks/utils/UtxoPosLibWrapper.sol
+++ b/plasma_framework/contracts/mocks/utils/UtxoPosLibWrapper.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.5.0;
+
+import "../../src/utils/UtxoPosLib.sol";
+
+contract UtxoPosLibWrapper {
+    using UtxoPosLib for UtxoPosLib.UtxoPos;
+
+    function blockNum(uint256 _utxoPos) public pure returns (uint256) {
+        return UtxoPosLib.UtxoPos(_utxoPos).blockNum();
+    }
+
+    function txIndex(uint256 _utxoPos) public pure returns (uint256) {
+        return UtxoPosLib.UtxoPos(_utxoPos).txIndex();
+    }
+
+    function outputIndex(uint256 _utxoPos) public pure returns (uint8) {
+        return UtxoPosLib.UtxoPos(_utxoPos).outputIndex();
+    }
+
+    function txPos(uint256 _utxoPos) public pure returns (uint256) {
+        return UtxoPosLib.UtxoPos(_utxoPos).txPos();
+    }
+}

--- a/plasma_framework/contracts/src/utils/Merkle.sol
+++ b/plasma_framework/contracts/src/utils/Merkle.sol
@@ -1,0 +1,42 @@
+pragma solidity ^0.5.0;
+
+/**
+ * @title Merkle
+ * @dev Library for working with Merkle trees.
+ */
+library Merkle {
+
+    /**
+     * @notice Checks that a leaf hash is contained in a root hash.
+     * @param leaf Leaf hash to verify.
+     * @param index Position of the leaf hash in the Merkle tree.
+     * @param rootHash Root of the Merkle tree.
+     * @param proof A Merkle proof demonstrating membership of the leaf hash.
+     * @return True of the leaf hash is in the Merkle tree. False otherwise.
+    */
+    function checkMembership(bytes32 leaf, uint256 index, bytes32 rootHash, bytes memory proof)
+        internal
+        pure
+        returns (bool)
+    {
+        require(proof.length % 32 == 0, "Length of merkle proof must be a multiple of of 32.");
+
+        bytes32 proofElement;
+        bytes32 computedHash = leaf;
+        uint256 j = index;
+        // NOTE: we're skipping the first 32 bytes of `proof`, which holds the size of the dynamically sized `bytes`
+        for (uint256 i = 32; i <= proof.length; i += 32) {
+            assembly {
+                proofElement := mload(add(proof, i))
+            }
+            if (j % 2 == 0) {
+                computedHash = keccak256(abi.encodePacked(computedHash, proofElement));
+            } else {
+                computedHash = keccak256(abi.encodePacked(proofElement, computedHash));
+            }
+            j = j / 2;
+        }
+
+        return computedHash == rootHash;
+    }
+}

--- a/plasma_framework/contracts/src/utils/UtxoPosLib.sol
+++ b/plasma_framework/contracts/src/utils/UtxoPosLib.sol
@@ -1,0 +1,62 @@
+pragma solidity ^0.5.0;
+
+library UtxoPosLib {
+    struct UtxoPos {
+        uint256 value;
+    }
+
+    uint256 constant internal BLOCK_OFFSET = 1000000000;
+    uint256 constant internal TX_OFFSET = 10000;
+
+    /**
+     * @notice Given an UTXO position, returns the block number.
+     * @param _utxoPos Output identifier in form of utxo position.
+     * @return The output's block number.
+     */
+    function blockNum(UtxoPos memory _utxoPos)
+        internal
+        pure
+        returns (uint256)
+    {
+        return _utxoPos.value / BLOCK_OFFSET;
+    }
+
+    /**
+     * @notice Given an UTXO position, returns the transaction index.
+     * @param _utxoPos Output identifier in form of utxo position.
+     * @return The output's transaction index.
+     */
+    function txIndex(UtxoPos memory _utxoPos)
+        internal
+        pure
+        returns (uint256)
+    {
+        return (_utxoPos.value % BLOCK_OFFSET) / TX_OFFSET;
+    }
+
+    /**
+     * @notice Given an UTXO position, returns the output index.
+     * @param _utxoPos Output identifier in form of utxo position.
+     * @return The output's index.
+     */
+    function outputIndex(UtxoPos memory _utxoPos)
+        internal
+        pure
+        returns (uint8)
+    {
+        return uint8(_utxoPos.value % TX_OFFSET);
+    }
+
+    /**
+     * @notice Given an UTXO position, returns transaction position.
+     * @param _utxoPos Output identifier in form of utxo position.
+     * @return The transaction position.
+     */
+    function txPos(UtxoPos memory _utxoPos)
+        internal
+        pure
+        returns (uint256)
+    {
+        return _utxoPos.value / TX_OFFSET;
+    }
+}

--- a/plasma_framework/test/helpers/merkle.js
+++ b/plasma_framework/test/helpers/merkle.js
@@ -1,0 +1,75 @@
+const NullHash = web3.utils.sha3('\00'.repeat(32));
+
+
+class MerkleNode {
+  constructor(data, left=null, right=null) {
+        this.data = data;
+        this.left = left;
+        this.right = right;
+  }
+}
+
+class MerkleTree {
+    constructor(leaves) {
+        this.height = parseInt(Math.log(leaves.length), 10) + 1;
+        this.leafCount = 2 ** this.height;
+
+        this.leaves = leaves.map(web3.utils.sha3);
+
+        const fill = Array.from({length: this.leafCount - this.leaves.length}, () => NullHash);
+        this.leaves = this.leaves.concat(fill);
+        this.tree = [MerkleTree.create_nodes(this.leaves)];
+        this.root = this.create_tree(this.tree[0]);
+    }
+
+    static create_nodes(leaves) {
+        return leaves.map(leaf => new MerkleNode(leaf));
+    }
+
+    create_tree(level) {
+        if (level.length == 1) {
+            return level[0].data;
+        }
+
+        const level_size = level.length;
+        let next_level = [];
+
+        let i = 0;
+        while (i < level_size) {
+            const combined_data = level[i].data + level[i+1].data.slice(2); // JS stores hashes as hex-encoded strings
+            const combined = web3.utils.sha3(web3.utils.hexToBytes(combined_data));
+            const next_node = new MerkleNode(combined, level[i], level[i + 1]);
+            next_level.push(next_node);
+            i += 2;
+        }
+
+        this.tree.push(next_level);
+        return this.create_tree(next_level);
+    }
+
+    getInclusionProof(leaf) {
+        const hashedLeaf = web3.utils.sha3(leaf);
+
+        let index = this.leaves.indexOf(hashedLeaf);
+        if (index == -1) {
+            throw "Argument is not a leaf in the tree"
+        }
+
+        let proof = '0x';
+        for (let i = 0; i < this.height; i++) {
+            let sibling_index;
+            if (index % 2 == 0) {
+                sibling_index = index + 1;
+            } else {
+                sibling_index = index - 1;
+            }
+            index = Math.floor(index / 2);
+
+            proof += this.tree[i][sibling_index].data.slice(2);
+        }
+
+        return proof;
+    }
+}
+
+module.exports.MerkleTree = MerkleTree;

--- a/plasma_framework/test/src/utils/Merkle.test.js
+++ b/plasma_framework/test/src/utils/Merkle.test.js
@@ -1,0 +1,49 @@
+const Merkle = artifacts.require('MerkleWrapper');
+
+const { expectRevert } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
+
+const { MerkleTree } = require('../../helpers/merkle.js');
+
+contract('Merkle', () => {
+    before('setup merkle contract and tree value', async () => {
+        this.merkleContract = await Merkle.new();
+        this.leaves = ['leaf 1', 'leaf 2', 'leaf 3'];
+        this.merkleTree = new MerkleTree(this.leaves);
+    });
+
+    describe('checkMembership', () => {
+        it('should return true when proven included', async () => {
+            const leafIndex = 0;
+            const leafData = web3.utils.sha3(this.leaves[leafIndex]);
+            const rootHash = this.merkleTree.root;
+            const proof = this.merkleTree.getInclusionProof(this.leaves[leafIndex]);
+
+            const result = await this.merkleContract.checkMembership(leafData, leafIndex, rootHash, proof);
+            expect(result).to.be.true;
+        });
+
+        it('should return false when not able to prove included', async () => {
+            const leafIndex = 0;
+            const leafData = web3.utils.sha3(this.leaves[leafIndex]);
+            const fakeRootHash = web3.utils.sha3('random root hash');
+            const proof = this.merkleTree.getInclusionProof(this.leaves[leafIndex]);
+
+            const result = await this.merkleContract.checkMembership(leafData, leafIndex, fakeRootHash, proof);
+            expect(result).to.be.false;
+        });
+    
+        it('should reject call when proof data size is incorrect', async () => {
+            const leafIndex = 0;
+            const leafData = web3.utils.sha3(this.leaves[leafIndex]);
+            const rootHash = this.merkleTree.root;
+            const proof = this.merkleTree.getInclusionProof(this.leaves[leafIndex]);
+            const wrongSizeProof = proof + '13212';
+
+            await expectRevert(
+                this.merkleContract.checkMembership(leafData, leafIndex, rootHash, wrongSizeProof),
+                "Length of merkle proof must be a multiple of of 32."
+            );
+        });
+    });
+});

--- a/plasma_framework/test/src/utils/UtxoPosLib.test.js
+++ b/plasma_framework/test/src/utils/UtxoPosLib.test.js
@@ -1,0 +1,47 @@
+const UtxoPosLib = artifacts.require('UtxoPosLibWrapper');
+
+const { BN } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
+
+contract('UtxoPosLib', () => {
+    before('setup contract and utxo pos values', async () => {
+        this.contract = await UtxoPosLib.new();
+
+        this.blockNumber = 314159;
+        this.txIndex = 123;
+        this.outputIndex = 2;
+
+        const BLOCK_OFFSET = 1000000000;
+        const TX_OFFSET = 10000;
+        this.utxoPos = this.blockNumber * BLOCK_OFFSET + this.txIndex * TX_OFFSET + this.outputIndex;
+        this.txPos = this.utxoPos / TX_OFFSET;
+    });
+
+    describe('blockNum', () => {
+        it('should parse the correct block number', async () => {
+            expect(await this.contract.blockNum(this.utxoPos))
+                .to.be.bignumber.equal(new BN(this.blockNumber));
+        });
+    });
+
+    describe('txIndex', () => {
+        it('should parse the correct tx index', async () => {
+            expect(await this.contract.txIndex(this.utxoPos))
+                .to.be.bignumber.equal(new BN(this.txIndex));
+        });
+    });
+
+    describe('outputIndex', () => {
+        it('should parse the correct output index', async () => {
+            expect(await this.contract.outputIndex(this.utxoPos))
+                .to.be.bignumber.equal(new BN(this.outputIndex));
+        });
+    });
+
+    describe('txPos', () => {
+        it('should parse the correct tx position', async () => {
+            expect(await this.contract.txPos(this.utxoPos))
+                .to.be.bignumber.equal(new BN(this.txPos));
+        });
+    });
+});


### PR DESCRIPTION
### Note
- port `Merkle.sol` and add related test (test code thanks to @pik694 's POC code)
- Although there is a [Merkle lib in open-zepplin](https://github.com/OpenZeppelin/openzeppelin-solidity/blob/bd13be9174943f3fa18896df4ac269f411143c7d/contracts/cryptography/MerkleProof.sol), but their code require the leaves to be sorted :(. So I don't think we can use that.
- add new lib `UtxoPosLib.sol` to handle utxo pos related functions. Originally in `PlasmaCore.sol`.

### Side note
found open zeppelin's latest `ERCRecover` (they renamed `ECDSA`), so we don't need to port that :)
https://github.com/OpenZeppelin/openzeppelin-solidity/blob/bd13be9174943f3fa18896df4ac269f411143c7d/contracts/cryptography/ECDSA.sol
### Test
truffle test
```
Contract: Merkle
    checkMembership
      ✓ should return true when proven included (41ms)
      ✓ should return false when not able to prove included
      ✓ should reject call when proof data size is incorrect

  Contract: UtxoPosLib
    blockNum
      ✓ should parse the correct block number
    txIndex
      ✓ should parse the correct tx index
    outputIndex
      ✓ should parse the correct output index
    txPos
      ✓ should parse the correct tx position
```