### PR TITLE
refactor: optimize gas cost when starting standard payment exit

### DIFF
--- a/plasma_framework/contracts/src/exits/payment/PaymentStandardExitable.sol
+++ b/plasma_framework/contracts/src/exits/payment/PaymentStandardExitable.sol
@@ -115,25 +115,24 @@ contract PaymentStandardExitable is OnlyWithValue {
         private
         view
     {
+        require(data.output.amount > 0, "Should not exit with amount 0");
+        require(data.output.owner() == msg.sender, "Only output owner can start an exit");
+        require(exits[data.exitId].exitable == false, "Exit already started");
         bytes32 leafData = keccak256(data.rlpTx);
         require(
             Merkle.checkMembership(leafData, data.utxoPos.txIndex(), data.txBlockRoot, data.txInclusionProof),
             "transaction inclusion proof failed"
         );
-        require(data.output.amount > 0, "Should not exit with amount 0");
-        require(data.output.owner() == msg.sender, "Only output owner can start an exit");
-        require(exits[data.exitId].exitable == false, "Exit already started");
     }
 
     function saveStandardExitData(StartStandardExitData memory data) private {
-        PaymentExitDataModel.StandardExit memory exitData = PaymentExitDataModel.StandardExit({
+        exits[data.exitId] = PaymentExitDataModel.StandardExit({
             exitable: true,
             position: uint192(data.utxoPos.value),
             token: data.output.token,
             exitTarget: data.output.owner(),
             amount: data.output.amount
         });
-        exits[data.exitId] = exitData;
     }
 
     function enqueueStandardExit(StartStandardExitData memory data) private {

--- a/plasma_framework/test/src/exits/utils/ExitableTimestamp.test.js
+++ b/plasma_framework/test/src/exits/utils/ExitableTimestamp.test.js
@@ -3,11 +3,6 @@ const ExitableTimestamp = artifacts.require('ExitableTimestampWrapper');
 const { BN, time } = require('openzeppelin-test-helpers');
 const { expect } = require('chai');
 
-function sleep(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-
 contract('ExitableTimestamp', () => {
     const MIN_EXIT_PERIOD = 60 * 60 * 24 * 7; // 1 week
 
@@ -18,7 +13,6 @@ contract('ExitableTimestamp', () => {
     describe('calculate', () => {
         it('should get the correct exit timestamp for deposit tx', async () => {
             const latestTimestamp = await time.latest();
-            await sleep(2000);
             expect(await this.contract.calculate(latestTimestamp, MIN_EXIT_PERIOD, true))
                 .to.be.bignumber.equal(latestTimestamp.add(new BN(MIN_EXIT_PERIOD)));
         });


### PR DESCRIPTION
Applying gas cost optimizations suggested by @kevsul:
 - change order of verifying that start of payment exit is valid, call most costly `require` as the last one
 - do not use a temporary memory variable and put a structure directly into storage