### PR TITLE
[PaymentExitGame] start standard exit implementation

### DIFF
--- a/plasma_framework/contracts/mocks/exits/utils/ExitIdWrapper.sol
+++ b/plasma_framework/contracts/mocks/exits/utils/ExitIdWrapper.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.5.0;
+
+import "../../../src/utils/UtxoPosLib.sol";
+import "../../../src/exits/utils/ExitId.sol";
+
+contract ExitIdWrapper {
+    function getStandardExitId(bool _isDeposit, bytes memory _txBytes, uint256 _utxoPos)
+        public
+        pure
+        returns (uint192)
+    {
+        UtxoPosLib.UtxoPos memory utxoPos = UtxoPosLib.UtxoPos(_utxoPos);
+        return ExitId.getStandardExitId(_isDeposit, _txBytes, utxoPos);
+    }
+}

--- a/plasma_framework/contracts/mocks/exits/utils/ExitableTimestampWrapper.sol
+++ b/plasma_framework/contracts/mocks/exits/utils/ExitableTimestampWrapper.sol
@@ -1,0 +1,20 @@
+pragma solidity ^0.5.0;
+
+import "../../../src/exits/utils/ExitableTimestamp.sol";
+
+contract ExitableTimestampWrapper {
+    using ExitableTimestamp for ExitableTimestamp.Calculator;
+    ExitableTimestamp.Calculator calculator;
+
+    constructor(uint256 _minExitPeriod) public {
+        calculator = ExitableTimestamp.Calculator(_minExitPeriod);
+    }
+
+    function calculate(uint256 _now, uint256 _blockTimestamp, bool _isDeposit)
+        public
+        view
+        returns (uint256)
+    {
+        return calculator.calculate(_now, _blockTimestamp, _isDeposit);
+    }
+}

--- a/plasma_framework/contracts/mocks/framework/DummyExitGame.sol
+++ b/plasma_framework/contracts/mocks/framework/DummyExitGame.sol
@@ -3,9 +3,9 @@ pragma experimental ABIEncoderV2;
 
 import "./registries/ExitGameRegistryMock.sol";
 import "../../src/framework/ExitGameController.sol";
-import "../../src/framework/interfaces/ExitProcessor.sol";
+import "../../src/framework/interfaces/IExitProcessor.sol";
 
