### PR TITLE
fix: registery require non-empty key and value

### DIFF
--- a/plasma_framework/contracts/src/framework/registries/ExitGameRegistry.sol
+++ b/plasma_framework/contracts/src/framework/registries/ExitGameRegistry.sol
@@ -17,6 +17,8 @@ contract ExitGameRegistry is Operated {
      * @param _contract Address of the exit game contract.
      */
     function registerExitGame(uint256 _txType, address _contract) public onlyOperator {
+        require(_txType != 0, "should not register with tx type 0");
+        require(_contract != address(0), "should not register with an empty exit game address");
         require(_exitGames[_txType] == address(0), "The tx type is already registered");
         require(_exitGameToTxType[_contract] == 0, "The exit game contract is already registered");
 

--- a/plasma_framework/contracts/src/framework/registries/VaultRegistry.sol
+++ b/plasma_framework/contracts/src/framework/registries/VaultRegistry.sol
@@ -17,6 +17,8 @@ contract VaultRegistry is Operated {
      * @param _vaultAddress address of the vault contract.
      */
     function registerVault(uint256 _vaultId, address _vaultAddress) public onlyOperator {
+        require(_vaultId != 0, "should not register with vault id 0");
+        require(_vaultAddress != address(0), "should not register an empty vault address");
         require(_vaults[_vaultId] == address(0), "The vault id is already registered");
         require(_vaultToId[_vaultAddress] == 0, "The vault contract is already registered");
 

--- a/plasma_framework/test/src/framework/registries/ExitGameRegistry.test.js
+++ b/plasma_framework/test/src/framework/registries/ExitGameRegistry.test.js
@@ -1,7 +1,9 @@
 const ExitGameRegistry = artifacts.require('ExitGameRegistryMock');
 const DummyExitGame = artifacts.require('DummyExitGame');
 
-const { BN, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
+const {
+    BN, constants, expectEvent, expectRevert,
+} = require('openzeppelin-test-helpers');
 const { expect } = require('chai');
 
 contract('ExitGameRegistry', ([_, other]) => {
@@ -71,6 +73,20 @@ contract('ExitGameRegistry', ([_, other]) => {
             await expectRevert(
                 this.registry.registerExitGame(1, this.dummyExitGame.address, { from: other }),
                 'Not being called by operator',
+            );
+        });
+
+        it('rejects when trying to register with tx type 0', async () => {
+            await expectRevert(
+                this.registry.registerExitGame(0, this.dummyExitGame.address),
+                'should not register with tx type 0',
+            );
+        });
+
+        it('rejects when trying to register with empty address', async () => {
+            await expectRevert(
+                this.registry.registerExitGame(1, constants.ZERO_ADDRESS),
+                'should not register with an empty exit game address',
             );
         });
 

--- a/plasma_framework/test/src/framework/registries/VaultRegistry.test.js
+++ b/plasma_framework/test/src/framework/registries/VaultRegistry.test.js
@@ -1,7 +1,9 @@
 const VaultRegistry = artifacts.require('VaultRegistryMock');
 const DummyVault = artifacts.require('DummyVault');
 
-const { BN, expectEvent, expectRevert } = require('openzeppelin-test-helpers');
+const {
+    BN, constants, expectEvent, expectRevert,
+} = require('openzeppelin-test-helpers');
 const { expect } = require('chai');
 
 contract('VaultRegistry', ([_, other]) => {
@@ -71,6 +73,20 @@ contract('VaultRegistry', ([_, other]) => {
             await expectRevert(
                 this.registry.registerVault(1, this.dummyVault.address, { from: other }),
                 'Not being called by operator',
+            );
+        });
+
+        it('rejects when trying to register with vault id 0', async () => {
+            await expectRevert(
+                this.registry.registerVault(0, this.dummyVault.address),
+                'should not register with vault id 0',
+            );
+        });
+
+        it('rejects when trying to register with an empty vault address', async () => {
+            await expectRevert(
+                this.registry.registerVault(1, constants.ZERO_ADDRESS),
+                'should not register an empty vault address',
             );
         });
 


### PR DESCRIPTION
### Note
We rely on empty value to check whether contracts are whitelisted/registered. Being able to register with empty value would break the assumption.

### Test
truffle test
```
Contract: ExitGameRegistry
    registerExitGame
      ✓ rejects when trying to register with tx type 0
      ✓ rejects when trying to register with empty address

Contract: VaultRegistry
    registerVault
      ✓ rejects when trying to register with vault id 0 (39ms)
      ✓ rejects when trying to register with an empty vault address (39ms)
```