-contract DummyExitGame is ExitProcessor {
+contract DummyExitGame is IExitProcessor {
     uint256 public uniquePriorityFromEnqueue;
 
     ExitGameRegistryMock private exitGameRegistry;

--- a/plasma_framework/contracts/mocks/framework/DummyPlasmaFramework.sol
+++ b/plasma_framework/contracts/mocks/framework/DummyPlasmaFramework.sol
@@ -1,0 +1,35 @@
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+import "../../src/framework/interfaces/IPlasmaFramework.sol";
+import "../../src/framework/models/BlockModel.sol";
+
+contract DummyPlasmaFramework is IPlasmaFramework {
+    mapping (uint256 => BlockModel.Block) public blocks;
+    mapping (bytes32 => ExitModel.Exit) public testExitQueue;
+
+    /**
+        Interface functions
+     */
+
+    function CHILD_BLOCK_INTERVAL() external view returns (uint256) {
+        return 1000;
+    }
+
+    function minExitPeriod() external view returns (uint256) {
+        return 60 * 60 * 24 * 7; // 7 days
+    }
+
+    function enqueue(uint192 _priority, address _token, ExitModel.Exit memory _exit) public returns (uint256) {
+        bytes32 key = keccak256(abi.encodePacked(uint256(_priority), _token));
+        testExitQueue[key] = _exit;
+    }
+
+    /**
+     Custom test helpers
+     */
+
+    function setBlock(uint256 _blockNum, bytes32 _root, uint256 _timestamp) external {
+        blocks[_blockNum] = BlockModel.Block(_root, _timestamp);
+    }
+}

--- a/plasma_framework/contracts/mocks/transactions/outputs/PaymentOutputModelMock.sol
+++ b/plasma_framework/contracts/mocks/transactions/outputs/PaymentOutputModelMock.sol
@@ -5,6 +5,7 @@ import "../../../src/transactions/outputs/PaymentOutputModel.sol";
 import "../../../src/utils/RLP.sol";
 
 contract PaymentOutputModelMock {
+    using PaymentOutputModel for PaymentOutputModel.Output;
 
     using RLP for bytes;
 
@@ -13,4 +14,12 @@ contract PaymentOutputModelMock {
         return output;
     }
 
+    function owner(uint256 _amount, address _owner, address _token) public pure returns (address payable) {
+        PaymentOutputModel.Output memory output = PaymentOutputModel.Output({
+            amount: _amount,
+            outputGuard: bytes32(uint256(_owner)),
+            token: _token
+        });
+        return output.owner();
+    }
 }

--- a/plasma_framework/contracts/mocks/utils/AddressPayableWrapper.sol
+++ b/plasma_framework/contracts/mocks/utils/AddressPayableWrapper.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.5.0;
+
+import "../../src/utils/AddressPayable.sol";
+
+contract AddressPayableWrapper {
+
+    function convert(address _address)
+        public
+        pure
+        returns (address payable)
+    {
+        return AddressPayable.convert(_address);
+    }
+}

--- a/plasma_framework/contracts/mocks/utils/IsDepositWrapper.sol
+++ b/plasma_framework/contracts/mocks/utils/IsDepositWrapper.sol
@@ -1,0 +1,17 @@
+pragma solidity ^0.5.0;
+
+import "../../src/utils/IsDeposit.sol";
+
+contract IsDepositWrapper {
+    using IsDeposit for IsDeposit.Predicate;
+
+    IsDeposit.Predicate isDeposit;
+
+    constructor(uint256 _childBlockInterval) public {
+        isDeposit = IsDeposit.Predicate(_childBlockInterval);
+    }
+
+    function test(uint256 _blockNum) public view returns (bool) {
+        return isDeposit.test(_blockNum);
+    }
+}

--- a/plasma_framework/contracts/mocks/utils/OnlyWithValueMock.sol
+++ b/plasma_framework/contracts/mocks/utils/OnlyWithValueMock.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.5.0;
+
+import "../../src/utils/OnlyWithValue.sol";
+
+contract OnlyWithValueMock is OnlyWithValue {
+    event OnlyWithValuePassed();
+
+    function checkOnlyWithValue(uint256 _value) public payable onlyWithValue(_value) {
+        emit OnlyWithValuePassed();
+    }
+}

--- a/plasma_framework/contracts/mocks/utils/TxPosLibWrapper.sol
+++ b/plasma_framework/contracts/mocks/utils/TxPosLibWrapper.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+import "../../src/utils/TxPosLib.sol";
+
+contract TxPosLibWrapper {
+    using TxPosLib for TxPosLib.TxPos;
+
+    function blockNum(uint256 _txPos) public pure returns (uint256) {
+        return TxPosLib.TxPos(_txPos).blockNum();
+    }
+
+    function txIndex(uint256 _txPos) public pure returns (uint256) {
+        return TxPosLib.TxPos(_txPos).txIndex();
+    }
+}

--- a/plasma_framework/contracts/mocks/utils/UtxoPosLibWrapper.sol
+++ b/plasma_framework/contracts/mocks/utils/UtxoPosLibWrapper.sol
@@ -1,5 +1,7 @@
 pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
 
+import "../../src/utils/TxPosLib.sol";
 import "../../src/utils/UtxoPosLib.sol";
 
 contract UtxoPosLibWrapper {
@@ -17,7 +19,7 @@ contract UtxoPosLibWrapper {
         return UtxoPosLib.UtxoPos(_utxoPos).outputIndex();
     }
 
-    function txPos(uint256 _utxoPos) public pure returns (uint256) {
+    function txPos(uint256 _utxoPos) public pure returns (TxPosLib.TxPos memory) {
         return UtxoPosLib.UtxoPos(_utxoPos).txPos();
     }
 }

--- a/plasma_framework/contracts/src/exits/payment/PaymentExitDataModel.sol
+++ b/plasma_framework/contracts/src/exits/payment/PaymentExitDataModel.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.5.0;
+
+library PaymentExitDataModel {
+    struct StandardExit {
+        bool exitable;
+        uint192 position;
+        address token;
+        address payable exitTarget;
+        uint256 amount;
+    }
+}

--- a/plasma_framework/contracts/src/exits/payment/PaymentExitGame.sol
+++ b/plasma_framework/contracts/src/exits/payment/PaymentExitGame.sol
@@ -1,0 +1,13 @@
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+import "./PaymentStandardExitable.sol";
+import "../../framework/interfaces/IExitProcessor.sol";
+
+contract PaymentExitGame is IExitProcessor, PaymentStandardExitable {
+    constructor(address _framework) public PaymentStandardExitable(_framework) {}
+
+    function processExit(uint256 _exitId) external {
+        // TODO: implement this
+    }
+}

--- a/plasma_framework/contracts/src/exits/payment/PaymentStandardExitable.sol
+++ b/plasma_framework/contracts/src/exits/payment/PaymentStandardExitable.sol
@@ -1,0 +1,153 @@
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+import "./PaymentExitDataModel.sol";
+import "../utils/ExitId.sol";
+import "../utils/ExitableTimestamp.sol";
+import "../../framework/interfaces/IPlasmaFramework.sol";
+import "../../framework/models/ExitModel.sol";
+import "../../utils/IsDeposit.sol";
+import "../../utils/OnlyWithValue.sol";
+import "../../utils/TxPosLib.sol";
+import "../../utils/UtxoPosLib.sol";
+import "../../utils/Merkle.sol";
+import "../../transactions/PaymentTransactionModel.sol";
+import "../../transactions/outputs/PaymentOutputModel.sol";
+
+contract PaymentStandardExitable is OnlyWithValue {
+    using PaymentOutputModel for PaymentOutputModel.Output;
+    using UtxoPosLib for UtxoPosLib.UtxoPos;
+    using TxPosLib for TxPosLib.TxPos;
+    using IsDeposit for IsDeposit.Predicate;
+    using ExitableTimestamp for ExitableTimestamp.Calculator;
+
+    uint256 public constant standardExitBond = 31415926535 wei;
+    mapping (uint192 => PaymentExitDataModel.StandardExit) public exits;
+
+    IPlasmaFramework private framework;
+    IsDeposit.Predicate private isDeposit;
+    ExitableTimestamp.Calculator private exitableTimestampCalculator;
+
+    /**
+    @dev data to be passed around startStandardExit helper functions
+     */
+    struct StartStandardExitData {
+        UtxoPosLib.UtxoPos utxoPos;
+        PaymentTransactionModel.Transaction outputTx;
+        PaymentOutputModel.Output output;
+        uint192 exitId;
+        bool isTxDeposit;
+        bytes txInclusionProof;
+        bytes rlpTx;
+        bytes32 txBlockRoot;
+        uint256 txBlockTimeStamp;
+    }
+
+    event ExitStarted(
+        address indexed owner,
+        uint192 exitId
+    );
+
+    constructor(address _framework) public {
+        framework = IPlasmaFramework(_framework);
+        isDeposit = IsDeposit.Predicate(framework.CHILD_BLOCK_INTERVAL());
+        exitableTimestampCalculator = ExitableTimestamp.Calculator(framework.minExitPeriod());
+    }
+
+    /**
+     * @notice Starts a standard withdrawal of a given output. Uses output-age priority.
+     * @dev requires the exiting UTXO's token to be added via 'addToken'
+     * @param _utxoPos Position of the exiting output.
+     * @param _outputTx RLP encoded transaction that created the exiting output.
+     * @param _outputTxInclusionProof A Merkle proof showing that the transaction was included.
+     */
+    function startStandardExit(
+        uint192 _utxoPos,
+        bytes calldata _outputTx,
+        bytes calldata _outputTxInclusionProof
+    )
+        external
+        payable
+        onlyWithValue(standardExitBond)
+    {
+        StartStandardExitData memory data = setupStartStandardExitData(_utxoPos, _outputTx, _outputTxInclusionProof);
+        verifyStartStandardExitData(data);
+        saveStandardExitData(data);
+        enqueueStandardExit(data);
+
+        emit ExitStarted(data.output.owner(), data.exitId);
+    }
+
+    /**
+    Private functions
+    */
+
+    function setupStartStandardExitData(
+        uint192 _utxoPos,
+        bytes memory _outputTx,
+        bytes memory _txInclusionProof
+    )
+        private
+        view
+        returns (StartStandardExitData memory)
+    {
+        UtxoPosLib.UtxoPos memory utxoPos = UtxoPosLib.UtxoPos(_utxoPos);
+        PaymentTransactionModel.Transaction memory outputTx = PaymentTransactionModel.decode(_outputTx);
+        PaymentOutputModel.Output memory output = outputTx.outputs[utxoPos.outputIndex()];
+        bool isTxDeposit = isDeposit.test(utxoPos.blockNum());
+        uint192 exitId = ExitId.getStandardExitId(isTxDeposit, _outputTx, utxoPos);
+        (bytes32 root, uint256 blockTimestamp) = framework.blocks(utxoPos.blockNum());
+
+        return StartStandardExitData({
+            utxoPos: utxoPos,
+            outputTx: outputTx,
+            output: output,
+            exitId: exitId,
+            isTxDeposit: isTxDeposit,
+            txInclusionProof: _txInclusionProof,
+            rlpTx: _outputTx,
+            txBlockRoot: root,
+            txBlockTimeStamp: blockTimestamp
+        });
+    }
+
+    function verifyStartStandardExitData(StartStandardExitData memory data)
+        private
+        view
+    {
+        bytes32 leafData = keccak256(data.rlpTx);
+        require(
+            Merkle.checkMembership(leafData, data.utxoPos.txIndex(), data.txBlockRoot, data.txInclusionProof),
+            "transaction inclusion proof failed"
+        );
+        require(data.output.amount > 0, "Should not exit with amount 0");
+        require(data.output.owner() == msg.sender, "Only output owner can start an exit");
+        require(exits[data.exitId].exitable == false, "Exit already started");
+    }
+
+    function saveStandardExitData(StartStandardExitData memory data) private {
+        PaymentExitDataModel.StandardExit memory exitData = PaymentExitDataModel.StandardExit({
+            exitable: true,
+            position: uint192(data.utxoPos.value),
+            token: data.output.token,
+            exitTarget: data.output.owner(),
+            amount: data.output.amount
+        });
+        exits[data.exitId] = exitData;
+    }
+
+    function enqueueStandardExit(StartStandardExitData memory data) private {
+        uint256 exitableAt = exitableTimestampCalculator.calculate(
+            block.timestamp, data.txBlockTimeStamp, data.isTxDeposit
+        );
+
+        uint192 priority = uint192(data.utxoPos.value);
+        ExitModel.Exit memory exitDataForQueue = ExitModel.Exit({
+            exitProcessor: address(this),
+            exitableAt: exitableAt,
+            exitId: data.exitId
+        });
+
+        framework.enqueue(priority, data.output.token, exitDataForQueue);
+    }
+}

--- a/plasma_framework/contracts/src/exits/utils/ExitId.sol
+++ b/plasma_framework/contracts/src/exits/utils/ExitId.sol
@@ -1,0 +1,49 @@
+pragma solidity ^0.5.0;
+
+import "../../utils/UtxoPosLib.sol";
+import "../../framework/interfaces/IPlasmaFramework.sol";
+
+library ExitId {
+    using UtxoPosLib for UtxoPosLib.UtxoPos;
+
+    /**
+     * @notice Given transaction bytes and UTXO position, returns its exit ID.
+     * @dev Id from a deposit is computed differently from any other tx.
+     * @param _isDeposit Predicate to check whether a block num is a deposit block.
+     * @param _txBytes Transaction bytes.
+     * @param _utxoPos UTXO position of the exiting output.
+     * @return _standardExitId Unique standard exit id.
+     *     Anatomy of returned value, most significant bits first:
+     *     8 bits - oindex
+     *     1 bit - in-flight flag
+     *     151 bit - hash(tx) or hash(tx|utxo) for deposit
+     */
+    function getStandardExitId(
+        bool _isDeposit,
+        bytes memory _txBytes,
+        UtxoPosLib.UtxoPos memory _utxoPos
+    )
+        internal
+        pure
+        returns (uint192)
+    {
+        if (_isDeposit) {
+            bytes32 hash = keccak256(abi.encodePacked(_txBytes, _utxoPos.value));
+            return _computeStandardExitId(hash, _utxoPos.outputIndex());
+        }
+
+        return _computeStandardExitId(keccak256(_txBytes), _utxoPos.outputIndex());
+    }
+
+    /**
+    Private
+    */
+
+    function _computeStandardExitId(bytes32 _txhash, uint8 _outputIndex)
+        private
+        pure
+        returns (uint192)
+    {
+        return uint192((uint256(_txhash) >> 105) | (uint256(_outputIndex) << 152));
+    }
+}

--- a/plasma_framework/contracts/src/exits/utils/ExitableTimestamp.sol
+++ b/plasma_framework/contracts/src/exits/utils/ExitableTimestamp.sol
@@ -1,0 +1,29 @@
+pragma solidity ^0.5.0;
+
+import "../../framework/interfaces/IPlasmaFramework.sol";
+
+import "openzeppelin-solidity/contracts/math/Math.sol";
+
+library ExitableTimestamp {
+    struct Calculator {
+        uint256 minExitPeriod;
+    }
+
+    function calculate(
+        Calculator memory _calculator,
+        uint256 _now,
+        uint256 _blockTimestamp,
+        bool _isDeposit
+    )
+        internal
+        pure
+        returns (uint256)
+    {
+        uint256 minExitableTimestamp = _now + _calculator.minExitPeriod;
+
+        if (_isDeposit) {
+            return minExitableTimestamp;
+        }
+        return Math.max(_blockTimestamp + (_calculator.minExitPeriod * 2), minExitableTimestamp);
+    }
+}

--- a/plasma_framework/contracts/src/framework/ExitGameController.sol
+++ b/plasma_framework/contracts/src/framework/ExitGameController.sol
@@ -67,6 +67,7 @@ contract ExitGameController is ExitGameRegistry {
      * @notice Enqueue exits from exit game contracts
      * @dev Unique priority is a combination of original priority and an increasing nonce
      * @dev Use public instead of external because structs in calldata not currently supported.
+     * @dev Also, caller of this function should add "pragma experimental ABIEncoderV2;" on top of file
      * @param _priority The priority of the exit itself
      * @param _token Token for the exit
      * @param _exit Exit data that contains the basic information for exit processor that processes the exit

--- a/plasma_framework/contracts/src/framework/ExitGameController.sol
+++ b/plasma_framework/contracts/src/framework/ExitGameController.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.5.0;
 pragma experimental ABIEncoderV2;
 
 import "./models/ExitModel.sol";
-import "./interfaces/ExitProcessor.sol";
+import "./interfaces/IExitProcessor.sol";
 import "./registries/ExitGameRegistry.sol";
 import "./utils/PriorityQueue.sol";
 
@@ -106,7 +106,7 @@ contract ExitGameController is ExitGameRegistry {
         uint256 processedNum = 0;
 
         while (processedNum < _maxExitsToProcess && exit.exitableAt < block.timestamp) {
-            ExitProcessor processor = ExitProcessor(exit.exitProcessor);
+            IExitProcessor processor = IExitProcessor(exit.exitProcessor);
 
             processor.processExit(exit.exitId);
 

--- a/plasma_framework/contracts/src/framework/PlasmaFramework.sol
+++ b/plasma_framework/contracts/src/framework/PlasmaFramework.sol
@@ -6,9 +6,10 @@ import "./ExitGameController.sol";
 import "./registries/VaultRegistry.sol";
 import "./registries/ExitGameRegistry.sol";
 import "./utils/Operated.sol";
+import "./interfaces/IPlasmaFramework.sol";
 
-contract PlasmaFramework is Operated, VaultRegistry, ExitGameRegistry, ExitGameController, BlockController {
-    uint256 constant CHILD_BLOCK_INTERVAL = 1000;
+contract PlasmaFramework is IPlasmaFramework, Operated, VaultRegistry, ExitGameRegistry, ExitGameController, BlockController {
+    uint256 public constant CHILD_BLOCK_INTERVAL = 1000;
 
     // NOTE: this is the "middle" period.
     // Exit period for fresh utxos is double of that while IFE phase is half of that

--- a/plasma_framework/contracts/src/framework/interfaces/IExitProcessor.sol
+++ b/plasma_framework/contracts/src/framework/interfaces/IExitProcessor.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.0;
 
-interface ExitProcessor {
+interface IExitProcessor {
     /**
      * @dev Custom function to process exit. Would do nothing if not able to exit (eg. successfully challenged)
      * @param _exitId unique id for exit per tx type.

--- a/plasma_framework/contracts/src/framework/interfaces/IPlasmaFramework.sol
+++ b/plasma_framework/contracts/src/framework/interfaces/IPlasmaFramework.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+import "../models/ExitModel.sol";
+
+
+interface IPlasmaFramework {
+    function CHILD_BLOCK_INTERVAL() external view returns (uint256);
+
+    function minExitPeriod() external view returns (uint256);
+
+    function blocks(uint256 _blockNumber) external view returns (bytes32, uint256);
+
+    function enqueue(uint192 _priority, address _token, ExitModel.Exit calldata _exit) external returns (uint256);
+}

--- a/plasma_framework/contracts/src/transactions/outputs/PaymentOutputModel.sol
+++ b/plasma_framework/contracts/src/transactions/outputs/PaymentOutputModel.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.5.0;
 pragma experimental ABIEncoderV2;
 
 import "../../utils/RLP.sol";
+import "../../utils/AddressPayable.sol";
 
 library PaymentOutputModel {
 
@@ -13,8 +14,14 @@ library PaymentOutputModel {
         address token;
     }
 
-    function hash(Output memory _output) internal pure returns (bytes32) {
-        return keccak256(abi.encode(_output));
+    /**
+     * @notice Get the 'owner' from the output with the assumption of
+     *         'outputGuard' field directly holding owner's address.
+     * @dev 'outputGuard' can potentially be hash of pre-image that holds the owner info.
+     *       This should not and cannot be handled here.
+     */
+    function owner(Output memory _output) internal pure returns (address payable) {
+        return AddressPayable.convert(address(uint256(_output.outputGuard)));
     }
 
     function decode(RLP.RLPItem memory encoded) internal pure returns (Output memory) {

--- a/plasma_framework/contracts/src/utils/AddressPayable.sol
+++ b/plasma_framework/contracts/src/utils/AddressPayable.sol
@@ -1,0 +1,12 @@
+pragma solidity ^0.5.0;
+
+library AddressPayable {
+
+    /**
+     * @notice Converts an `address` into `address payable`.
+     * @dev Note that this is simply a type cast: the actual underlying value is not changed.
+     */
+    function convert(address account) internal pure returns (address payable) {
+        return address(uint160(account));
+    }
+}

--- a/plasma_framework/contracts/src/utils/IsDeposit.sol
+++ b/plasma_framework/contracts/src/utils/IsDeposit.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.5.0;
+
+library IsDeposit {
+    struct Predicate {
+        uint256 childBlockInterval;
+    }
+
+    function test(Predicate memory _predicate, uint256 _blockNum) internal pure returns (bool) {
+        return _blockNum % _predicate.childBlockInterval != 0;
+    }
+}

--- a/plasma_framework/contracts/src/utils/OnlyWithValue.sol
+++ b/plasma_framework/contracts/src/utils/OnlyWithValue.sol
@@ -1,0 +1,8 @@
+pragma solidity ^0.5.0;
+
+contract OnlyWithValue {
+    modifier onlyWithValue(uint256 _value) {
+        require(msg.value == _value, "Input value mismatches with msg.value");
+        _;
+    }
+}

--- a/plasma_framework/contracts/src/utils/TxPosLib.sol
+++ b/plasma_framework/contracts/src/utils/TxPosLib.sol
@@ -1,0 +1,38 @@
+pragma solidity ^0.5.0;
+
+/**
+@dev transaction position = (blockNumber * BLOCK_OFFSET_FOR_TX_POS + txIndex).
+ */
+library TxPosLib {
+    struct TxPos {
+        uint256 value;
+    }
+
+    uint256 constant internal BLOCK_OFFSET_FOR_TX_POS = 1000000000 / 10000;
+
+    /**
+     * @notice Given a TX position, returns the block number.
+     * @param _txPos position of transaction.
+     * @return The output's block number.
+     */
+    function blockNum(TxPos memory _txPos)
+        internal
+        pure
+        returns (uint256)
+    {
+        return _txPos.value / BLOCK_OFFSET_FOR_TX_POS;
+    }
+
+    /**
+     * @notice Given a Tx position, returns the transaction index.
+     * @param _txPos position of transaction.
+     * @return The output's transaction index.
+     */
+    function txIndex(TxPos memory _txPos)
+        internal
+        pure
+        returns (uint256)
+    {
+        return _txPos.value % BLOCK_OFFSET_FOR_TX_POS;
+    }
+}

--- a/plasma_framework/contracts/src/utils/UtxoPosLib.sol
+++ b/plasma_framework/contracts/src/utils/UtxoPosLib.sol
@@ -1,5 +1,10 @@
 pragma solidity ^0.5.0;
 
+import "./TxPosLib.sol";
+
+/**
+@dev UTXO position = (blockNumber * BLOCK_OFFSET + txIndex * TX_OFFSET + outputIndex).
+ */
 library UtxoPosLib {
     struct UtxoPos {
         uint256 value;
@@ -55,8 +60,8 @@ library UtxoPosLib {
     function txPos(UtxoPos memory _utxoPos)
         internal
         pure
-        returns (uint256)
+        returns (TxPosLib.TxPos memory)
     {
-        return _utxoPos.value / TX_OFFSET;
+        return TxPosLib.TxPos(_utxoPos.value / TX_OFFSET);
     }
 }

--- a/plasma_framework/contracts/src/vaults/predicates/EthDepositVerifier.sol
+++ b/plasma_framework/contracts/src/vaults/predicates/EthDepositVerifier.sol
@@ -2,8 +2,11 @@ pragma solidity ^0.5.0;
 
 import "./IEthDepositVerifier.sol";
 import {PaymentTransactionModel as DepositTx} from "../../transactions/PaymentTransactionModel.sol";
+import {PaymentOutputModel as DepositOutputModel} from "../../transactions/outputs/PaymentOutputModel.sol";
 
 contract EthDepositVerifier is IEthDepositVerifier {
+    using DepositOutputModel for DepositOutputModel.Output;
+
     uint8 constant DEPOSIT_TX_TYPE = 1;
 
     function verify(bytes calldata _depositTx, uint256 amount, address _sender) external view {
@@ -18,7 +21,7 @@ contract EthDepositVerifier is IEthDepositVerifier {
         require(decodedTx.outputs[0].amount == amount, "Deposited value does not match sent amount");
         require(decodedTx.outputs[0].token == address(0), "Output does not have correct currency (ETH)");
 
-        address depositorsAddress = address(uint160(uint256(decodedTx.outputs[0].outputGuard)));
+        address depositorsAddress = decodedTx.outputs[0].owner();
         require(depositorsAddress == _sender, "Depositor's address does not match sender's address");
 
     }

--- a/plasma_framework/contracts/src/vaults/predicates/IErc20DepositVerifier.sol
+++ b/plasma_framework/contracts/src/vaults/predicates/IErc20DepositVerifier.sol
@@ -7,5 +7,8 @@ interface IErc20DepositVerifier {
      * @param _sender The owner of the deposit transaction.
      * @param _vault The address of the Erc20Vault contract.
      */
-    function verify(bytes calldata _depositTx, address _sender, address _vault) external view returns (address owner, address token, uint256 amount);
+    function verify(bytes calldata _depositTx, address _sender, address _vault)
+        external
+        view
+        returns (address owner, address token, uint256 amount);
 }

--- a/plasma_framework/migrations/1_initial_migration.js
+++ b/plasma_framework/migrations/1_initial_migration.js
@@ -1,5 +1,5 @@
 const Migrations = artifacts.require('Migrations');
 
-module.exports = function (deployer) {
+module.exports = (deployer) => {
     deployer.deploy(Migrations);
 };

--- a/plasma_framework/test/helpers/merkle.js
+++ b/plasma_framework/test/helpers/merkle.js
@@ -10,8 +10,19 @@ class MerkleNode {
 }
 
 class MerkleTree {
-    constructor(leaves) {
-        this.height = parseInt(Math.log(leaves.length), 10) + 1;
+    constructor(leaves, height = 0) {
+        const minHeightForLeaves = parseInt(Math.log(leaves.length), 10) + 1;
+
+        if (height === 0) {
+            this.height = minHeightForLeaves;
+        } else if (height > minHeightForLeaves) {
+            this.height = height;
+        } else {
+            throw new Error(
+                `height should be at least ${minHeightForLeaves} for the list of leaves`
+            );
+        }
+
         this.leafCount = 2 ** this.height;
 
         this.leaves = leaves.map(web3.utils.sha3);

--- a/plasma_framework/test/helpers/merkle.js
+++ b/plasma_framework/test/helpers/merkle.js
@@ -19,7 +19,7 @@ class MerkleTree {
             this.height = height;
         } else {
             throw new Error(
-                `height should be at least ${minHeightForLeaves} for the list of leaves`
+                `height should be at least ${minHeightForLeaves} for the list of leaves`,
             );
         }
 

--- a/plasma_framework/test/helpers/testlang.js
+++ b/plasma_framework/test/helpers/testlang.js
@@ -7,4 +7,11 @@ function deposit(amount, owner, tokenAddress = constants.ZERO_ADDRESS) {
     return depositTx.rlpEncoded();
 }
 
+function buildUtxoPos(blockNum, txIndex, outputIndex) {
+    const BLOCK_OFFSET = 1000000000;
+    const TX_OFFSET = 10000;
+    return blockNum * BLOCK_OFFSET + txIndex * TX_OFFSET + outputIndex;
+}
+
 module.exports.deposit = deposit;
+module.exports.buildUtxoPos = buildUtxoPos;

--- a/plasma_framework/test/helpers/utils.js
+++ b/plasma_framework/test/helpers/utils.js
@@ -1,0 +1,6 @@
+async function spentOnGas(receipt) {
+    const tx = await web3.eth.getTransaction(receipt.transactionHash);
+    return web3.utils.toBN(tx.gasPrice).muln(receipt.gasUsed);
+}
+
+module.exports.spentOnGas = spentOnGas;

--- a/plasma_framework/test/src/exits/payment/PaymentExitGame.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentExitGame.test.js
@@ -1,0 +1,147 @@
+const PaymentExitGame = artifacts.require('PaymentExitGame');
+const PlasmaFramework = artifacts.require('PlasmaFramework');
+const PriorityQueue = artifacts.require('PriorityQueue');
+const EthVault = artifacts.require('EthVault');
+const EthDepositVerifier = artifacts.require('EthDepositVerifier');
+const ExitId = artifacts.require('ExitIdWrapper');
+
+const { BN, constants } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
+
+const { MerkleTree } = require('../../../helpers/merkle.js');
+const { PaymentTransactionOutput, PaymentTransaction } = require('../../../helpers/transaction.js');
+const Testlang = require('../../../helpers/testlang.js');
+
+contract('PaymentExitGame - End to End Tests', ([_, alice, bob]) => {
+    const MIN_EXIT_PERIOD = 60 * 60 * 24 * 7; // 1 week
+    const STANDARD_EXIT_BOND = 31415926535; // wei
+    const ETH = constants.ZERO_ADDRESS;
+    const DEPOSIT_VALUE = 1000000;
+
+    const setupContracts = async () => {
+        this.framework = await PlasmaFramework.new(MIN_EXIT_PERIOD);
+        this.exitGame = await PaymentExitGame.new(this.framework.address);
+        this.ethVault = await EthVault.new(this.framework.address);
+        this.exitIdHelper = await ExitId.new();
+
+        const depositVerifier = await EthDepositVerifier.new();
+        await this.ethVault.setDepositVerifier(depositVerifier.address);
+        await this.framework.registerVault(1, this.ethVault.address);
+        await this.framework.registerExitGame(1, this.exitGame.address);
+    };
+
+    const aliceDeposits = async () => {
+        const depositBlockNum = (await this.framework.nextDepositBlock()).toNumber();
+        this.depositUtxoPos = Testlang.buildUtxoPos(depositBlockNum, 0, 0);
+        this.depositTx = Testlang.deposit(DEPOSIT_VALUE, alice);
+        this.merkleTreeForDepositTx = new MerkleTree([this.depositTx], 16);
+        this.merkleProofForDepositTx = this.merkleTreeForDepositTx.getInclusionProof(this.depositTx);
+
+        await this.ethVault.deposit(this.depositTx, { from: alice, value: DEPOSIT_VALUE });
+    };
+
+    const aliceTransferToBob = async () => {
+        const tranferTxBlockNum = (await this.framework.nextChildBlock()).toNumber();
+        this.transferUtxoPos = Testlang.buildUtxoPos(tranferTxBlockNum, 0, 0);
+
+        const output = new PaymentTransactionOutput(1000, bob, ETH);
+
+        // TODO: utxo_pos or output_id pending decision here: https://github.com/omisego/research/issues/93
+        // if it ends up differently should alter this function accordingly
+        this.transferTx = (new PaymentTransaction(1, [this.transferUtxoPos], [output])).rlpEncoded();
+        this.merkleTreeForTransferTx = new MerkleTree([this.transferTx]);
+        this.merkleProofForTransferTx = this.merkleTreeForTransferTx.getInclusionProof(this.transferTx);
+
+        await this.framework.submitBlock(this.merkleTreeForTransferTx.root);
+    };
+
+    describe('Given contracts deployed, exit game and ETH vault registered', () => {
+        beforeEach(setupContracts);
+
+        describe('Given alice deposited', () => {
+            beforeEach(aliceDeposits);
+
+            describe('When alice starts standard exit on the deposit tx', () => {
+                beforeEach(async () => {
+                    await this.exitGame.startStandardExit(
+                        this.depositUtxoPos, this.depositTx, this.merkleProofForDepositTx,
+                        { from: alice, value: STANDARD_EXIT_BOND },
+                    );
+                });
+
+                it('should save the StandardExit data when successfully done', async () => {
+                    const exitId = await this.exitIdHelper.getStandardExitId(true, this.depositTx, this.depositUtxoPos);
+                    const standardExitData = await this.exitGame.exits(exitId);
+
+                    expect(standardExitData.exitable).to.be.true;
+                    expect(standardExitData.position).to.be.bignumber.equal(new BN(this.depositUtxoPos));
+                    expect(standardExitData.token).to.equal(ETH);
+                    expect(standardExitData.exitTarget).to.equal(alice);
+                    expect(standardExitData.amount).to.be.bignumber.equal(new BN(DEPOSIT_VALUE));
+                });
+
+                it('should put the exit data into the queue of framework', async () => {
+                    const priorityQueueAddress = await this.framework.exitsQueues(ETH);
+                    const priorityQueue = await PriorityQueue.at(priorityQueueAddress);
+                    const uniquePriority = await priorityQueue.getMin();
+
+                    // right most 64 bits are nonce for priority queue
+                    expect(uniquePriority.shrn(64)).to.be.bignumber.equal(new BN(this.depositUtxoPos));
+                });
+            });
+        });
+
+        describe('Given alice deposited and transfered to bob', () => {
+            beforeEach(async () => {
+                await aliceDeposits();
+                await aliceTransferToBob();
+            });
+
+            describe('When bob tries to start the standard exit on the transfered tx', () => {
+                beforeEach(async () => {
+                    await this.exitGame.startStandardExit(
+                        this.transferUtxoPos, this.transferTx, this.merkleProofForTransferTx,
+                        { from: bob, value: STANDARD_EXIT_BOND },
+                    );
+                });
+
+                it('should start successully', async () => {
+                    const exitId = await this.exitIdHelper.getStandardExitId(
+                        false, this.transferTx, this.transferUtxoPos,
+                    );
+                    const standardExitData = await this.exitGame.exits(exitId);
+                    expect(standardExitData.exitable).to.be.true;
+                });
+            });
+        });
+
+        describe('Given alice deposited and transfered to bob', () => {
+            beforeEach(async () => {
+                await aliceDeposits();
+                await aliceTransferToBob();
+            });
+
+            describe('When alice tries to start the standard exit on the deposit tx', () => {
+                beforeEach(async () => {
+                    await this.exitGame.startStandardExit(
+                        this.depositUtxoPos, this.depositTx, this.merkleProofForDepositTx,
+                        { from: alice, value: STANDARD_EXIT_BOND },
+                    );
+                });
+
+                it('should still be able to start standard exit even already spent', async () => {
+                    const exitId = await this.exitIdHelper.getStandardExitId(true, this.depositTx, this.depositUtxoPos);
+                    const standardExitData = await this.exitGame.exits(exitId);
+                    expect(standardExitData.exitable).to.be.true;
+                });
+
+                describe('Then bob can challenge the standard exit spent', async () => {
+                    it('TODO: should challenge it successfully', async () => {
+                        // TODO: implement this!
+                        // this is to show case how we can do cool BDD style in E2E test and reuse setup
+                    });
+                });
+            });
+        });
+    });
+});

--- a/plasma_framework/test/src/exits/payment/PaymentStandardExitable.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentStandardExitable.test.js
@@ -1,0 +1,206 @@
+const PaymentStandardExitable = artifacts.require('PaymentStandardExitable');
+const DummyPlasmaFramework = artifacts.require('DummyPlasmaFramework');
+const DummyVault = artifacts.require('DummyVault');
+const ExitId = artifacts.require('ExitIdWrapper');
+const IsDeposit = artifacts.require('IsDepositWrapper');
+const ExitableTimestamp = artifacts.require('ExitableTimestampWrapper');
+
+const { BN, constants, expectRevert, time } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
+
+const { MerkleTree } = require('../../../helpers/merkle.js');
+const { spentOnGas } = require('../../../helpers/utils.js');
+const Testlang = require('../../../helpers/testlang.js');
+
+
+contract('PaymentStandardExitable', ([_, alice, bob]) => {
+    const STANDARD_EXIT_BOND = 31415926535; // wei
+    const ETH = constants.ZERO_ADDRESS;
+    const CHILD_BLOCK_INTERVAL = 1000;
+    const MIN_EXIT_PERIOD = 60 * 60 * 24 * 7; // 1 week
+
+    const buildTestData = (amount, blockNum) => {
+        const tx = Testlang.deposit(amount, alice, ETH);
+        const utxoPos = Testlang.buildUtxoPos(blockNum, 0, 0);
+        const merkleTree = new MerkleTree([tx], 3);
+        const merkleProof = merkleTree.getInclusionProof(tx);
+
+        return {
+            utxoPos, tx, merkleTree, merkleProof,
+        };
+    };
+
+    describe('startStandardExit', () => {
+        before(async () => {
+            this.exitIdHelper = await ExitId.new();
+            this.isDeposit = await IsDeposit.new(CHILD_BLOCK_INTERVAL);
+            this.exitableHelper = await ExitableTimestamp.new(MIN_EXIT_PERIOD);
+        });
+
+        beforeEach(async () => {
+            this.framework = await DummyPlasmaFramework.new();
+            this.exitGame = await PaymentStandardExitable.new(this.framework.address);
+            this.vault = await DummyVault.new();
+        });
+
+        it('should fail when cannot prove the tx is included in the block', async () => {
+            const testAmount = 1000;
+            const dummyBlockNum = 1000;
+            const data = buildTestData(testAmount, dummyBlockNum);
+            const fakeRoot = web3.utils.sha3('fake root data');
+
+            await this.framework.setBlock(dummyBlockNum, fakeRoot, 0);
+
+            await expectRevert(
+                this.exitGame.startStandardExit(
+                    data.utxoPos, data.tx, data.merkleProof,
+                    { from: alice, value: STANDARD_EXIT_BOND },
+                ),
+                'transaction inclusion proof failed',
+            );
+        });
+
+        it('should fail when exit with amount of 0', async () => {
+            const testAmount = 0;
+            const dummyBlockNum = 1000;
+            const data = buildTestData(testAmount, dummyBlockNum);
+
+            await this.framework.setBlock(dummyBlockNum, data.merkleTree.root, 0);
+
+            await expectRevert(
+                this.exitGame.startStandardExit(
+                    data.utxoPos, data.tx, data.merkleProof,
+                    { from: alice, value: STANDARD_EXIT_BOND },
+                ),
+                'Should not exit with amount 0',
+            );
+        });
+
+        it('should fail when amount of bond is invalid', async () => {
+            const testAmount = 1000;
+            const dummyBlockNum = 1000;
+            const data = buildTestData(testAmount, dummyBlockNum);
+
+            await this.framework.setBlock(dummyBlockNum, data.merkleTree.root, 0);
+
+            const invalidBond = STANDARD_EXIT_BOND - 100;
+            await expectRevert(
+                this.exitGame.startStandardExit(
+                    data.utxoPos, data.tx, data.merkleProof,
+                    { from: alice, value: invalidBond },
+                ),
+                'Input value mismatches with msg.value',
+            );
+        });
+
+        it('should fail when not initiated by the output owner', async () => {
+            const testAmount = 1000;
+            const dummyBlockNum = 1000;
+            const data = buildTestData(testAmount, dummyBlockNum);
+
+            await this.framework.setBlock(dummyBlockNum, data.merkleTree.root, 0);
+
+            const nonOutputOwner = bob;
+            await expectRevert(
+                this.exitGame.startStandardExit(
+                    data.utxoPos, data.tx, data.merkleProof,
+                    { from: nonOutputOwner, value: STANDARD_EXIT_BOND },
+                ),
+                'Only output owner can start an exit',
+            );
+        });
+
+        it('should fail when same exit already started', async () => {
+            const testAmount = 1000;
+            const dummyBlockNum = 1000;
+            const data = buildTestData(testAmount, dummyBlockNum);
+
+            await this.framework.setBlock(dummyBlockNum, data.merkleTree.root, 0);
+
+            await this.exitGame.startStandardExit(
+                data.utxoPos, data.tx, data.merkleProof,
+                { from: alice, value: STANDARD_EXIT_BOND },
+            );
+
+            await expectRevert(
+                this.exitGame.startStandardExit(
+                    data.utxoPos, data.tx, data.merkleProof,
+                    { from: alice, value: STANDARD_EXIT_BOND },
+                ),
+                'Exit already started',
+            );
+        });
+
+        it('should charge the bond for the user', async () => {
+            const testAmount = 1000;
+            const dummyBlockNum = 1000;
+            const data = buildTestData(testAmount, dummyBlockNum);
+
+            await this.framework.setBlock(dummyBlockNum, data.merkleTree.root, 0);
+
+            const preBalance = new BN(await web3.eth.getBalance(alice));
+            const tx = await this.exitGame.startStandardExit(
+                data.utxoPos, data.tx, data.merkleProof,
+                { from: alice, value: STANDARD_EXIT_BOND },
+            );
+            const actualPostBalance = new BN(await web3.eth.getBalance(alice));
+            const expectedPostBalance = preBalance
+                .sub(new BN(STANDARD_EXIT_BOND))
+                .sub(await spentOnGas(tx.receipt));
+
+            expect(actualPostBalance).to.be.bignumber.equal(expectedPostBalance);
+        });
+
+        it('should save the StandardExit data when successfully done', async () => {
+            const testAmount = 1000;
+            const dummyBlockNum = 1000;
+            const data = buildTestData(testAmount, dummyBlockNum);
+
+            await this.framework.setBlock(dummyBlockNum, data.merkleTree.root, 0);
+
+            await this.exitGame.startStandardExit(
+                data.utxoPos, data.tx, data.merkleProof,
+                { from: alice, value: STANDARD_EXIT_BOND },
+            );
+
+            const isTxDeposit = await this.isDeposit.test(dummyBlockNum);
+            const exitId = await this.exitIdHelper.getStandardExitId(isTxDeposit, data.tx, data.utxoPos);
+
+            const standardExitData = await this.exitGame.exits(exitId);
+
+            expect(standardExitData.exitable).to.be.true;
+            expect(standardExitData.position).to.be.bignumber.equal(new BN(data.utxoPos));
+            expect(standardExitData.exitTarget).to.equal(alice);
+            expect(standardExitData.token).to.equal(ETH);
+            expect(standardExitData.amount).to.be.bignumber.equal(new BN(testAmount));
+        });
+
+        it('should put the exit data into the queue of framework', async () => {
+            const testAmount = 1000;
+            const dummyBlockNum = 1000;
+            const data = buildTestData(testAmount, dummyBlockNum);
+            const currentTimestamp = await time.latest();
+            const timestamp = currentTimestamp.sub(new BN(15));
+
+            await this.framework.setBlock(dummyBlockNum, data.merkleTree.root, timestamp);
+
+            await this.exitGame.startStandardExit(
+                data.utxoPos, data.tx, data.merkleProof,
+                { from: alice, value: STANDARD_EXIT_BOND },
+            );
+
+            const isTxDeposit = await this.isDeposit.test(dummyBlockNum);
+            const exitId = await this.exitIdHelper.getStandardExitId(isTxDeposit, data.tx, data.utxoPos);
+            const exitableAt = await this.exitableHelper.calculate(
+                currentTimestamp, timestamp, isTxDeposit,
+            );
+
+            const queueKey = web3.utils.soliditySha3(data.utxoPos, ETH);
+            const queueExitData = await this.framework.testExitQueue(queueKey);
+
+            expect(queueExitData.exitId).to.be.bignumber.equal(exitId);
+            expect(queueExitData.exitProcessor).to.equal(this.exitGame.address);
+            expect(queueExitData.exitableAt).to.be.bignumber.equal(exitableAt);
+        });
+    });
+});

--- a/plasma_framework/test/src/exits/payment/PaymentStandardExitable.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentStandardExitable.test.js
@@ -5,7 +5,9 @@ const ExitId = artifacts.require('ExitIdWrapper');
 const IsDeposit = artifacts.require('IsDepositWrapper');
 const ExitableTimestamp = artifacts.require('ExitableTimestampWrapper');
 
-const { BN, constants, expectRevert, time } = require('openzeppelin-test-helpers');
+const {
+    BN, constants, expectRevert, time,
+} = require('openzeppelin-test-helpers');
 const { expect } = require('chai');
 
 const { MerkleTree } = require('../../../helpers/merkle.js');

--- a/plasma_framework/test/src/exits/utils/ExitId.test.js
+++ b/plasma_framework/test/src/exits/utils/ExitId.test.js
@@ -1,0 +1,54 @@
+const ExitId = artifacts.require('ExitIdWrapper');
+
+const { BN, constants } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
+
+const { PaymentTransaction, PaymentTransactionOutput } = require('../../../helpers/transaction.js');
+
+contract('ExitId', () => {
+    const OUTPUT_GUARD = `0x${Array(64).fill(1).join('')}`;
+    const EMPTY_BYTES32 = `0x${Array(64).fill(0).join('')}`;
+
+    before('setup', async () => {
+        this.contract = await ExitId.new();
+    });
+
+    describe('getStandardExitId', () => {
+        it('should get the correct exit id for deposit tx output', async () => {
+            const output = new PaymentTransactionOutput(100, OUTPUT_GUARD, constants.ZERO_ADDRESS);
+            const transaction = new PaymentTransaction(1, [EMPTY_BYTES32], [output], EMPTY_BYTES32);
+            const dummyTxBytes = web3.utils.bytesToHex(transaction.rlpEncoded());
+
+            const isDeposit = true;
+            const dummyUtxoPos = 1000000000;
+
+            expect(await this.contract.getStandardExitId(isDeposit, dummyTxBytes, dummyUtxoPos))
+                .to.be.bignumber.equal(new BN('1689944644183802670505857770498004820948604745'));
+        });
+
+        it('should return distinct exit ids for deposits that differ only in utxo pos', async () => {
+            const output = new PaymentTransactionOutput(100, OUTPUT_GUARD, constants.ZERO_ADDRESS);
+            const transaction = new PaymentTransaction(1, [EMPTY_BYTES32], [output], EMPTY_BYTES32);
+            const dummyTxBytes = web3.utils.bytesToHex(transaction.rlpEncoded());
+
+            const isDeposit = true;
+            const dummyUtxoPos1 = 1000000000;
+            const dummyUtxoPos2 = 2000000000;
+
+            const exitId1 = await this.contract.getStandardExitId(isDeposit, dummyTxBytes, dummyUtxoPos1);
+            const exitId2 = await this.contract.getStandardExitId(isDeposit, dummyTxBytes, dummyUtxoPos2);
+            expect(exitId1).to.not.equal(exitId2);
+        });
+
+        it('should get the correct exit id for non deposit tx output', async () => {
+            const output = new PaymentTransactionOutput(100, OUTPUT_GUARD, constants.ZERO_ADDRESS);
+            const transaction = new PaymentTransaction(1, [1000000000], [output], EMPTY_BYTES32);
+            const dummyTxBytes = web3.utils.bytesToHex(transaction.rlpEncoded());
+
+            const isDeposit = false;
+            const dummyUtxoPos = 123;
+            expect(await this.contract.getStandardExitId(isDeposit, dummyTxBytes, dummyUtxoPos))
+                .to.be.bignumber.equal(new BN('703552653258022238271278712366387034216770541439'));
+        });
+    });
+});

--- a/plasma_framework/test/src/exits/utils/ExitableTimestamp.test.js
+++ b/plasma_framework/test/src/exits/utils/ExitableTimestamp.test.js
@@ -1,0 +1,40 @@
+const ExitableTimestamp = artifacts.require('ExitableTimestampWrapper');
+
+const { BN, time } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
+
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+
+contract('ExitableTimestamp', () => {
+    const MIN_EXIT_PERIOD = 60 * 60 * 24 * 7; // 1 week
+
+    before('setup', async () => {
+        this.contract = await ExitableTimestamp.new(MIN_EXIT_PERIOD);
+    });
+
+    describe('calculate', () => {
+        it('should get the correct exit timestamp for deposit tx', async () => {
+            const latestTimestamp = await time.latest();
+            await sleep(2000);
+            expect(await this.contract.calculate(latestTimestamp, MIN_EXIT_PERIOD, true))
+                .to.be.bignumber.equal(latestTimestamp.add(new BN(MIN_EXIT_PERIOD)));
+        });
+
+        it('should get the correct exit timestamp for non deposit tx whose age is older than MIN_EXIT_PERIOD', async () => {
+            const latestTimestamp = await time.latest();
+            const oldTimestamp = 0;
+            expect(await this.contract.calculate(latestTimestamp, oldTimestamp, false))
+                .to.be.bignumber.equal(latestTimestamp.add(new BN(MIN_EXIT_PERIOD)));
+        });
+
+        it('should get the correct exit timestamp for non deposit tx whose age is younger than MIN_EXIT_PERIOD', async () => {
+            const latestTimestamp = await time.latest();
+            const youngTimestamp = latestTimestamp - 15;
+            expect(await this.contract.calculate(latestTimestamp, youngTimestamp, false))
+                .to.be.bignumber.equal(new BN(youngTimestamp + 2 * MIN_EXIT_PERIOD));
+        });
+    });
+});

--- a/plasma_framework/test/src/transactions/outputs/PaymentOutputModel.test.js
+++ b/plasma_framework/test/src/transactions/outputs/PaymentOutputModel.test.js
@@ -7,23 +7,31 @@ const PaymentOutputModelMock = artifacts.require('PaymentOutputModelMock');
 
 const OUTPUT_GUARD = `0x${Array(64).fill(1).join('')}`;
 
-contract('PaymentOutputModel', () => {
+contract('PaymentOutputModel', ([alice]) => {
     before(async () => {
         this.test = await PaymentOutputModelMock.new();
     });
 
-    it('should decode output', async () => {
-        const expected = new PaymentTransactionOutput(100, OUTPUT_GUARD, constants.ZERO_ADDRESS);
-        const encoded = web3.utils.bytesToHex(rlp.encode(expected.formatForRlpEncoding()));
+    describe('decode', () => {
+        it('should decode output', async () => {
+            const expected = new PaymentTransactionOutput(100, OUTPUT_GUARD, constants.ZERO_ADDRESS);
+            const encoded = web3.utils.bytesToHex(rlp.encode(expected.formatForRlpEncoding()));
 
-        const output = await this.test.decode(encoded);
-        const actual = PaymentTransactionOutput.parseFromContractOutput(output);
+            const output = await this.test.decode(encoded);
+            const actual = PaymentTransactionOutput.parseFromContractOutput(output);
 
-        expect(JSON.stringify(actual)).to.equal(JSON.stringify(expected));
+            expect(JSON.stringify(actual)).to.equal(JSON.stringify(expected));
+        });
+
+        it('should fail when decoding invalid output', async () => {
+            const encoded = web3.utils.bytesToHex(rlp.encode([0, 0, 0, 0]));
+            await expectRevert(this.test.decode(encoded), 'Invalid output encoding');
+        });
     });
 
-    it('should fail when decoding invalid output', async () => {
-        const encoded = web3.utils.bytesToHex(rlp.encode([0, 0, 0, 0]));
-        await expectRevert(this.test.decode(encoded), 'Invalid output encoding');
+    describe('owner', () => {
+        it('should parse the owner address from output guard when output guard holds the owner info directly', async () => {
+            expect(await this.test.owner(100, alice, constants.ZERO_ADDRESS)).to.equal(alice);
+        });
     });
 });

--- a/plasma_framework/test/src/utils/AddressPayable.test.js
+++ b/plasma_framework/test/src/utils/AddressPayable.test.js
@@ -1,0 +1,32 @@
+const AddressPayable = artifacts.require('AddressPayableWrapper');
+
+const { constants } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
+
+/**
+ * Test cases credit to open zepplin:
+ * https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/test/utils/Address.test.js#L25
+ *
+ * They have the same functionality code but does not release that function in the library.
+ */
+contract('AddressPayable', ([arbitraryAddress]) => {
+    before('setup', async () => {
+        this.contract = await AddressPayable.new();
+    });
+
+    describe('convert', () => {
+        const ALL_ONES_ADDRESS = '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF';
+
+        it('should return a payable address when the account is the zero address', async () => {
+            expect(await this.contract.convert(constants.ZERO_ADDRESS)).to.equal(constants.ZERO_ADDRESS);
+        });
+
+        it('should return a payable address when the account is an arbitrary address', async () => {
+            expect(await this.contract.convert(arbitraryAddress)).to.equal(arbitraryAddress);
+        });
+
+        it('should return a payable address when the account is the all ones address', async () => {
+            expect(await this.contract.convert(ALL_ONES_ADDRESS)).to.equal(ALL_ONES_ADDRESS);
+        });
+    });
+});

--- a/plasma_framework/test/src/utils/IsDeposit.test.js
+++ b/plasma_framework/test/src/utils/IsDeposit.test.js
@@ -1,0 +1,21 @@
+const IsDeposit = artifacts.require('IsDepositWrapper');
+
+const { expect } = require('chai');
+
+contract('IsDeposit', () => {
+    const CHILD_BLOCK_INTERVAL = 1000;
+
+    before('setup', async () => {
+        this.contract = await IsDeposit.new(CHILD_BLOCK_INTERVAL);
+    });
+
+    describe('test', () => {
+        it('should return true when it is a deposit block', async () => {
+            expect(await this.contract.test(1)).to.be.true;
+        });
+
+        it('should return false when it is not a deposit block', async () => {
+            expect(await this.contract.test(CHILD_BLOCK_INTERVAL)).to.be.false;
+        });
+    });
+});

--- a/plasma_framework/test/src/utils/OnlyWithValue.test.js
+++ b/plasma_framework/test/src/utils/OnlyWithValue.test.js
@@ -1,0 +1,29 @@
+const OnlyWithValue = artifacts.require('OnlyWithValueMock');
+
+const { expectRevert, expectEvent } = require('openzeppelin-test-helpers');
+
+contract('OnlyWithValue', () => {
+    beforeEach(async () => {
+        this.contract = await OnlyWithValue.new();
+    });
+
+    describe('onlyWithValue', () => {
+        it('should accept call when the value matches', async () => {
+            const testValue = 100;
+            const { receipt } = await this.contract.checkOnlyWithValue(testValue, { value: testValue });
+            await expectEvent.inTransaction(
+                receipt.transactionHash,
+                OnlyWithValue,
+                'OnlyWithValuePassed',
+                {},
+            );
+        });
+
+        it('should reject call when value mismatches', async () => {
+            await expectRevert(
+                this.contract.checkOnlyWithValue(100, { value: 200 }),
+                'Input value mismatches with msg.value',
+            );
+        });
+    });
+});

--- a/plasma_framework/test/src/utils/TxPosLib.test.js
+++ b/plasma_framework/test/src/utils/TxPosLib.test.js
@@ -1,0 +1,30 @@
+const TxPosLib = artifacts.require('TxPosLibWrapper');
+
+const { BN } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
+
+contract('TxPosLib', () => {
+    before('setup lib and tx pos values', async () => {
+        this.contract = await TxPosLib.new();
+
+        this.blockNumber = 314159;
+        this.txIndex = 123;
+
+        const BLOCK_OFFSET_OF_TX_POS = 1000000000 / 10000;
+        this.txPos = this.blockNumber * BLOCK_OFFSET_OF_TX_POS + this.txIndex ;
+    });
+
+    describe('blockNum', () => {
+        it('should parse the correct block number', async () => {
+            expect(await this.contract.blockNum(this.txPos))
+                .to.be.bignumber.equal(new BN(this.blockNumber));
+        });
+    });
+
+    describe('txIndex', () => {
+        it('should parse the correct tx index', async () => {
+            expect(await this.contract.txIndex(this.txPos))
+                .to.be.bignumber.equal(new BN(this.txIndex));
+        });
+    });
+});

--- a/plasma_framework/test/src/utils/TxPosLib.test.js
+++ b/plasma_framework/test/src/utils/TxPosLib.test.js
@@ -11,7 +11,7 @@ contract('TxPosLib', () => {
         this.txIndex = 123;
 
         const BLOCK_OFFSET_OF_TX_POS = 1000000000 / 10000;
-        this.txPos = this.blockNumber * BLOCK_OFFSET_OF_TX_POS + this.txIndex ;
+        this.txPos = this.blockNumber * BLOCK_OFFSET_OF_TX_POS + this.txIndex;
     });
 
     describe('blockNum', () => {

--- a/plasma_framework/test/src/utils/UtxoPosLib.test.js
+++ b/plasma_framework/test/src/utils/UtxoPosLib.test.js
@@ -40,8 +40,8 @@ contract('UtxoPosLib', () => {
 
     describe('txPos', () => {
         it('should parse the correct tx position', async () => {
-            expect(await this.contract.txPos(this.utxoPos))
-                .to.be.bignumber.equal(new BN(this.txPos));
+            const txPos = await this.contract.txPos(this.utxoPos);
+            expect(new BN(txPos.value)).to.be.bignumber.equal(new BN(this.txPos));
         });
     });
 });

--- a/plasma_framework/test/src/vaults/EthVault.test.js
+++ b/plasma_framework/test/src/vaults/EthVault.test.js
@@ -5,8 +5,9 @@ const EthDepositVerifier = artifacts.require('EthDepositVerifier');
 const { BN, constants, expectRevert } = require('openzeppelin-test-helpers');
 const { expect } = require('chai');
 
-const Testlang = require('../../helpers/testlang.js');
 const { PaymentTransaction, PaymentTransactionOutput } = require('../../helpers/transaction.js');
+const { spentOnGas } = require('../../helpers/utils.js');
+const Testlang = require('../../helpers/testlang.js');
 
 contract('EthVault', ([_, alice]) => {
     const DEPOSIT_VALUE = 1000000;
@@ -107,8 +108,3 @@ contract('EthVault', ([_, alice]) => {
         });
     });
 });
-
-async function spentOnGas(receipt) {
-    const tx = await web3.eth.getTransaction(receipt.transactionHash);
-    return web3.utils.toBN(tx.gasPrice).muln(receipt.gasUsed);
-}


### PR DESCRIPTION
### Note
- I decide to move all `PaymentExitGame` related to a folder together instead of the style in POC. This would be easier to expend our folder structure for new tx types in the future.
- Instead of a single `PaymentExitGame` file, I decided to put standard exit related function all together in `PaymentStandardExitable` and make it a mixin. Since we don't need to cross check IFE and SE during the game process anymore (only check input/output finalization when `processExit`), I think this makes sense to do so.
- I tried to manage the git commit for each new contract/library. Should be able to follow the commit for code review. Sorry for a large code PR.
- I experimented different test style for `PaymentExitGame - End to End Tests` and   `PaymentStandardExitable`. Would like to hear how do people like this or not? This was what in my mind to have two types of tests.

close #135 

### Test
truffle test
```
  Contract: AddressPayable
    convert
      ✓ should return a payable address when the account is the zero address
      ✓ should return a payable address when the account is an arbitrary address
      ✓ should return a payable address when the account is the all ones address

  Contract: IsDeposit
    test
      ✓ should return true when it is a deposit block (38ms)
      ✓ should return false when it is not a deposit block

  Contract: OnlyWithValue
    onlyWithValue
      ✓ should accept call when the value matches (54ms)
      ✓ should reject call when value mismatches (57ms)

  Contract: TxPosLib
    blockNum
      ✓ should parse the correct block number
    txIndex
      ✓ should parse the correct tx index (42ms)

  Contract: PaymentExitGame - End to End Tests
    Given contracts deployed, exit game and ETH vault registered
      Given alice deposited
        When alice starts standard exit on the deposit tx
          ✓ should saves the StandardExit data when successfully done
          ✓ should put the exit data into the queue of framework (42ms)
      Given alice deposited and transfered to bob
        When bob tries to start the standard exit on the transfered tx
          ✓ should start successully
      Given alice deposited and transfered to bob
        When alice tries to start the standard exit on the deposit tx
          ✓ should still be able to start standard exit even already spent
          Then bob can challenge the standard exit spent
            ✓ TODO:  should challenges it successfully

  Contract: PaymentStandardExitable
    startStandardExit
      ✓ should fail when cannot prove the tx is included in the block (158ms)
      ✓ should fail when exit with amount of 0 (154ms)
      ✓ should fail when amount of bond is invalid (66ms)
      ✓ should fail when not initiated by the output owner (168ms)
      ✓ should fail when same exit already started (248ms)
      ✓ should saves the StandardExit data when successfully done (168ms)
      ✓ should put the exit data into the queue of framework (194ms)

  Contract: ExitId
    getStandardExitId
      ✓ should get the correct exit id for deposit tx output
      ✓ should not conflict with same exit id when two deposit txs with same output but different utxo pos (56ms)
      ✓ should get the correct exit id for non deposit tx output

  Contract: ExitableTimestamp
    calculate
      ✓ should get the correct exit timestamp for deposit tx
      ✓ should get the correct exit timestamp for non deposit tx whose age is older than MIN_EXIT_PERIOD
      ✓ should get the correct exit timestamp for non deposit tx whose age is younger than MIN_EXIT_PERIOD
```