### PR TITLE
draft: output guard + output predicate in challenge

### DIFF
--- a/plasma_framework/contracts/mocks/exits/DummyOutputGuardParser.sol
+++ b/plasma_framework/contracts/mocks/exits/DummyOutputGuardParser.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.5.0;
+
+import "../../src/exits/IOutputGuardParser.sol";
+
+contract DummyOutputGuardParser is IOutputGuardParser {
+    address payable resultAddress;
+
+    constructor(address payable _resultAddress) public {
+        resultAddress = _resultAddress;
+    }
+
+    function parseExitTarget(bytes calldata)
+        external
+        view
+        returns (address payable)
+    {
+        return resultAddress;
+    }
+}

--- a/plasma_framework/contracts/mocks/exits/payment/PaymentStandardExitableMock.sol
+++ b/plasma_framework/contracts/mocks/exits/payment/PaymentStandardExitableMock.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+import "../../../src/exits/payment/PaymentStandardExitable.sol";
+
+contract PaymentStandardExitableMock is PaymentStandardExitable {
+    constructor(address _framework) public PaymentStandardExitable(_framework) {}
+
+    // to make contract not abstract
+    function processExit(uint256 _exitId) external {}
+
+    /** helper functions for testing */
+
+    function setExit(uint192 _exitId, PaymentExitDataModel.StandardExit memory _exitData) public {
+        PaymentStandardExitable.exits[_exitId] = _exitData;
+    }
+
+    function depositFundForTest() public payable {}
+}

--- a/plasma_framework/contracts/mocks/exits/payment/spendingConditions/PaymentSpendindConditionTrue.sol
+++ b/plasma_framework/contracts/mocks/exits/payment/spendingConditions/PaymentSpendindConditionTrue.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.5.0;
+
+import "../../../../src/exits/payment/spendingConditions/IPaymentSpendingCondition.sol";
+
+contract PaymentSpendingConditionTrue is IPaymentSpendingCondition {
+    function verify(
+        bytes32,
+        uint256,
+        bytes32,
+        bytes calldata,
+        uint8,
+        bytes calldata
+    ) external view returns (bool) {
+        return true;
+    }
+}

--- a/plasma_framework/contracts/mocks/exits/payment/spendingConditions/PaymentSpendingConditionExpected.sol
+++ b/plasma_framework/contracts/mocks/exits/payment/spendingConditions/PaymentSpendingConditionExpected.sol
@@ -1,0 +1,42 @@
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+import "../../../../src/exits/payment/spendingConditions/IPaymentSpendingCondition.sol";
+
+contract PaymentSpendingConditionExpected is IPaymentSpendingCondition {
+    Expected expected;
+    struct Expected {
+        bytes32 outputGuard;
+        uint256 utxoPos;
+        bytes32 outputId;
+        bytes consumeTx;
+        uint8 inputIndex;
+        bytes witness;
+    }
+
+    function setExpected(Expected memory _expected) public {
+        expected = _expected;
+    }
+
+    function verify(
+        bytes32 _outputGuard,
+        uint256 _utxoPos,
+        bytes32 _outputId,
+        bytes calldata _consumeTx,
+        uint8 _inputIndex,
+        bytes calldata _witness
+    ) external view returns (bool) {
+        require(expected.outputGuard == _outputGuard, "output guard not as expected");
+        require(expected.utxoPos == _utxoPos, "utxo pos not as expected");
+        require(expected.outputId == _outputId, "output id not as expected");
+        require(compareBytes(expected.consumeTx, _consumeTx), "consume tx not as expected");
+        require(expected.inputIndex == _inputIndex, "input index not as expected");
+        require(compareBytes(expected.witness, _witness), "witness not as expected");
+
+        return true;
+    }
+
+    function compareBytes(bytes memory a, bytes memory b) private pure returns (bool) {
+        return keccak256(abi.encodePacked(a)) == keccak256(abi.encodePacked(b));
+    }
+}

--- a/plasma_framework/contracts/mocks/exits/payment/spendingConditions/PaymentSpendingConditionFalse.sol
+++ b/plasma_framework/contracts/mocks/exits/payment/spendingConditions/PaymentSpendingConditionFalse.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.5.0;
+
+import "../../../../src/exits/payment/spendingConditions/IPaymentSpendingCondition.sol";
+
+contract PaymentSpendingConditionFalse is IPaymentSpendingCondition {
+    function verify(
+        bytes32,
+        uint256,
+        bytes32,
+        bytes calldata,
+        uint8,
+        bytes calldata
+    ) external view returns (bool) {
+        return false;
+    }
+}

--- a/plasma_framework/contracts/mocks/exits/payment/spendingConditions/PaymentSpendingConditionRevert.sol
+++ b/plasma_framework/contracts/mocks/exits/payment/spendingConditions/PaymentSpendingConditionRevert.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.5.0;
+
+import "../../../../src/exits/payment/spendingConditions/IPaymentSpendingCondition.sol";
+
+contract PaymentSpendingConditionRevert is IPaymentSpendingCondition {
+    string constant public revertMessage = "testing payment spending condition reverts";
+
+    function verify(
+        bytes32,
+        uint256,
+        bytes32,
+        bytes calldata,
+        uint8,
+        bytes calldata
+    ) external view returns (bool) {
+        require(false, revertMessage);
+    }
+}

--- a/plasma_framework/contracts/mocks/exits/utils/OutputGuardWrapper.sol
+++ b/plasma_framework/contracts/mocks/exits/utils/OutputGuardWrapper.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.5.0;
+
+import "../../../src/exits/utils/OutputGuard.sol";
+
+contract OutputGuardWrapper {
+    function build(
+        uint256 _outputType,
+        bytes memory _outputGuardData
+    )
+        public
+        pure
+        returns (bytes32)
+    {
+        return OutputGuard.build(_outputType, _outputGuardData);
+    }
+}

--- a/plasma_framework/contracts/mocks/exits/utils/OutputIdWrapper.sol
+++ b/plasma_framework/contracts/mocks/exits/utils/OutputIdWrapper.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.5.0;
+
+import "../../../src/exits/utils/OutputId.sol";
+
+contract OutputIdWrapper {
+    function compute(
+        bool _isDeposit,
+        bytes memory _txBytes,
+        uint8 _outputIndex,
+        uint256 _utxoPosValue
+    )
+        public
+        pure
+        returns (bytes32)
+    {
+        return OutputId.compute(_isDeposit, _txBytes, _outputIndex, _utxoPosValue);
+    }
+}

--- a/plasma_framework/contracts/mocks/transactions/eip712Libs/PaymentEip712LibMock.sol
+++ b/plasma_framework/contracts/mocks/transactions/eip712Libs/PaymentEip712LibMock.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.5.0;
+
+import "../../../src/transactions/eip712Libs/PaymentEip712Lib.sol";
+import "../../../src/transactions/PaymentTransactionModel.sol";
+
+contract PaymentEip712LibMock {
+    function hashTx(address _verifyingContract, bytes memory _rlpTx)
+        public
+        pure
+        returns (bytes32)
+    {
+        PaymentEip712Lib.Constants memory eip712 = PaymentEip712Lib.initConstants(_verifyingContract);
+        return PaymentEip712Lib.hashTx(eip712, PaymentTransactionModel.decode(_rlpTx));
+    }
+}

--- a/plasma_framework/contracts/mocks/utils/FreezableMock.sol
+++ b/plasma_framework/contracts/mocks/utils/FreezableMock.sol
@@ -1,0 +1,12 @@
+pragma solidity ^0.5.0;
+
+import "../../src/utils/Freezable.sol";
+
+contract FreezableMock is Freezable {
+
+    event OnlyNonFrozenChecked();
+
+    function checkOnlyNotFrozen() public onlyNonFrozen {
+        emit OnlyNonFrozenChecked();
+    }
+}

--- a/plasma_framework/contracts/src/exits/IOutputGuardParser.sol
+++ b/plasma_framework/contracts/src/exits/IOutputGuardParser.sol
@@ -1,0 +1,8 @@
+pragma solidity ^0.5.0;
+
+interface IOutputGuardParser {
+    /**
+    * @notice This parses the 'exit target' data out from the output guard data.
+    */
+    function parseExitTarget(bytes calldata _outputGuardData) external view returns (address payable);
+}

--- a/plasma_framework/contracts/src/exits/OutputGuardParserRegistry.sol
+++ b/plasma_framework/contracts/src/exits/OutputGuardParserRegistry.sol
@@ -1,0 +1,30 @@
+pragma solidity ^0.5.0;
+
+import "./IOutputGuardParser.sol";
+import "../utils/Freezable.sol";
+import "../framework/utils/Operated.sol";
+
+contract OutputGuardParserRegistry is Operated, Freezable {
+    mapping(uint256 => IOutputGuardParser) private _outputGuardParsers;
+
+    function outputGuardParsers(uint256 _outputType) public view returns (IOutputGuardParser) {
+        return _outputGuardParsers[_outputType];
+    }
+
+    /**
+     * @notice Register the output parser.
+     * @param _outputType output type that the parser is registered with.
+     * @param _parserAddress Address of the output parser.
+     */
+    function registerOutputGuardParser(uint256 _outputType, address _parserAddress)
+        public
+        onlyOperator
+        onlyNonFrozen
+    {
+        require(_outputType != 0, "Should not register with output type 0");
+        require(_parserAddress != address(0), "Should not register an empty address");
+        require(address(_outputGuardParsers[_outputType]) == address(0), "The output type has already been registered");
+
+        _outputGuardParsers[_outputType] = IOutputGuardParser(_parserAddress);
+    }
+}

--- a/plasma_framework/contracts/src/exits/payment/PaymentExitDataModel.sol
+++ b/plasma_framework/contracts/src/exits/payment/PaymentExitDataModel.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.5.0;
 library PaymentExitDataModel {
     struct StandardExit {
         bool exitable;
-        uint192 position;
+        bytes32 outputRelatedDataHash;
         address token;
         address payable exitTarget;
         uint256 amount;

--- a/plasma_framework/contracts/src/exits/payment/PaymentStandardExitable.sol
+++ b/plasma_framework/contracts/src/exits/payment/PaymentStandardExitable.sol
@@ -2,9 +2,16 @@ pragma solidity ^0.5.0;
 pragma experimental ABIEncoderV2;
 
 import "./PaymentExitDataModel.sol";
+import "./spendingConditions/IPaymentSpendingCondition.sol";
+import "./spendingConditions/PaymentSpendingConditionRegistry.sol";
+import "../IOutputGuardParser.sol";
+import "../OutputGuardParserRegistry.sol";
 import "../utils/ExitId.sol";
 import "../utils/ExitableTimestamp.sol";
+import "../utils/OutputId.sol";
+import "../utils/OutputGuard.sol";
 import "../../framework/interfaces/IPlasmaFramework.sol";
+import "../../framework/interfaces/IExitProcessor.sol";
 import "../../framework/models/ExitModel.sol";
 import "../../utils/IsDeposit.sol";
 import "../../utils/OnlyWithValue.sol";
@@ -14,7 +21,12 @@ import "../../utils/Merkle.sol";
 import "../../transactions/PaymentTransactionModel.sol";
 import "../../transactions/outputs/PaymentOutputModel.sol";
 
-contract PaymentStandardExitable is OnlyWithValue {
+contract PaymentStandardExitable is
+    IExitProcessor,
+    OnlyWithValue,
+    OutputGuardParserRegistry,
+    PaymentSpendingConditionRegistry
+{
     using PaymentOutputModel for PaymentOutputModel.Output;
     using UtxoPosLib for UtxoPosLib.UtxoPos;
     using TxPosLib for TxPosLib.TxPos;
@@ -28,24 +40,69 @@ contract PaymentStandardExitable is OnlyWithValue {
     IsDeposit.Predicate private isDeposit;
     ExitableTimestamp.Calculator private exitableTimestampCalculator;
 
+    struct StartStandardExitInputData {
+        uint192 utxoPos;
+        bytes rlpOutputTx;
+        uint256 outputType;
+        bytes outputGuardData;
+        bytes outputTxInclusionProof;
+    }
+
     /**
-    @dev data to be passed around startStandardExit helper functions
+     * @dev data to be passed around startStandardExit helper functions
      */
     struct StartStandardExitData {
+        StartStandardExitInputData input;
         UtxoPosLib.UtxoPos utxoPos;
         PaymentTransactionModel.Transaction outputTx;
         PaymentOutputModel.Output output;
+        address outputGuardParser;
+        address payable exitTarget;
         uint192 exitId;
         bool isTxDeposit;
-        bytes txInclusionProof;
-        bytes rlpTx;
         bytes32 txBlockRoot;
         uint256 txBlockTimeStamp;
+    }
+
+    /**
+     * @notice input data for challengeStandardExit.
+     * @param _exitId Identifier of the standard exit to challenge.
+     * @param _outputType The output type of the exiting output.
+     * @param _outputUtxoPos The utxo position of the exiting output.
+     * @param _outputId The unique id of exiting output.
+     * @param _outputGuardData (optional) The output guard data of the output. Could be empty when output type is 0.
+     * @param _challengeTxType The tx type if the challenge transaction.
+     * @param _challengeTx RLP encoded transaction that spends the exiting output.
+     * @param _inputIndex Which input of the challenging tx corresponds to the exiting output.
+     * @param _witness Witness data that can prove the exiting output is spent.
+     */
+    struct ChallengeStandardExitInputData {
+        uint192 exitId;
+        uint256 outputType;
+        uint256 outputUtxoPos;
+        bytes32 outputId;
+        bytes32 outputGuard;
+        uint256 challengeTxType;
+        bytes challengeTx;
+        uint8 inputIndex;
+        bytes witness;
+    }
+
+    /**
+     * @dev data to be passed around challengeStandardExit helper functions
+     */
+    struct ChallengeStandardExitData {
+        ChallengeStandardExitInputData input;
+        PaymentExitDataModel.StandardExit exitData;
     }
 
     event ExitStarted(
         address indexed owner,
         uint192 exitId
+    );
+
+    event ExitChallenged(
+        uint256 indexed utxoPos
     );
 
     constructor(address _framework) public {
@@ -58,54 +115,100 @@ contract PaymentStandardExitable is OnlyWithValue {
      * @notice Starts a standard withdrawal of a given output. Uses output-age priority.
      * @dev requires the exiting UTXO's token to be added via 'addToken'
      * @param _utxoPos Position of the exiting output.
-     * @param _outputTx RLP encoded transaction that created the exiting output.
+     * @param _rlpOutputTx RLP encoded transaction that created the exiting output.
+     * @param _outputType Specific type of the output.
+     * @param _outputGuardData (Optional) Output guard data if the output type is not 0.
      * @param _outputTxInclusionProof A Merkle proof showing that the transaction was included.
      */
     function startStandardExit(
         uint192 _utxoPos,
-        bytes calldata _outputTx,
+        bytes calldata _rlpOutputTx,
+        uint256 _outputType,
+        bytes calldata _outputGuardData,
         bytes calldata _outputTxInclusionProof
     )
         external
         payable
         onlyWithValue(standardExitBond)
     {
-        StartStandardExitData memory data = setupStartStandardExitData(_utxoPos, _outputTx, _outputTxInclusionProof);
+        StartStandardExitInputData memory input = StartStandardExitInputData({
+            utxoPos: _utxoPos,
+            rlpOutputTx: _rlpOutputTx,
+            outputType: _outputType,
+            outputGuardData: _outputGuardData,
+            outputTxInclusionProof: _outputTxInclusionProof
+        });
+
+        StartStandardExitData memory data = setupStartStandardExitData(input);
         verifyStartStandardExitData(data);
         saveStandardExitData(data);
         enqueueStandardExit(data);
 
-        emit ExitStarted(data.output.owner(), data.exitId);
+        emit ExitStarted(data.exitTarget, data.exitId);
     }
 
     /**
-    Private functions
+     * @notice Challenge a standard exit by showing the exiting output was spent.
+     * @dev Uses struct as input because too many variables and failed to compile.
+     * @dev Uses public instead of external because ABIEncoder V2 cannot uses struct calldata + external
+     * @param _input input data to challenge. See struct 'ChallengeStandardExitInputData' for detailed param info.
+     */
+    function challengeStandardExit(ChallengeStandardExitInputData memory _input)
+        public
+        payable
+    {
+        ChallengeStandardExitData memory data = ChallengeStandardExitData({
+            input: _input,
+            exitData: exits[_input.exitId]
+        });
+        verifyChallengeExitExists(data);
+        verifyOutputRelatedDataHash(data);
+        verifySpendingCondition(data);
+
+        delete exits[_input.exitId];
+        msg.sender.transfer(standardExitBond);
+
+        emit ExitChallenged(_input.outputUtxoPos);
+    }
+
+    /**
+    Start standard exit helper functions
     */
 
-    function setupStartStandardExitData(
-        uint192 _utxoPos,
-        bytes memory _outputTx,
-        bytes memory _txInclusionProof
-    )
+    function setupStartStandardExitData(StartStandardExitInputData memory input)
         private
         view
         returns (StartStandardExitData memory)
     {
-        UtxoPosLib.UtxoPos memory utxoPos = UtxoPosLib.UtxoPos(_utxoPos);
-        PaymentTransactionModel.Transaction memory outputTx = PaymentTransactionModel.decode(_outputTx);
+        UtxoPosLib.UtxoPos memory utxoPos = UtxoPosLib.UtxoPos(input.utxoPos);
+        PaymentTransactionModel.Transaction memory outputTx = PaymentTransactionModel.decode(input.rlpOutputTx);
         PaymentOutputModel.Output memory output = outputTx.outputs[utxoPos.outputIndex()];
         bool isTxDeposit = isDeposit.test(utxoPos.blockNum());
-        uint192 exitId = ExitId.getStandardExitId(isTxDeposit, _outputTx, utxoPos);
+        uint192 exitId = ExitId.getStandardExitId(isTxDeposit, input.rlpOutputTx, utxoPos);
         (bytes32 root, uint256 blockTimestamp) = framework.blocks(utxoPos.blockNum());
+        bytes memory outputGuardData = input.outputType == 0 ? bytes("") : input.outputGuardData;
+
+        address payable exitTarget;
+        IOutputGuardParser outputGuardParser;
+        if (input.outputType == 0) {
+            // output type 0 --> output holding owner address directly
+            exitTarget = output.owner();
+        } else if (input.outputType != 0) {
+            outputGuardParser = OutputGuardParserRegistry.outputGuardParsers(input.outputType);
+            if (address(outputGuardParser) != address(0)) {
+                exitTarget = outputGuardParser.parseExitTarget(outputGuardData);
+            }
+        }
 
         return StartStandardExitData({
+            input: input,
             utxoPos: utxoPos,
             outputTx: outputTx,
             output: output,
+            outputGuardParser: address(outputGuardParser),
+            exitTarget: exitTarget,
             exitId: exitId,
             isTxDeposit: isTxDeposit,
-            txInclusionProof: _txInclusionProof,
-            rlpTx: _outputTx,
             txBlockRoot: root,
             txBlockTimeStamp: blockTimestamp
         });
@@ -116,21 +219,39 @@ contract PaymentStandardExitable is OnlyWithValue {
         view
     {
         require(data.output.amount > 0, "Should not exit with amount 0");
-        require(data.output.owner() == msg.sender, "Only output owner can start an exit");
+
+        if (data.input.outputType != 0) {
+            bytes32 outputGuardFromPreImage = OutputGuard.build(data.input.outputType, data.input.outputGuardData);
+            require(data.output.outputGuard == outputGuardFromPreImage, "Output guard data mismatch pre-image");
+            require(data.outputGuardParser != address(0), "Failed to get the output guard parser for the output type");
+        }
+
+        require(data.exitTarget == msg.sender, "Only exit target can start an exit");
         require(exits[data.exitId].exitable == false, "Exit already started");
-        bytes32 leafData = keccak256(data.rlpTx);
+
+        bytes32 leafData = keccak256(data.input.rlpOutputTx);
         require(
-            Merkle.checkMembership(leafData, data.utxoPos.txIndex(), data.txBlockRoot, data.txInclusionProof),
+            Merkle.checkMembership(
+                leafData, data.utxoPos.txIndex(), data.txBlockRoot, data.input.outputTxInclusionProof
+            ),
             "transaction inclusion proof failed"
         );
     }
 
     function saveStandardExitData(StartStandardExitData memory data) private {
+        bytes32 outputId = OutputId.compute(
+            data.isTxDeposit, data.input.rlpOutputTx, data.utxoPos.outputIndex(), data.utxoPos.value
+        );
+
+        bytes32 outputRelatedDataHash = keccak256(
+            abi.encodePacked(data.utxoPos.value, outputId, data.input.outputType, data.output.outputGuard)
+        );
+
         exits[data.exitId] = PaymentExitDataModel.StandardExit({
             exitable: true,
-            position: uint192(data.utxoPos.value),
+            outputRelatedDataHash: outputRelatedDataHash,
             token: data.output.token,
-            exitTarget: data.output.owner(),
+            exitTarget: data.exitTarget,
             amount: data.output.amount
         });
     }
@@ -148,5 +269,42 @@ contract PaymentStandardExitable is OnlyWithValue {
         });
 
         framework.enqueue(priority, data.output.token, exitDataForQueue);
+    }
+
+    /**
+    Challenge standard exit helper functions
+    */
+
+    function verifyChallengeExitExists(ChallengeStandardExitData memory data) private pure {
+        require(data.exitData.exitable == true, "Such exit does not exists");
+    }
+
+    function verifyOutputRelatedDataHash(ChallengeStandardExitData memory data) private pure {
+        ChallengeStandardExitInputData memory input = data.input;
+        bytes32 outputRelatedDataHash = keccak256(
+            abi.encodePacked(input.outputUtxoPos, input.outputId, input.outputType, input.outputGuard)
+        );
+
+        require(data.exitData.outputRelatedDataHash == outputRelatedDataHash,
+                "Some of the output related challenge data are invalid for the exit");
+    }
+
+    function verifySpendingCondition(ChallengeStandardExitData memory data) private view {
+        ChallengeStandardExitInputData memory input = data.input;
+
+        IPaymentSpendingCondition condition = PaymentSpendingConditionRegistry.spendingConditions(
+            input.outputType, input.challengeTxType
+        );
+        require(address(condition) != address(0), "Spending condition contract not found");
+
+        bool isSpentByChallengeTx = condition.verify(
+            input.outputGuard,
+            input.outputUtxoPos,
+            input.outputId,
+            input.challengeTx,
+            input.inputIndex,
+            input.witness
+        );
+        require(isSpentByChallengeTx, "Spending condition failed");
     }
 }

--- a/plasma_framework/contracts/src/exits/payment/spendingConditions/IPaymentSpendingCondition.sol
+++ b/plasma_framework/contracts/src/exits/payment/spendingConditions/IPaymentSpendingCondition.sol
@@ -1,0 +1,21 @@
+pragma solidity ^0.5.0;
+
+interface IPaymentSpendingCondition {
+    /**
+     * @notice The function that checks output spending condition via authenticate owner.
+     * @param _outputGuard OutputGuard of the output.
+     * @param _utxoPos (optional) serves as the identifier of output. One of utxoPos and outputId must be with value.
+     * @param _outputId (optional) serves as the identifier of output. One of utxoPos and outputId must be with value.
+     * @param _consumeTx The transaction that consumes the output.
+     * @param _inputIndex The input index of the consume transaction that points to the output.
+     * @param _witness Witness data that would be able to prove that output is able to be consumed.
+     */
+    function verify(
+        bytes32 _outputGuard,
+        uint256 _utxoPos,
+        bytes32 _outputId,
+        bytes calldata _consumeTx,
+        uint8 _inputIndex,
+        bytes calldata _witness
+    ) external view returns (bool);
+}

--- a/plasma_framework/contracts/src/exits/payment/spendingConditions/PaymentOutputToPaymentTxCondition.sol
+++ b/plasma_framework/contracts/src/exits/payment/spendingConditions/PaymentOutputToPaymentTxCondition.sol
@@ -1,0 +1,49 @@
+pragma solidity ^0.5.0;
+
+import 'openzeppelin-solidity/contracts/cryptography/ECDSA.sol';
+
+import "./IPaymentSpendingCondition.sol";
+import "../../../utils/AddressPayable.sol";
+import "../../../transactions/PaymentTransactionModel.sol";
+import "../../../transactions/eip712Libs/PaymentEip712Lib.sol";
+
+contract PaymentOutputToPaymentTxCondition is IPaymentSpendingCondition {
+    using PaymentEip712Lib for PaymentEip712Lib.Constants;
+
+    uint256 constant public PAYMENT_TX_TYPE = 1;
+    PaymentEip712Lib.Constants eip712;
+
+    constructor(address _framework) public {
+        eip712 = PaymentEip712Lib.initConstants(_framework);
+    }
+
+    /**
+     * @notice The function that checks output spending condition via authenticate owner.
+     * @param _outputGuard bytes that hold the address of owner directly.
+     * @param _utxoPos serves as the identifier of output.
+     * @param _consumeTx The rlp encoded transaction that consumes the output.
+     * @param _inputIndex The input index of the consume transaction that points to the output.
+     * @param _signature The signature of the output owner.
+     */
+    function verify(
+        bytes32 _outputGuard,
+        uint256 _utxoPos,
+        bytes32 /*_outputId*/,
+        bytes calldata _consumeTx,
+        uint8 _inputIndex,
+        bytes calldata _signature
+    )
+        external
+        view
+        returns (bool)
+    {
+        PaymentTransactionModel.Transaction memory consumeTx = PaymentTransactionModel.decode(_consumeTx);
+        require(consumeTx.txType == PAYMENT_TX_TYPE, "The consume tx is not of payment tx type");
+        require(consumeTx.inputs[_inputIndex] == bytes32(_utxoPos), "The consume tx does not consume the output with such utxo pos");
+
+        address payable owner = AddressPayable.convert(address(uint256(_outputGuard)));
+        require(owner == ECDSA.recover(eip712.hashTx(consumeTx), _signature), "tx not correctly signed");
+
+        return true;
+    }
+}

--- a/plasma_framework/contracts/src/exits/payment/spendingConditions/PaymentSpendingConditionRegistry.sol
+++ b/plasma_framework/contracts/src/exits/payment/spendingConditions/PaymentSpendingConditionRegistry.sol
@@ -1,0 +1,40 @@
+pragma solidity ^0.5.0;
+
+import "./IPaymentSpendingCondition.sol";
+import "../../../utils/Freezable.sol";
+import "../../../framework/utils/Operated.sol";
+
+contract PaymentSpendingConditionRegistry is Operated, Freezable {
+    mapping(bytes32 => IPaymentSpendingCondition) private _spendingConditions;
+
+    function spendingConditions(uint256 _outputType, uint256 _consumeTxType)
+        public
+        view
+        returns (IPaymentSpendingCondition)
+    {
+        bytes32 key = keccak256(abi.encodePacked(_outputType, _consumeTxType));
+        return _spendingConditions[key];
+    }
+
+    /**
+     * @notice Register the spending condition.
+     * @dev output type with 0 is allowed but consume tx type should not be 0
+     * @param _outputType output type that the parser is registered with.
+     * @param _consumeTxType output type that the parser is registered with.
+     * @param _address Address of the spending condition contract.
+     */
+    function registerSpendingCondition(uint256 _outputType, uint256 _consumeTxType, address _address)
+        public
+        onlyOperator
+        onlyNonFrozen
+    {
+        require(_consumeTxType != 0, "Should not register with consume tx type 0");
+        require(_address != address(0), "Should not register an empty address");
+
+        bytes32 key = keccak256(abi.encodePacked(_outputType, _consumeTxType));
+        require(address(_spendingConditions[key]) == address(0),
+                "The output type has already been registered");
+
+        _spendingConditions[key] = IPaymentSpendingCondition(_address);
+    }
+}

--- a/plasma_framework/contracts/src/exits/utils/ExitId.sol
+++ b/plasma_framework/contracts/src/exits/utils/ExitId.sol
@@ -28,8 +28,8 @@ library ExitId {
         returns (uint192)
     {
         if (_isDeposit) {
-            bytes32 hash = keccak256(abi.encodePacked(_txBytes, _utxoPos.value));
-            return _computeStandardExitId(hash, _utxoPos.outputIndex());
+            bytes32 hashData = keccak256(abi.encodePacked(_txBytes, _utxoPos.value));
+            return _computeStandardExitId(hashData, _utxoPos.outputIndex());
         }
 
         return _computeStandardExitId(keccak256(_txBytes), _utxoPos.outputIndex());

--- a/plasma_framework/contracts/src/exits/utils/OutputGuard.sol
+++ b/plasma_framework/contracts/src/exits/utils/OutputGuard.sol
@@ -1,0 +1,22 @@
+pragma solidity ^0.5.0;
+
+library OutputGuard {
+
+    /**
+     * @notice Build the output guard from pre-image components (output type and output guard data).
+     * @param _outputType type of the output
+     * @param _outputGuardData output guard data in bytes
+     * @return right most 20 bytes of the hashed data of pre-image with padding 0s in front
+     */
+    function build(
+        uint256 _outputType,
+        bytes memory _outputGuardData
+    )
+        internal
+        pure
+        returns (bytes32)
+    {
+        bytes32 hashData = keccak256(abi.encodePacked(_outputType, _outputGuardData));
+        return bytes32(uint256(uint160(uint256(hashData))));
+    }
+}

--- a/plasma_framework/contracts/src/exits/utils/OutputId.sol
+++ b/plasma_framework/contracts/src/exits/utils/OutputId.sol
@@ -1,0 +1,32 @@
+pragma solidity ^0.5.0;
+
+library OutputId {
+
+    /**
+     * @notice Computes the output id of an output
+     * @dev Id for a deposit output is computed differently from any other outputs.
+     * @param _isDeposit boolean value representing the output is from a deposit tx or not
+     * @param _txBytes Transaction bytes.
+     * @param _outputIndex output index of the output.
+     * @param _utxoPosValue (optinal) UTXO position of the deposit output.
+     */
+    function compute(
+        bool _isDeposit,
+        bytes memory _txBytes,
+        uint256 _outputIndex,
+        uint256 _utxoPosValue
+    )
+        internal
+        pure
+        returns (bytes32)
+    {
+        // Deposit tx bytes might not be unique because all inputs are empty.
+        // Other tx relies on the fact that input would point to a unique output identifier (utxo_pos or output_id).
+        // As a result need to add utxo position value into the hash.
+        if (_isDeposit) {
+            return keccak256(abi.encodePacked(_txBytes, _outputIndex, _utxoPosValue));
+        }
+
+        return keccak256(abi.encodePacked(_txBytes, _outputIndex));
+    }
+}

--- a/plasma_framework/contracts/src/transactions/PaymentTransactionModel.sol
+++ b/plasma_framework/contracts/src/transactions/PaymentTransactionModel.sol
@@ -7,6 +7,10 @@ library PaymentTransactionModel {
 
     using RLP for bytes;
     using RLP for RLP.RLPItem;
+    using PaymentOutputModel for PaymentOutputModel.Output;
+
+    uint8 constant public MAX_INPUT_NUM = 4;
+    uint8 constant public MAX_OUTPUT_NUM = 4;
 
     uint8 constant private ENCODED_LENGTH_WITH_METADATA = 4;
     uint8 constant private ENCODED_LENGTH_WITHOUT_METADATA = 3;
@@ -27,9 +31,11 @@ library PaymentTransactionModel {
 
         RLP.RLPItem[] memory rlpInputs = rlpTx[1].toList();
         require(rlpInputs.length > 0, "Transaction must have inputs");
+        require(rlpInputs.length < MAX_INPUT_NUM, "Transaction inputs num exceeds limit");
 
         RLP.RLPItem[] memory rlpOutputs = rlpTx[2].toList();
         require(rlpOutputs.length > 0, "Transaction must have outputs");
+        require(rlpOutputs.length < MAX_OUTPUT_NUM, "Transaction outputs num exceeds limit");
 
         uint txType = rlpTx[0].toUint();
 

--- a/plasma_framework/contracts/src/transactions/eip712Libs/PaymentEip712Lib.sol
+++ b/plasma_framework/contracts/src/transactions/eip712Libs/PaymentEip712Lib.sol
@@ -1,0 +1,120 @@
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+import "../PaymentTransactionModel.sol";
+import "../outputs/PaymentOutputModel.sol";
+import "../../utils/UtxoPosLib.sol";
+
+library PaymentEip712Lib {
+    using UtxoPosLib for UtxoPosLib.UtxoPos;
+
+    uint8 constant public MAX_INPUT_NUM = 4;
+    uint8 constant public MAX_OUTPUT_NUM = 4;
+
+    struct Constants {
+        bytes2 EIP191_PREFIX;
+        bytes32 EIP712_DOMAIN_HASH;
+        bytes32 TX_TYPE_HASH;
+        bytes32 INPUT_TYPE_HASH;
+        bytes32 OUTPUT_TYPE_HASH;
+        bytes32 DOMAIN_SEPARATOR;
+    }
+
+    function initConstants(address _verifyingContract) internal pure returns (Constants memory) {
+        bytes2  EIP191_PREFIX = "\x19\x01";
+        bytes32 EIP712_DOMAIN_HASH = keccak256(abi.encodePacked(
+            "EIP712Domain(string name,string version,address verifyingContract,bytes32 salt)"
+        ));
+        bytes32 TX_TYPE_HASH = keccak256(abi.encodePacked(
+            "Transaction(uint256 txType,Input input0,Input input1,Input input2,Input input3,Output output0,Output output1,Output output2,Output output3,bytes32 metadata)Input(uint256 blknum,uint256 txindex,uint256 oindex)Output(bytes32 owner,address currency,uint256 amount)"
+        ));
+        bytes32 INPUT_TYPE_HASH = keccak256(abi.encodePacked("Input(uint256 blknum,uint256 txindex,uint256 oindex)"));
+        bytes32 OUTPUT_TYPE_HASH = keccak256(abi.encodePacked("Output(bytes32 owner,address currency,uint256 amount)"));
+
+        bytes32 salt = 0xfad5c7f626d80f9256ef01929f3beb96e058b8b4b0e3fe52d84f054c0e2a7a83;
+
+        bytes32 DOMAIN_SEPARATOR = keccak256(abi.encode(
+            EIP712_DOMAIN_HASH,
+            keccak256("OMG Network"),
+            keccak256("1"),
+            address(_verifyingContract),
+            salt
+        ));
+
+        return Constants({
+            EIP191_PREFIX: EIP191_PREFIX,
+            EIP712_DOMAIN_HASH: EIP712_DOMAIN_HASH,
+            TX_TYPE_HASH: TX_TYPE_HASH,
+            INPUT_TYPE_HASH: INPUT_TYPE_HASH,
+            OUTPUT_TYPE_HASH: OUTPUT_TYPE_HASH,
+            DOMAIN_SEPARATOR: DOMAIN_SEPARATOR
+        });
+    }
+
+    function hashTx(Constants memory _eip712, PaymentTransactionModel.Transaction memory _tx)
+        internal
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encodePacked(
+            _eip712.EIP191_PREFIX,
+            _eip712.DOMAIN_SEPARATOR,
+            _hashTx(_eip712, _tx)
+        ));
+    }
+
+    function _hashTx(Constants memory _eip712, PaymentTransactionModel.Transaction memory _tx)
+        private
+        pure
+        returns (bytes32)
+    {
+        // pad empty value to input array
+        bytes32[] memory inputs = new bytes32[](MAX_INPUT_NUM);
+        for (uint i = 0; i < _tx.inputs.length ; i++) {
+            inputs[i] = _tx.inputs[i];
+        }
+
+        // pad empty value to output array
+        PaymentOutputModel.Output[] memory outputs = new PaymentOutputModel.Output[](MAX_OUTPUT_NUM);
+        for (uint i = 0; i < _tx.outputs.length ; i++) {
+            outputs[i] = _tx.outputs[i];
+        }
+
+        return keccak256(abi.encode(
+            _eip712.TX_TYPE_HASH,
+            _tx.txType,
+            _hashInput(_eip712, inputs[0]),
+            _hashInput(_eip712, inputs[1]),
+            _hashInput(_eip712, inputs[2]),
+            _hashInput(_eip712, inputs[3]),
+            _hashOutput(_eip712, outputs[0]),
+            _hashOutput(_eip712, outputs[1]),
+            _hashOutput(_eip712, outputs[2]),
+            _hashOutput(_eip712, outputs[3]),
+            _tx.metaData
+        ));
+    }
+
+    function _hashInput(Constants memory _eip712, bytes32 _input) private pure returns (bytes32) {
+        UtxoPosLib.UtxoPos memory utxo = UtxoPosLib.UtxoPos(uint256(_input));
+        return keccak256(abi.encode(
+            _eip712.INPUT_TYPE_HASH,
+            utxo.blockNum(),
+            utxo.txIndex(),
+            uint256(utxo.outputIndex())
+        ));
+    }
+
+    function _hashOutput(Constants memory _eip712, PaymentOutputModel.Output memory _output)
+        private
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encode(
+            _eip712.OUTPUT_TYPE_HASH,
+            _output.outputGuard,
+            _output.token,
+            _output.amount
+        ));
+    }
+}

--- a/plasma_framework/contracts/src/transactions/outputs/PaymentOutputModel.sol
+++ b/plasma_framework/contracts/src/transactions/outputs/PaymentOutputModel.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.5.0;
 pragma experimental ABIEncoderV2;
 
+import "../eip712Libs/PaymentEip712Lib.sol";
 import "../../utils/RLP.sol";
 import "../../utils/AddressPayable.sol";
 

--- a/plasma_framework/contracts/src/utils/Freezable.sol
+++ b/plasma_framework/contracts/src/utils/Freezable.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.5.0;
+
+contract Freezable {
+    bool private _isFrozen = false;
+
+    modifier onlyNonFrozen() {
+        require(_isFrozen == false, "The function has been frozen");
+        _;
+    }
+
+    function isFrozen() public view returns (bool) {
+        return _isFrozen;
+    }
+
+    function freeze() public {
+        _isFrozen = true;
+    }
+}

--- a/plasma_framework/package-lock.json
+++ b/plasma_framework/package-lock.json
@@ -205,6 +205,12 @@
           "requires": {
             "ansi-regex": "^2.0.0"
           }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
         }
       }
     },
@@ -234,6 +240,24 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
       "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==",
       "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bip66": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "bl": {
       "version": "1.2.2",
@@ -917,18 +941,6 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
     },
-    "diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-      "dev": true
-    },
-    "diff": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
-      "dev": true
-    },
     "diffie-hellman": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
@@ -954,6 +966,17 @@
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
       "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
       "dev": true
+    },
+    "drbg.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+      "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+      "dev": true,
+      "requires": {
+        "browserify-aes": "^1.0.6",
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4"
+      }
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -1042,12 +1065,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-      "dev": true
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "escape-string-regexp": {
@@ -1356,6 +1373,98 @@
         }
       }
     },
+    "eth-sig-util": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.2.0.tgz",
+      "integrity": "sha512-bAxW35bL4U2lrtjjV8rFGJ8B27z4Sn5v9eIaNdpPUnPfUAtrvx5j8atfyV+k+JOnbppcvKhWCO1rQSBk4kkAhw==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.2.1",
+        "elliptic": "^6.4.0",
+        "ethereumjs-abi": "0.6.5",
+        "ethereumjs-util": "^5.1.1",
+        "tweetnacl": "^1.0.0",
+        "tweetnacl-util": "^0.15.0"
+      },
+      "dependencies": {
+        "elliptic": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
+          "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
+          "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A==",
+          "dev": true
+        }
+      }
+    },
+    "ethereumjs-abi": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.5.tgz",
+      "integrity": "sha1-WmN+8Wq0NHP6cqKa2QhxQFs/UkE=",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.10.0",
+        "ethereumjs-util": "^4.3.0"
+      },
+      "dependencies": {
+        "ethereumjs-util": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+          "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.8.0",
+            "create-hash": "^1.1.2",
+            "keccakjs": "^0.2.0",
+            "rlp": "^2.0.0",
+            "secp256k1": "^3.0.1"
+          }
+        }
+      }
+    },
+    "ethereumjs-util": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
+      "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.11.0",
+        "create-hash": "^1.1.2",
+        "ethjs-util": "0.1.6",
+        "keccak": "^1.0.2",
+        "rlp": "^2.0.0",
+        "safe-buffer": "^5.1.1",
+        "secp256k1": "^3.0.1"
+      }
+    },
     "ethers": {
       "version": "4.0.29",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.29.tgz",
@@ -1401,6 +1510,16 @@
       "requires": {
         "bn.js": "4.11.6",
         "number-to-bn": "1.7.0"
+      }
+    },
+    "ethjs-util": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
+      "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
+      "dev": true,
+      "requires": {
+        "is-hex-prefixed": "1.0.0",
+        "strip-hex-prefix": "1.0.0"
       }
     },
     "eventemitter3": {
@@ -1547,6 +1666,12 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
       "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
+      "dev": true
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "dev": true
     },
     "finalhandler": {
@@ -2213,6 +2338,18 @@
         "verror": "1.10.0"
       }
     },
+    "keccak": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+      "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+      "dev": true,
+      "requires": {
+        "bindings": "^1.2.1",
+        "inherits": "^2.0.3",
+        "nan": "^2.2.1",
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "keccakjs": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.3.tgz",
@@ -2443,6 +2580,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
         },
         "glob": {
           "version": "7.1.2",
@@ -3219,6 +3362,51 @@
         "pbkdf2": "^3.0.3"
       }
     },
+    "secp256k1": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
+      "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
+      "dev": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "bip66": "^1.1.5",
+        "bn.js": "^4.11.8",
+        "create-hash": "^1.2.0",
+        "drbg.js": "^1.0.1",
+        "elliptic": "^6.4.1",
+        "nan": "^2.14.0",
+        "safe-buffer": "^5.1.2"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "dev": true
+        },
+        "elliptic": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
+          "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        },
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+          "dev": true
+        }
+      }
+    },
     "seek-bzip": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
@@ -3803,6 +3991,12 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
+    },
+    "tweetnacl-util": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.0.tgz",
+      "integrity": "sha1-RXbBzuXi1j0gf+5S8boCgZSAvHU=",
       "dev": true
     },
     "type-check": {

--- a/plasma_framework/package.json
+++ b/plasma_framework/package.json
@@ -13,6 +13,8 @@
     "eslint": "^5.3.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.17.3",
+    "eth-sig-util": "^2.2.0",
+    "ethereumjs-util": "^6.1.0",
     "openzeppelin-test-helpers": "^0.4.0",
     "rlp": "^2.2.3",
     "truffle": "^5.0.25"

--- a/plasma_framework/test/helpers/paymentEip712.js
+++ b/plasma_framework/test/helpers/paymentEip712.js
@@ -1,0 +1,75 @@
+const { constants, BN } = require('openzeppelin-test-helpers');
+const { UtxoPos } = require('./utxoPos.js');
+
+const EMPTY_BYTES32 = '0x0000000000000000000000000000000000000000000000000000000000000000';
+const NULL_OUTPUT = { outputGuard: EMPTY_BYTES32, token: constants.ZERO_ADDRESS, amount: 0 };
+
+const EIP191_PREFIX = '0x1901';
+const EIP712_DOMAIN_HASH = web3.utils.sha3('EIP712Domain(string name,string version,address verifyingContract,bytes32 salt)');
+const TX_TYPE_HASH = web3.utils.sha3('Transaction(uint256 txType,Input input0,Input input1,Input input2,Input input3,Output output0,Output output1,Output output2,Output output3,bytes32 metadata)Input(uint256 blknum,uint256 txindex,uint256 oindex)Output(bytes32 owner,address currency,uint256 amount)');
+const INPUT_TYPE_HASH = web3.utils.sha3('Input(uint256 blknum,uint256 txindex,uint256 oindex)');
+const OUTPUT_TYPE_HASH = web3.utils.sha3('Output(bytes32 owner,address currency,uint256 amount)');
+const SALT = '0xfad5c7f626d80f9256ef01929f3beb96e058b8b4b0e3fe52d84f054c0e2a7a83';
+
+const hashInput = (input) => {
+    const utxoPos = new UtxoPos(input);
+
+    return web3.utils.sha3(web3.eth.abi.encodeParameters([
+        'bytes32', 'uint256', 'uint256', 'uint256',
+    ], [
+        INPUT_TYPE_HASH,
+        utxoPos.blockNum(),
+        utxoPos.txIndex(),
+        utxoPos.outputIndex(),
+    ]));
+};
+
+const hashOutput = output => web3.utils.sha3(
+    web3.eth.abi.encodeParameters([
+        'bytes32', 'bytes32', 'address', 'uint256',
+    ], [
+        OUTPUT_TYPE_HASH,
+        output.outputGuard,
+        output.token,
+        output.amount,
+    ]),
+);
+
+const hashTx = (tx, verifyingContract) => {
+    const domainSeparator = web3.utils.sha3(web3.eth.abi.encodeParameters([
+        'bytes32', 'bytes32', 'bytes32', 'address', 'bytes32',
+    ], [
+        EIP712_DOMAIN_HASH,
+        web3.utils.sha3('OMG Network'),
+        web3.utils.sha3('1'),
+        verifyingContract,
+        SALT,
+    ]));
+
+    const inputs = tx.inputs.map(hashInput);
+    const outputs = tx.outputs.map(hashOutput);
+
+    const txHash = web3.utils.sha3(web3.eth.abi.encodeParameters([
+        'bytes32', 'uint256', 'bytes32', 'bytes32', 'bytes32', 'bytes32', 'bytes32', 'bytes32', 'bytes32', 'bytes32', 'bytes32',
+    ], [
+        TX_TYPE_HASH,
+        tx.transactionType,
+        inputs.length > 0 ? inputs[0] : hashInput(0),
+        inputs.length > 1 ? inputs[1] : hashInput(0),
+        inputs.length > 2 ? inputs[2] : hashInput(0),
+        inputs.length > 3 ? inputs[3] : hashInput(0),
+        outputs.length > 0 ? outputs[0] : hashOutput(NULL_OUTPUT),
+        outputs.length > 1 ? outputs[1] : hashOutput(NULL_OUTPUT),
+        outputs.length > 2 ? outputs[2] : hashOutput(NULL_OUTPUT),
+        outputs.length > 3 ? outputs[3] : hashOutput(NULL_OUTPUT),
+        tx.metaData || EMPTY_BYTES32,
+    ]));
+
+    return web3.utils.soliditySha3(
+        { t: 'bytes2', v: EIP191_PREFIX },
+        { t: 'bytes32', v: domainSeparator },
+        { t: 'bytes32', v: txHash },
+    );
+};
+
+module.exports = { hashTx, hashInput, hashOutput };

--- a/plasma_framework/test/helpers/sign.js
+++ b/plasma_framework/test/helpers/sign.js
@@ -1,0 +1,15 @@
+const ethUtil = require('ethereumjs-util');
+const sigUtil = require('eth-sig-util');
+
+function sign(msgHashHex, privateKey) {
+    // remove prefix '0x'
+    const message = (msgHashHex.length === 66) ? msgHashHex.substring(2) : msgHashHex;
+    const tosign = Buffer.from(message, 'hex');
+    const signed = ethUtil.ecsign(
+        tosign,
+        Buffer.from(privateKey.replace('0x', ''), 'hex'),
+    );
+    return sigUtil.concatSig(signed.v, signed.r, signed.s);
+}
+
+module.exports = { sign };

--- a/plasma_framework/test/helpers/testlang.js
+++ b/plasma_framework/test/helpers/testlang.js
@@ -1,17 +1,15 @@
 const { constants } = require('openzeppelin-test-helpers');
 const { PaymentTransactionOutput, PlasmaDepositTransaction } = require('./transaction.js');
+const { addressToOutputGuard } = require('./utils.js');
 
 function deposit(amount, owner, tokenAddress = constants.ZERO_ADDRESS) {
-    const output = new PaymentTransactionOutput(amount, owner, tokenAddress);
+    // if passed in with address format, auto transform to outputGuard format
+    const outputGuard = owner.length < 66 ? addressToOutputGuard(owner) : owner;
+    const output = new PaymentTransactionOutput(amount, outputGuard, tokenAddress);
     const depositTx = new PlasmaDepositTransaction(output);
     return web3.utils.bytesToHex(depositTx.rlpEncoded());
 }
 
-function buildUtxoPos(blockNum, txIndex, outputIndex) {
-    const BLOCK_OFFSET = 1000000000;
-    const TX_OFFSET = 10000;
-    return blockNum * BLOCK_OFFSET + txIndex * TX_OFFSET + outputIndex;
-}
-
-module.exports.deposit = deposit;
-module.exports.buildUtxoPos = buildUtxoPos;
+module.exports = {
+    deposit,
+};

--- a/plasma_framework/test/helpers/testlang.js
+++ b/plasma_framework/test/helpers/testlang.js
@@ -4,7 +4,7 @@ const { PaymentTransactionOutput, PlasmaDepositTransaction } = require('./transa
 function deposit(amount, owner, tokenAddress = constants.ZERO_ADDRESS) {
     const output = new PaymentTransactionOutput(amount, owner, tokenAddress);
     const depositTx = new PlasmaDepositTransaction(output);
-    return depositTx.rlpEncoded();
+    return web3.utils.bytesToHex(depositTx.rlpEncoded());
 }
 
 function buildUtxoPos(blockNum, txIndex, outputIndex) {

--- a/plasma_framework/test/helpers/transaction.js
+++ b/plasma_framework/test/helpers/transaction.js
@@ -1,6 +1,6 @@
 const rlp = require('rlp');
 
-const NULL_DATA = Buffer.alloc(32, 0);
+const EMPTY_BYTES32 = `0x${Array(64).fill(0).join('')}`;
 const TransactionTypes = {
     PLASMA_DEPOSIT: 1,
 };
@@ -16,6 +16,10 @@ class PaymentTransactionOutput {
         return [this.amount, this.outputGuard, this.token];
     }
 
+    rlpEncoded() {
+        return rlp.encode(this.formatForRlpEncoding());
+    }
+
     static parseFromContractOutput(output) {
         const amount = parseInt(output.amount, 10);
         const outputGuard = web3.eth.abi.decodeParameter('bytes32', output.outputGuard);
@@ -24,7 +28,7 @@ class PaymentTransactionOutput {
 }
 
 class PaymentTransaction {
-    constructor(transactionType, inputs, outputs, metaData = NULL_DATA) {
+    constructor(transactionType, inputs, outputs, metaData = EMPTY_BYTES32) {
         this.transactionType = transactionType;
         this.inputs = inputs;
         this.outputs = outputs;
@@ -47,11 +51,13 @@ class PaymentTransaction {
 }
 
 class PlasmaDepositTransaction extends PaymentTransaction {
-    constructor(output, metaData = NULL_DATA) {
-        super(TransactionTypes.PLASMA_DEPOSIT, [NULL_DATA], [output], metaData);
+    constructor(output, metaData = EMPTY_BYTES32) {
+        super(TransactionTypes.PLASMA_DEPOSIT, [0], [output], metaData);
     }
 }
 
-module.exports.PaymentTransaction = PaymentTransaction;
-module.exports.PlasmaDepositTransaction = PlasmaDepositTransaction;
-module.exports.PaymentTransactionOutput = PaymentTransactionOutput;
+module.exports = {
+    PaymentTransaction,
+    PlasmaDepositTransaction,
+    PaymentTransactionOutput,
+};

--- a/plasma_framework/test/helpers/utils.js
+++ b/plasma_framework/test/helpers/utils.js
@@ -13,6 +13,11 @@ function buildOutputGuard(outputType, outputGuardData) {
     return `0x${paddingZeros}${rightMostBytes20}`;
 }
 
+function addressToOutputGuard(address) {
+    const paddingZeros = Array(24).fill(0).join('');
+    return `0x${paddingZeros}${address.substring(2)}`;
+}
+
 function computeOutputId(isDeposit, txBytes, outputIndex, utxoPos) {
     if (isDeposit) {
         return computeDepositOutputId(txBytes, outputIndex, utxoPos);
@@ -35,8 +40,11 @@ function computeNormalOutputId(txBytes, outputIndex) {
     );
 }
 
-module.exports.spentOnGas = spentOnGas;
-module.exports.buildOutputGuard = buildOutputGuard;
-module.exports.computeOutputId = computeOutputId;
-module.exports.computeDepositOutputId = computeDepositOutputId;
-module.exports.computeNormalOutputId = computeNormalOutputId;
+module.exports = {
+    spentOnGas,
+    buildOutputGuard,
+    computeOutputId,
+    computeDepositOutputId,
+    computeNormalOutputId,
+    addressToOutputGuard,
+};

--- a/plasma_framework/test/helpers/utils.js
+++ b/plasma_framework/test/helpers/utils.js
@@ -3,4 +3,40 @@ async function spentOnGas(receipt) {
     return web3.utils.toBN(tx.gasPrice).muln(receipt.gasUsed);
 }
 
+function buildOutputGuard(outputType, outputGuardData) {
+    const hashValue = web3.utils.soliditySha3(
+        { t: 'uint256', v: outputType },
+        { t: 'bytes', v: outputGuardData },
+    );
+    const rightMostBytes20 = hashValue.substring(hashValue.length - 40, hashValue.length);
+    const paddingZeros = Array(24).fill(0).join('');
+    return `0x${paddingZeros}${rightMostBytes20}`;
+}
+
+function computeOutputId(isDeposit, txBytes, outputIndex, utxoPos) {
+    if (isDeposit) {
+        return computeDepositOutputId(txBytes, outputIndex, utxoPos);
+    }
+    return computeNormalOutputId(txBytes, outputIndex);
+}
+
+function computeDepositOutputId(txBytes, outputIndex, utxoPos) {
+    return web3.utils.soliditySha3(
+        { t: 'bytes', v: txBytes },
+        { t: 'uint256', v: outputIndex },
+        { t: 'uint256', v: utxoPos },
+    );
+}
+
+function computeNormalOutputId(txBytes, outputIndex) {
+    return web3.utils.soliditySha3(
+        { t: 'bytes', v: txBytes },
+        { t: 'uint256', v: outputIndex },
+    );
+}
+
 module.exports.spentOnGas = spentOnGas;
+module.exports.buildOutputGuard = buildOutputGuard;
+module.exports.computeOutputId = computeOutputId;
+module.exports.computeDepositOutputId = computeDepositOutputId;
+module.exports.computeNormalOutputId = computeNormalOutputId;

--- a/plasma_framework/test/helpers/utxoPos.js
+++ b/plasma_framework/test/helpers/utxoPos.js
@@ -1,0 +1,30 @@
+function buildUtxoPos(blockNum, txIndex, outputIndex) {
+    const BLOCK_OFFSET = 1000000000;
+    const TX_OFFSET = 10000;
+    return blockNum * BLOCK_OFFSET + txIndex * TX_OFFSET + outputIndex;
+}
+
+class UtxoPos {
+    constructor(utxoPos) {
+        this.utxoPos = utxoPos;
+        this.BLOCK_OFFSET = 1000000000;
+        this.TX_OFFSET = 10000;
+    }
+
+    blockNum() {
+        return Math.floor(this.utxoPos / this.BLOCK_OFFSET);
+    }
+
+    txIndex() {
+        return Math.floor((this.utxoPos % this.BLOCK_OFFSET) / this.TX_OFFSET);
+    }
+
+    outputIndex() {
+        return this.utxoPos % this.TX_OFFSET;
+    }
+}
+
+module.exports = {
+    buildUtxoPos,
+    UtxoPos,
+};

--- a/plasma_framework/test/src/exits/payment/PaymentExitGame.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentExitGame.test.js
@@ -1,38 +1,66 @@
 const PaymentExitGame = artifacts.require('PaymentExitGame');
+const PaymentOutputToPaymentTxCondition = artifacts.require('PaymentOutputToPaymentTxCondition');
 const PlasmaFramework = artifacts.require('PlasmaFramework');
 const PriorityQueue = artifacts.require('PriorityQueue');
 const EthVault = artifacts.require('EthVault');
 const EthDepositVerifier = artifacts.require('EthDepositVerifier');
 const ExitId = artifacts.require('ExitIdWrapper');
+const OutputId = artifacts.require('OutputIdWrapper');
 
-const { BN, constants } = require('openzeppelin-test-helpers');
+const { BN, constants, expectEvent } = require('openzeppelin-test-helpers');
 const { expect } = require('chai');
 
 const { MerkleTree } = require('../../../helpers/merkle.js');
 const { PaymentTransactionOutput, PaymentTransaction } = require('../../../helpers/transaction.js');
+const { addressToOutputGuard, computeDepositOutputId } = require('../../../helpers/utils.js');
+const { sign } = require('../../../helpers/sign.js');
+const { hashTx } = require('../../../helpers/paymentEip712.js');
+const { buildUtxoPos } = require('../../../helpers/utxoPos.js');
 const Testlang = require('../../../helpers/testlang.js');
 
-contract('PaymentExitGame - End to End Tests', ([_, alice, bob]) => {
+contract('PaymentExitGame - End to End Tests', ([_, richFather, bob]) => {
     const MIN_EXIT_PERIOD = 60 * 60 * 24 * 7; // 1 week
     const STANDARD_EXIT_BOND = 31415926535; // wei
     const ETH = constants.ZERO_ADDRESS;
     const DEPOSIT_VALUE = 1000000;
+    const OUTPUT_TYPE_ZERO = 0;
+    const EMPTY_BYTES = '0x';
+    const PAYMENT_TX_TYPE = 1;
+
+    const alicePrivateKey = '0x7151e5dab6f8e95b5436515b83f423c4df64fe4c6149f864daa209b26adb10ca'
+    let alice;
+
+    before(async () => {
+        const password = 'password1234';
+        alice = await web3.eth.personal.importRawKey(alicePrivateKey, password);
+        alice = web3.utils.toChecksumAddress(alice);
+        web3.eth.personal.unlockAccount(alice, password, 3600);
+        web3.eth.sendTransaction({ to: alice, from: richFather, value: web3.utils.toWei('1', 'ether') });
+
+        this.exitIdHelper = await ExitId.new();
+        this.outputIdHelper = await OutputId.new();
+    });
 
     const setupContracts = async () => {
         this.framework = await PlasmaFramework.new(MIN_EXIT_PERIOD);
         this.exitGame = await PaymentExitGame.new(this.framework.address);
-        this.ethVault = await EthVault.new(this.framework.address);
-        this.exitIdHelper = await ExitId.new();
 
+        this.toPaymentCondition = await PaymentOutputToPaymentTxCondition.new(this.framework.address);
+        await this.exitGame.registerSpendingCondition(
+            OUTPUT_TYPE_ZERO, PAYMENT_TX_TYPE, this.toPaymentCondition.address,
+        );
+
+        this.ethVault = await EthVault.new(this.framework.address);
         const depositVerifier = await EthDepositVerifier.new();
         await this.ethVault.setDepositVerifier(depositVerifier.address);
+
         await this.framework.registerVault(1, this.ethVault.address);
-        await this.framework.registerExitGame(1, this.exitGame.address);
+        await this.framework.registerExitGame(PAYMENT_TX_TYPE, this.exitGame.address);
     };
 
     const aliceDeposits = async () => {
         const depositBlockNum = (await this.framework.nextDepositBlock()).toNumber();
-        this.depositUtxoPos = Testlang.buildUtxoPos(depositBlockNum, 0, 0);
+        this.depositUtxoPos = buildUtxoPos(depositBlockNum, 0, 0);
         this.depositTx = Testlang.deposit(DEPOSIT_VALUE, alice);
         this.merkleTreeForDepositTx = new MerkleTree([this.depositTx], 16);
         this.merkleProofForDepositTx = this.merkleTreeForDepositTx.getInclusionProof(this.depositTx);
@@ -42,13 +70,14 @@ contract('PaymentExitGame - End to End Tests', ([_, alice, bob]) => {
 
     const aliceTransferToBob = async () => {
         const tranferTxBlockNum = (await this.framework.nextChildBlock()).toNumber();
-        this.transferUtxoPos = Testlang.buildUtxoPos(tranferTxBlockNum, 0, 0);
+        this.transferUtxoPos = buildUtxoPos(tranferTxBlockNum, 0, 0);
 
-        const output = new PaymentTransactionOutput(1000, bob, ETH);
+        const output = new PaymentTransactionOutput(1000, addressToOutputGuard(bob), ETH);
 
         // TODO: utxo_pos or output_id pending decision here: https://github.com/omisego/research/issues/93
         // if it ends up differently should alter this function accordingly
-        this.transferTx = (new PaymentTransaction(1, [this.transferUtxoPos], [output])).rlpEncoded();
+        this.transferTxObject = new PaymentTransaction(1, [this.depositUtxoPos], [output]);
+        this.transferTx = this.transferTxObject.rlpEncoded();
         this.merkleTreeForTransferTx = new MerkleTree([this.transferTx]);
         this.merkleProofForTransferTx = this.merkleTreeForTransferTx.getInclusionProof(this.transferTx);
 
@@ -64,7 +93,8 @@ contract('PaymentExitGame - End to End Tests', ([_, alice, bob]) => {
             describe('When alice starts standard exit on the deposit tx', () => {
                 beforeEach(async () => {
                     await this.exitGame.startStandardExit(
-                        this.depositUtxoPos, this.depositTx, this.merkleProofForDepositTx,
+                        this.depositUtxoPos, this.depositTx, OUTPUT_TYPE_ZERO,
+                        EMPTY_BYTES, this.merkleProofForDepositTx,
                         { from: alice, value: STANDARD_EXIT_BOND },
                     );
                 });
@@ -73,8 +103,18 @@ contract('PaymentExitGame - End to End Tests', ([_, alice, bob]) => {
                     const exitId = await this.exitIdHelper.getStandardExitId(true, this.depositTx, this.depositUtxoPos);
                     const standardExitData = await this.exitGame.exits(exitId);
 
+                    const isDeposit = true;
+                    const outputIndexForDeposit = 0;
+                    const outputId = await this.outputIdHelper.compute(
+                        isDeposit, this.depositTx, outputIndexForDeposit, this.depositUtxoPos,
+                    );
+                    const expectedOutputRelatedDataHash = web3.utils.soliditySha3(
+                        { t: 'uint256', v: this.depositUtxoPos }, { t: 'bytes32', v: outputId },
+                        { t: 'uint256', v: OUTPUT_TYPE_ZERO }, { t: 'bytes32', v: addressToOutputGuard(alice) },
+                    );
+
                     expect(standardExitData.exitable).to.be.true;
-                    expect(standardExitData.position).to.be.bignumber.equal(new BN(this.depositUtxoPos));
+                    expect(standardExitData.outputRelatedDataHash).to.equal(expectedOutputRelatedDataHash);
                     expect(standardExitData.token).to.equal(ETH);
                     expect(standardExitData.exitTarget).to.equal(alice);
                     expect(standardExitData.amount).to.be.bignumber.equal(new BN(DEPOSIT_VALUE));
@@ -100,7 +140,8 @@ contract('PaymentExitGame - End to End Tests', ([_, alice, bob]) => {
             describe('When bob tries to start the standard exit on the transfered tx', () => {
                 beforeEach(async () => {
                     await this.exitGame.startStandardExit(
-                        this.transferUtxoPos, this.transferTx, this.merkleProofForTransferTx,
+                        this.transferUtxoPos, this.transferTx, OUTPUT_TYPE_ZERO,
+                        EMPTY_BYTES, this.merkleProofForTransferTx,
                         { from: bob, value: STANDARD_EXIT_BOND },
                     );
                 });
@@ -124,21 +165,47 @@ contract('PaymentExitGame - End to End Tests', ([_, alice, bob]) => {
             describe('When alice tries to start the standard exit on the deposit tx', () => {
                 beforeEach(async () => {
                     await this.exitGame.startStandardExit(
-                        this.depositUtxoPos, this.depositTx, this.merkleProofForDepositTx,
+                        this.depositUtxoPos, this.depositTx, OUTPUT_TYPE_ZERO,
+                        EMPTY_BYTES, this.merkleProofForDepositTx,
                         { from: alice, value: STANDARD_EXIT_BOND },
+                    );
+                    this.exitId = await this.exitIdHelper.getStandardExitId(
+                        true, this.depositTx, this.depositUtxoPos,
                     );
                 });
 
                 it('should still be able to start standard exit even already spent', async () => {
-                    const exitId = await this.exitIdHelper.getStandardExitId(true, this.depositTx, this.depositUtxoPos);
-                    const standardExitData = await this.exitGame.exits(exitId);
+                    const standardExitData = await this.exitGame.exits(this.exitId);
                     expect(standardExitData.exitable).to.be.true;
                 });
 
                 describe('Then bob can challenge the standard exit spent', async () => {
-                    it('TODO: should challenge it successfully', async () => {
-                        // TODO: implement this!
-                        // this is to show case how we can do cool BDD style in E2E test and reuse setup
+                    beforeEach(async () => {
+                        const txHash = hashTx(this.transferTxObject, this.framework.address);
+                        const signature = sign(txHash, alicePrivateKey);
+
+                        const input = {
+                            exitId: this.exitId.toString(10),
+                            outputType: OUTPUT_TYPE_ZERO,
+                            outputUtxoPos: this.depositUtxoPos,
+                            outputId: computeDepositOutputId(this.depositTx, 0, this.depositUtxoPos),
+                            outputGuard: addressToOutputGuard(alice),
+                            challengeTxType: PAYMENT_TX_TYPE,
+                            challengeTx: this.transferTx,
+                            inputIndex: 0,
+                            witness: signature,
+                        };
+
+                        const { logs } = await this.exitGame.challengeStandardExit(input);
+                        this.challengeTxLogs = logs;
+                    });
+
+                    it('should challenge it successfully', async () => {
+                        expectEvent.inLogs(
+                            this.challengeTxLogs,
+                            'ExitChallenged',
+                            { utxoPos: new BN(this.depositUtxoPos) },
+                        );
                     });
                 });
             });

--- a/plasma_framework/test/src/exits/payment/PaymentStandardExitable.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentStandardExitable.test.js
@@ -1,17 +1,25 @@
-const PaymentStandardExitable = artifacts.require('PaymentStandardExitable');
+const PaymentStandardExitable = artifacts.require('PaymentStandardExitableMock');
+const PaymentSpendingConditionExpected = artifacts.require('PaymentSpendingConditionExpected');
+const PaymentSpendingConditionFalse = artifacts.require('PaymentSpendingConditionFalse');
+const PaymentSpendingConditionTrue = artifacts.require('PaymentSpendingConditionTrue');
+const PaymentSpendingConditionRevert = artifacts.require('PaymentSpendingConditionRevert');
 const DummyPlasmaFramework = artifacts.require('DummyPlasmaFramework');
 const DummyVault = artifacts.require('DummyVault');
 const ExitId = artifacts.require('ExitIdWrapper');
+const OutputGuardParser = artifacts.require('DummyOutputGuardParser');
 const IsDeposit = artifacts.require('IsDepositWrapper');
 const ExitableTimestamp = artifacts.require('ExitableTimestampWrapper');
 
 const {
-    BN, constants, expectRevert, time,
+    BN, constants, expectEvent, expectRevert, time,
 } = require('openzeppelin-test-helpers');
 const { expect } = require('chai');
 
 const { MerkleTree } = require('../../../helpers/merkle.js');
-const { spentOnGas } = require('../../../helpers/utils.js');
+const { buildUtxoPos } = require('../../../helpers/utxoPos.js');
+const {
+    addressToOutputGuard, buildOutputGuard, computeOutputId, spentOnGas,
+} = require('../../../helpers/utils.js');
 const Testlang = require('../../../helpers/testlang.js');
 
 
@@ -20,19 +28,23 @@ contract('PaymentStandardExitable', ([_, alice, bob]) => {
     const ETH = constants.ZERO_ADDRESS;
     const CHILD_BLOCK_INTERVAL = 1000;
     const MIN_EXIT_PERIOD = 60 * 60 * 24 * 7; // 1 week
-
-    const buildTestData = (amount, blockNum) => {
-        const tx = Testlang.deposit(amount, alice, ETH);
-        const utxoPos = Testlang.buildUtxoPos(blockNum, 0, 0);
-        const merkleTree = new MerkleTree([tx], 3);
-        const merkleProof = merkleTree.getInclusionProof(tx);
-
-        return {
-            utxoPos, tx, merkleTree, merkleProof,
-        };
-    };
+    const OUTPUT_TYPE_ZERO = 0;
+    const EMPTY_BYTES = '0x0000000000000000000000000000000000000000000000000000000000000000000000';
+    const EMPTY_BYTES32 = '0x0000000000000000000000000000000000000000000000000000000000000000';
 
     describe('startStandardExit', () => {
+        const buildTestData = (amount, owner, blockNum) => {
+            const tx = Testlang.deposit(amount, owner, ETH);
+            const outputIndex = 0;
+            const utxoPos = buildUtxoPos(blockNum, 0, outputIndex);
+            const merkleTree = new MerkleTree([tx], 3);
+            const merkleProof = merkleTree.getInclusionProof(tx);
+
+            return {
+                utxoPos, outputIndex, tx, merkleTree, merkleProof,
+            };
+        };
+
         before(async () => {
             this.exitIdHelper = await ExitId.new();
             this.isDeposit = await IsDeposit.new(CHILD_BLOCK_INTERVAL);
@@ -47,15 +59,15 @@ contract('PaymentStandardExitable', ([_, alice, bob]) => {
 
         it('should fail when cannot prove the tx is included in the block', async () => {
             const testAmount = 1000;
-            const dummyBlockNum = 1000;
-            const data = buildTestData(testAmount, dummyBlockNum);
+            const dummyBlockNum = 1001;
+            const data = buildTestData(testAmount, alice, dummyBlockNum);
             const fakeRoot = web3.utils.sha3('fake root data');
 
             await this.framework.setBlock(dummyBlockNum, fakeRoot, 0);
 
             await expectRevert(
                 this.exitGame.startStandardExit(
-                    data.utxoPos, data.tx, data.merkleProof,
+                    data.utxoPos, data.tx, OUTPUT_TYPE_ZERO, EMPTY_BYTES, data.merkleProof,
                     { from: alice, value: STANDARD_EXIT_BOND },
                 ),
                 'transaction inclusion proof failed',
@@ -64,14 +76,14 @@ contract('PaymentStandardExitable', ([_, alice, bob]) => {
 
         it('should fail when exit with amount of 0', async () => {
             const testAmount = 0;
-            const dummyBlockNum = 1000;
-            const data = buildTestData(testAmount, dummyBlockNum);
+            const dummyBlockNum = 1001;
+            const data = buildTestData(testAmount, alice, dummyBlockNum);
 
             await this.framework.setBlock(dummyBlockNum, data.merkleTree.root, 0);
 
             await expectRevert(
                 this.exitGame.startStandardExit(
-                    data.utxoPos, data.tx, data.merkleProof,
+                    data.utxoPos, data.tx, OUTPUT_TYPE_ZERO, EMPTY_BYTES, data.merkleProof,
                     { from: alice, value: STANDARD_EXIT_BOND },
                 ),
                 'Should not exit with amount 0',
@@ -80,53 +92,94 @@ contract('PaymentStandardExitable', ([_, alice, bob]) => {
 
         it('should fail when amount of bond is invalid', async () => {
             const testAmount = 1000;
-            const dummyBlockNum = 1000;
-            const data = buildTestData(testAmount, dummyBlockNum);
+            const dummyBlockNum = 1001;
+            const data = buildTestData(testAmount, alice, dummyBlockNum);
 
             await this.framework.setBlock(dummyBlockNum, data.merkleTree.root, 0);
 
             const invalidBond = STANDARD_EXIT_BOND - 100;
             await expectRevert(
                 this.exitGame.startStandardExit(
-                    data.utxoPos, data.tx, data.merkleProof,
+                    data.utxoPos, data.tx, OUTPUT_TYPE_ZERO, EMPTY_BYTES, data.merkleProof,
                     { from: alice, value: invalidBond },
                 ),
                 'Input value mismatches with msg.value',
             );
         });
 
-        it('should fail when not initiated by the output owner', async () => {
+        it('should fail when not initiated by the exit target', async () => {
             const testAmount = 1000;
-            const dummyBlockNum = 1000;
-            const data = buildTestData(testAmount, dummyBlockNum);
+            const dummyBlockNum = 1001;
+            const data = buildTestData(testAmount, alice, dummyBlockNum);
 
             await this.framework.setBlock(dummyBlockNum, data.merkleTree.root, 0);
 
             const nonOutputOwner = bob;
             await expectRevert(
                 this.exitGame.startStandardExit(
-                    data.utxoPos, data.tx, data.merkleProof,
+                    data.utxoPos, data.tx, OUTPUT_TYPE_ZERO, EMPTY_BYTES, data.merkleProof,
                     { from: nonOutputOwner, value: STANDARD_EXIT_BOND },
                 ),
-                'Only output owner can start an exit',
+                'Only exit target can start an exit',
+            );
+        });
+
+        it('should fail when output guard mismatch pre-image data given output type non 0', async () => {
+            const testAmount = 1000;
+            const dummyBlockNum = 1001;
+            const data = buildTestData(testAmount, alice, dummyBlockNum);
+
+            const outputGuardExitTarget = alice;
+            const parser = await OutputGuardParser.new(outputGuardExitTarget);
+            await this.exitGame.registerOutputGuardParser(1, parser.address);
+
+            await this.framework.setBlock(dummyBlockNum, data.merkleTree.root, 0);
+
+            const outputType = 1;
+            await expectRevert(
+                this.exitGame.startStandardExit(
+                    data.utxoPos, data.tx, outputType, EMPTY_BYTES, data.merkleProof,
+                    { from: alice, value: STANDARD_EXIT_BOND },
+                ),
+                'Output guard data mismatch pre-image',
+            );
+        });
+
+        it('should fail when output guard parser is not registered with the output type given output type non 0', async () => {
+            const testAmount = 1000;
+            const dummyBlockNum = 1001;
+            const outputType = 1;
+            const outputGuardData = web3.utils.toHex(alice);
+            const outputGuard = buildOutputGuard(outputType, outputGuardData);
+
+            const data = buildTestData(testAmount, outputGuard, dummyBlockNum);
+
+            await this.framework.setBlock(dummyBlockNum, data.merkleTree.root, 0);
+
+            await expectRevert(
+                this.exitGame.startStandardExit(
+                    data.utxoPos, data.tx, outputType, outputGuardData, data.merkleProof,
+                    { from: alice, value: STANDARD_EXIT_BOND },
+                ),
+                'Failed to get the output guard parser for the output type',
             );
         });
 
         it('should fail when same exit already started', async () => {
             const testAmount = 1000;
-            const dummyBlockNum = 1000;
-            const data = buildTestData(testAmount, dummyBlockNum);
+            const dummyBlockNum = 1001;
+            const data = buildTestData(testAmount, alice, dummyBlockNum);
 
             await this.framework.setBlock(dummyBlockNum, data.merkleTree.root, 0);
 
             await this.exitGame.startStandardExit(
-                data.utxoPos, data.tx, data.merkleProof,
+                data.utxoPos, data.tx, OUTPUT_TYPE_ZERO, EMPTY_BYTES, data.merkleProof,
                 { from: alice, value: STANDARD_EXIT_BOND },
             );
 
             await expectRevert(
                 this.exitGame.startStandardExit(
-                    data.utxoPos, data.tx, data.merkleProof,
+                    data.utxoPos, data.tx, OUTPUT_TYPE_ZERO, EMPTY_BYTES, data.merkleProof,
                     { from: alice, value: STANDARD_EXIT_BOND },
                 ),
                 'Exit already started',
@@ -135,14 +188,14 @@ contract('PaymentStandardExitable', ([_, alice, bob]) => {
 
         it('should charge the bond for the user', async () => {
             const testAmount = 1000;
-            const dummyBlockNum = 1000;
-            const data = buildTestData(testAmount, dummyBlockNum);
+            const dummyBlockNum = 1001;
+            const data = buildTestData(testAmount, alice, dummyBlockNum);
 
             await this.framework.setBlock(dummyBlockNum, data.merkleTree.root, 0);
 
             const preBalance = new BN(await web3.eth.getBalance(alice));
             const tx = await this.exitGame.startStandardExit(
-                data.utxoPos, data.tx, data.merkleProof,
+                data.utxoPos, data.tx, OUTPUT_TYPE_ZERO, EMPTY_BYTES, data.merkleProof,
                 { from: alice, value: STANDARD_EXIT_BOND },
             );
             const actualPostBalance = new BN(await web3.eth.getBalance(alice));
@@ -155,39 +208,48 @@ contract('PaymentStandardExitable', ([_, alice, bob]) => {
 
         it('should save the StandardExit data when successfully done', async () => {
             const testAmount = 1000;
-            const dummyBlockNum = 1000;
-            const data = buildTestData(testAmount, dummyBlockNum);
+            const dummyBlockNum = 1001;
+            const outputOwner = alice;
+            const data = buildTestData(testAmount, outputOwner, dummyBlockNum);
 
             await this.framework.setBlock(dummyBlockNum, data.merkleTree.root, 0);
 
             await this.exitGame.startStandardExit(
-                data.utxoPos, data.tx, data.merkleProof,
+                data.utxoPos, data.tx, OUTPUT_TYPE_ZERO, EMPTY_BYTES, data.merkleProof,
                 { from: alice, value: STANDARD_EXIT_BOND },
             );
 
             const isTxDeposit = await this.isDeposit.test(dummyBlockNum);
             const exitId = await this.exitIdHelper.getStandardExitId(isTxDeposit, data.tx, data.utxoPos);
+            const outputId = computeOutputId(
+                isTxDeposit, data.tx, data.outputIndex, data.utxoPos,
+            );
+
+            const expectedOutputRelatedDataHash = web3.utils.soliditySha3(
+                { t: 'uint256', v: data.utxoPos }, { t: 'bytes32', v: outputId },
+                { t: 'uint256', v: OUTPUT_TYPE_ZERO }, { t: 'bytes32', v: addressToOutputGuard(outputOwner) },
+            );
 
             const standardExitData = await this.exitGame.exits(exitId);
 
             expect(standardExitData.exitable).to.be.true;
-            expect(standardExitData.position).to.be.bignumber.equal(new BN(data.utxoPos));
-            expect(standardExitData.exitTarget).to.equal(alice);
+            expect(standardExitData.outputRelatedDataHash).to.equal(expectedOutputRelatedDataHash);
+            expect(standardExitData.exitTarget).to.equal(outputOwner);
             expect(standardExitData.token).to.equal(ETH);
             expect(standardExitData.amount).to.be.bignumber.equal(new BN(testAmount));
         });
 
         it('should put the exit data into the queue of framework', async () => {
             const testAmount = 1000;
-            const dummyBlockNum = 1000;
-            const data = buildTestData(testAmount, dummyBlockNum);
+            const dummyBlockNum = 1001;
+            const data = buildTestData(testAmount, alice, dummyBlockNum);
             const currentTimestamp = await time.latest();
             const timestamp = currentTimestamp.sub(new BN(15));
 
             await this.framework.setBlock(dummyBlockNum, data.merkleTree.root, timestamp);
 
             await this.exitGame.startStandardExit(
-                data.utxoPos, data.tx, data.merkleProof,
+                data.utxoPos, data.tx, OUTPUT_TYPE_ZERO, EMPTY_BYTES, data.merkleProof,
                 { from: alice, value: STANDARD_EXIT_BOND },
             );
 
@@ -203,6 +265,313 @@ contract('PaymentStandardExitable', ([_, alice, bob]) => {
             expect(queueExitData.exitId).to.be.bignumber.equal(exitId);
             expect(queueExitData.exitProcessor).to.equal(this.exitGame.address);
             expect(queueExitData.exitableAt).to.be.bignumber.equal(exitableAt);
+        });
+
+        it('should emit ExitStarted event', async () => {
+            const testAmount = 1000;
+            const dummyBlockNum = 1001;
+            const data = buildTestData(testAmount, alice, dummyBlockNum);
+
+            await this.framework.setBlock(dummyBlockNum, data.merkleTree.root, 0);
+
+            const isTxDeposit = await this.isDeposit.test(dummyBlockNum);
+            const exitId = await this.exitIdHelper.getStandardExitId(isTxDeposit, data.tx, data.utxoPos);
+            const { logs } = await this.exitGame.startStandardExit(
+                data.utxoPos, data.tx, OUTPUT_TYPE_ZERO, EMPTY_BYTES, data.merkleProof,
+                { from: alice, value: STANDARD_EXIT_BOND },
+            );
+
+            expectEvent.inLogs(
+                logs,
+                'ExitStarted',
+                { owner: alice, exitId },
+            );
+        });
+    });
+
+    describe('challengeStandardExit', () => {
+        const getTestInput = (outputType, outputGuard) => ({
+            exitId: 123,
+            outputType,
+            outputUtxoPos: buildUtxoPos(1, 0, 0),
+            outputId: web3.utils.sha3('random'),
+            outputGuard,
+            challengeTxType: 1,
+            challengeTx: EMPTY_BYTES,
+            inputIndex: 0,
+            witness: EMPTY_BYTES,
+        });
+
+        const getOutputRelatedDataHash = input => web3.utils.soliditySha3(
+            { t: 'uint256', v: input.outputUtxoPos },
+            { t: 'bytes32', v: input.outputId },
+            { t: 'uint256', v: input.outputType },
+            { t: 'bytes32', v: input.outputGuard },
+        );
+
+        const getExpectedConditionInput = input => ({
+            outputGuard: input.outputGuard,
+            utxoPos: input.outputUtxoPos,
+            outputId: input.outputId,
+            consumeTx: input.challengeTx,
+            inputIndex: input.inputIndex,
+            witness: input.witness,
+        });
+
+        const getTestExitData = (outputRelatedDataHash, exitTarget) => ({
+            exitable: true,
+            outputRelatedDataHash,
+            token: ETH,
+            exitTarget,
+            amount: 66666,
+        });
+
+        beforeEach(async () => {
+            this.framework = await DummyPlasmaFramework.new();
+            this.exitGame = await PaymentStandardExitable.new(this.framework.address);
+        });
+
+        it('should fail when exit for such exit id does not exists', async () => {
+            const input = getTestInput(OUTPUT_TYPE_ZERO, addressToOutputGuard(alice));
+            await expectRevert(
+                this.exitGame.challengeStandardExit(input),
+                'Such exit does not exists',
+            );
+        });
+
+        it('should fail when utxo pos mismatch exit data', async () => {
+            const input = getTestInput(OUTPUT_TYPE_ZERO, addressToOutputGuard(alice));
+            const mismatchUtxoPos = input.outputUtxoPos + 1;
+            const outputRelatedDataHash = web3.utils.soliditySha3(
+                { t: 'uint256', v: mismatchUtxoPos },
+                { t: 'bytes32', v: input.outputId },
+                { t: 'uint256', v: input.outputType },
+                { t: 'bytes32', v: input.outputGuard },
+            );
+
+            await this.exitGame.setExit(input.exitId, getTestExitData(outputRelatedDataHash, alice));
+
+            await expectRevert(
+                this.exitGame.challengeStandardExit(input),
+                'Some of the output related challenge data are invalid for the exit',
+            );
+        });
+
+        it('should fail when output id mismatch exit data', async () => {
+            const input = getTestInput(OUTPUT_TYPE_ZERO, addressToOutputGuard(alice));
+            const mismatchOutputId = web3.utils.sha3(input.outputId);
+            const outputRelatedDataHash = web3.utils.soliditySha3(
+                { t: 'uint256', v: input.outputUtxoPos },
+                { t: 'bytes32', v: mismatchOutputId },
+                { t: 'uint256', v: input.outputType },
+                { t: 'bytes32', v: input.outputGuard },
+            );
+
+            await this.exitGame.setExit(input.exitId, getTestExitData(outputRelatedDataHash, alice));
+
+            await expectRevert(
+                this.exitGame.challengeStandardExit(input),
+                'Some of the output related challenge data are invalid for the exit',
+            );
+        });
+
+        it('should fail when output type mismatch exit data', async () => {
+            const input = getTestInput(OUTPUT_TYPE_ZERO, addressToOutputGuard(alice));
+            const mismatchOutputType = input.outputType + 1;
+            const outputRelatedDataHash = web3.utils.soliditySha3(
+                { t: 'uint256', v: input.outputUtxoPos },
+                { t: 'bytes32', v: input.outputId },
+                { t: 'uint256', v: mismatchOutputType },
+                { t: 'bytes32', v: input.outputGuard },
+            );
+
+            await this.exitGame.setExit(input.exitId, getTestExitData(outputRelatedDataHash, alice));
+
+            await expectRevert(
+                this.exitGame.challengeStandardExit(input),
+                'Some of the output related challenge data are invalid for the exit',
+            );
+        });
+
+        it('should fail when output guard mismatch exit data', async () => {
+            const input = getTestInput(OUTPUT_TYPE_ZERO, addressToOutputGuard(alice));
+            const mismatchOutputGuard = web3.utils.sha3('mismatch output guard');
+            const outputRelatedDataHash = web3.utils.soliditySha3(
+                { t: 'uint256', v: input.outputUtxoPos },
+                { t: 'bytes32', v: input.outputId },
+                { t: 'uint256', v: input.outputType },
+                { t: 'bytes32', v: mismatchOutputGuard },
+            );
+
+            await this.exitGame.setExit(input.exitId, getTestExitData(outputRelatedDataHash, alice));
+
+            await expectRevert(
+                this.exitGame.challengeStandardExit(input),
+                'Some of the output related challenge data are invalid for the exit',
+            );
+        });
+
+        it('should fail when not able to find the spending condition contract', async () => {
+            const input = getTestInput(OUTPUT_TYPE_ZERO, addressToOutputGuard(alice));
+            const outputRelatedDataHash = getOutputRelatedDataHash(input);
+            await this.exitGame.setExit(input.exitId, getTestExitData(outputRelatedDataHash, alice));
+
+            await expectRevert(
+                this.exitGame.challengeStandardExit(input),
+                'Spending condition contract not found',
+            );
+        });
+
+        it('should fail when spending condition contract returns false', async () => {
+            const input = getTestInput(OUTPUT_TYPE_ZERO, addressToOutputGuard(alice));
+            const outputRelatedDataHash = getOutputRelatedDataHash(input);
+            const conditionFalse = await PaymentSpendingConditionFalse.new();
+            await this.exitGame.registerSpendingCondition(
+                input.outputType, input.challengeTxType, conditionFalse.address,
+            );
+
+            await this.exitGame.setExit(input.exitId, getTestExitData(outputRelatedDataHash, alice));
+
+            await expectRevert(
+                this.exitGame.challengeStandardExit(input),
+                'Spending condition failed',
+            );
+        });
+
+        it('should fail when spending condition contract reverts', async () => {
+            const input = getTestInput(OUTPUT_TYPE_ZERO, addressToOutputGuard(alice));
+            const outputRelatedDataHash = getOutputRelatedDataHash(input);
+            const conditionRevert = await PaymentSpendingConditionRevert.new();
+            await this.exitGame.registerSpendingCondition(
+                input.outputType, input.challengeTxType, conditionRevert.address,
+            );
+
+            await this.exitGame.setExit(input.exitId, getTestExitData(outputRelatedDataHash, alice));
+
+            const revertMessage = await conditionRevert.revertMessage();
+            await expectRevert(
+                this.exitGame.challengeStandardExit(input),
+                revertMessage,
+            );
+        });
+
+        it('should calls the Spending Condition contract with expected params given output type 0', async () => {
+            await this.exitGame.depositFundForTest({ value: STANDARD_EXIT_BOND });
+
+            const input = getTestInput(OUTPUT_TYPE_ZERO, addressToOutputGuard(alice));
+            const outputRelatedDataHash = getOutputRelatedDataHash(input);
+            const conditionExpected = await PaymentSpendingConditionExpected.new();
+            const exitTarget = alice;
+
+            // spending condition contract would only returns true
+            // when expected data is as input params during 'verify(...)' called.
+            const expectedConditionInput = getExpectedConditionInput(input);
+            await conditionExpected.setExpected(expectedConditionInput);
+
+            await this.exitGame.registerSpendingCondition(
+                input.outputType, input.challengeTxType, conditionExpected.address,
+            );
+
+            await this.exitGame.setExit(input.exitId, getTestExitData(outputRelatedDataHash, exitTarget));
+
+            await this.exitGame.challengeStandardExit(input);
+            const exitData = await this.exitGame.exits(input.exitId);
+            expect(exitData.exitable).to.be.false;
+        });
+
+        it('should calls the Spending Condition contract with expected params given output type non 0', async () => {
+            await this.exitGame.depositFundForTest({ value: STANDARD_EXIT_BOND });
+
+            const outputType = 1;
+            const dummyOutputGuard = `0x${Array(64).fill(1).join('')}`;
+            const input = getTestInput(outputType, dummyOutputGuard);
+            const outputRelatedDataHash = getOutputRelatedDataHash(input);
+            const conditionExpected = await PaymentSpendingConditionExpected.new();
+            const exitTarget = alice;
+
+            // spending condition contract would only returns true
+            // when expected data is as input params during 'verify(...)' called.
+            const expectedConditionInput = getExpectedConditionInput(input);
+            await conditionExpected.setExpected(expectedConditionInput);
+
+            await this.exitGame.registerSpendingCondition(
+                input.outputType, input.challengeTxType, conditionExpected.address,
+            );
+
+            await this.exitGame.setExit(input.exitId, getTestExitData(outputRelatedDataHash, exitTarget));
+
+            await this.exitGame.challengeStandardExit(input);
+            const exitData = await this.exitGame.exits(input.exitId);
+            expect(exitData.exitable).to.be.false;
+        });
+
+        it('should deletes the exit data when successfully challenged', async () => {
+            await this.exitGame.depositFundForTest({ value: STANDARD_EXIT_BOND });
+
+            const input = getTestInput(OUTPUT_TYPE_ZERO, addressToOutputGuard(alice));
+            const outputRelatedDataHash = getOutputRelatedDataHash(input);
+            const conditionTrue = await PaymentSpendingConditionTrue.new();
+            await this.exitGame.registerSpendingCondition(
+                input.outputType, input.challengeTxType, conditionTrue.address,
+            );
+
+            await this.exitGame.setExit(input.exitId, getTestExitData(outputRelatedDataHash, alice));
+
+            await this.exitGame.challengeStandardExit(input);
+
+            const exitData = await this.exitGame.exits(input.exitId);
+            expect(exitData.exitable).to.be.false;
+            expect(exitData.outputRelatedDataHash).to.equal(EMPTY_BYTES32);
+            expect(exitData.token).to.equal(constants.ZERO_ADDRESS);
+            expect(exitData.exitTarget).to.equal(constants.ZERO_ADDRESS);
+            expect(exitData.amount.toNumber()).to.equal(0);
+        });
+
+        it('should transfer the standard exit bond to challenger when successfully challenged', async () => {
+            await this.exitGame.depositFundForTest({ value: STANDARD_EXIT_BOND });
+
+            const input = getTestInput(OUTPUT_TYPE_ZERO, addressToOutputGuard(alice));
+            const outputRelatedDataHash = getOutputRelatedDataHash(input);
+            const conditionTrue = await PaymentSpendingConditionTrue.new();
+            await this.exitGame.registerSpendingCondition(
+                input.outputType, input.challengeTxType, conditionTrue.address,
+            );
+
+            await this.exitGame.setExit(input.exitId, getTestExitData(outputRelatedDataHash, alice));
+
+            const preBalance = new BN(await web3.eth.getBalance(bob));
+
+            const tx = await this.exitGame.challengeStandardExit(
+                input, { from: bob },
+            );
+
+            const actualPostBalance = new BN(await web3.eth.getBalance(bob));
+            const expectedPostBalance = preBalance
+                .add(new BN(STANDARD_EXIT_BOND))
+                .sub(await spentOnGas(tx.receipt));
+
+            expect(actualPostBalance).to.be.bignumber.equal(expectedPostBalance);
+        });
+
+        it('should emit ExitChallenged event when successfully challenged', async () => {
+            await this.exitGame.depositFundForTest({ value: STANDARD_EXIT_BOND });
+
+            const input = getTestInput(OUTPUT_TYPE_ZERO, addressToOutputGuard(alice));
+            const outputRelatedDataHash = getOutputRelatedDataHash(input);
+            const conditionTrue = await PaymentSpendingConditionTrue.new();
+            await this.exitGame.registerSpendingCondition(
+                input.outputType, input.challengeTxType, conditionTrue.address,
+            );
+
+            await this.exitGame.setExit(input.exitId, getTestExitData(outputRelatedDataHash, alice));
+
+            const { logs } = await this.exitGame.challengeStandardExit(input);
+
+            expectEvent.inLogs(
+                logs,
+                'ExitChallenged',
+                { utxoPos: new BN(input.outputUtxoPos) },
+            );
         });
     });
 });

--- a/plasma_framework/test/src/exits/utils/OutputGuard.test.js
+++ b/plasma_framework/test/src/exits/utils/OutputGuard.test.js
@@ -1,0 +1,36 @@
+const OutputGuard = artifacts.require('OutputGuardWrapper');
+
+const { expect } = require('chai');
+const { buildOutputGuard } = require('../../../helpers/utils.js');
+
+contract('OutputId', () => {
+    const EMPTY_OUTPUT_GUARD = `0x${Array(64).fill(1).join('')}`;
+
+    before('setup', async () => {
+        this.contract = await OutputGuard.new();
+    });
+
+    describe('build', () => {
+        it('should get the correct output guard given output type 0 and empty output guard data', async () => {
+            const outputType = 0;
+            const result = await this.contract.build(outputType, EMPTY_OUTPUT_GUARD);
+            expect(web3.utils.toHex(result))
+                .to.equal(buildOutputGuard(outputType, EMPTY_OUTPUT_GUARD));
+        });
+
+        it('should get the correct output guard given output type non 0 and empty output guard data', async () => {
+            const outputType = 1;
+
+            expect(await this.contract.build(outputType, EMPTY_OUTPUT_GUARD))
+                .to.equal(buildOutputGuard(outputType, EMPTY_OUTPUT_GUARD));
+        });
+
+        it('should get the correct output guard given output type non 0 and non empty output guard data', async () => {
+            const outputType = 1;
+            const outputGuardData = web3.utils.utf8ToHex('output guard data');
+
+            expect(await this.contract.build(outputType, outputGuardData))
+                .to.equal(buildOutputGuard(outputType, outputGuardData));
+        });
+    });
+});

--- a/plasma_framework/test/src/exits/utils/OutputGuard.test.js
+++ b/plasma_framework/test/src/exits/utils/OutputGuard.test.js
@@ -3,7 +3,7 @@ const OutputGuard = artifacts.require('OutputGuardWrapper');
 const { expect } = require('chai');
 const { buildOutputGuard } = require('../../../helpers/utils.js');
 
-contract('OutputId', () => {
+contract('OutputGuard', () => {
     const EMPTY_OUTPUT_GUARD = `0x${Array(64).fill(1).join('')}`;
 
     before('setup', async () => {

--- a/plasma_framework/test/src/exits/utils/OutputId.test.js
+++ b/plasma_framework/test/src/exits/utils/OutputId.test.js
@@ -1,0 +1,86 @@
+const OutputId = artifacts.require('OutputIdWrapper');
+
+const { constants } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
+
+const { PaymentTransaction, PaymentTransactionOutput } = require('../../../helpers/transaction.js');
+const { computeDepositOutputId, computeNormalOutputId } = require('../../../helpers/utils.js');
+
+contract('OutputId', () => {
+    const OUTPUT_GUARD = `0x${Array(64).fill(1).join('')}`;
+    const EMPTY_BYTES32 = `0x${Array(64).fill(0).join('')}`;
+
+    before('setup', async () => {
+        this.contract = await OutputId.new();
+    });
+
+    describe('compute', () => {
+        it('should get the correct output id for deposit tx output', async () => {
+            const output = new PaymentTransactionOutput(100, OUTPUT_GUARD, constants.ZERO_ADDRESS);
+            const transaction = new PaymentTransaction(1, [EMPTY_BYTES32], [output], EMPTY_BYTES32);
+            const dummyTxBytes = web3.utils.bytesToHex(transaction.rlpEncoded());
+
+            const isDeposit = true;
+            const outputIndex = 0;
+            const dummyUtxoPos = 1000000000;
+
+            expect(await this.contract.compute(isDeposit, dummyTxBytes, outputIndex, dummyUtxoPos))
+                .to.equal(computeDepositOutputId(dummyTxBytes, outputIndex, dummyUtxoPos));
+        });
+
+        it('should return distinct output ids for deposits that differs in utxo pos', async () => {
+            const output = new PaymentTransactionOutput(100, OUTPUT_GUARD, constants.ZERO_ADDRESS);
+            const transaction = new PaymentTransaction(1, [EMPTY_BYTES32], [output], EMPTY_BYTES32);
+            const dummyTxBytes = web3.utils.bytesToHex(transaction.rlpEncoded());
+
+            const isDeposit = true;
+            const outputIndex = 0;
+            const dummyUtxoPos1 = 1000000000;
+            const dummyUtxoPos2 = 2000000000;
+
+            const outputId1 = await this.contract.compute(isDeposit, dummyTxBytes, outputIndex, dummyUtxoPos1);
+            const outputId2 = await this.contract.compute(isDeposit, dummyTxBytes, outputIndex, dummyUtxoPos2);
+            expect(outputId1).to.not.equal(outputId2);
+        });
+
+        it('should get the correct output id for non deposit tx output when output index is 0', async () => {
+            const output = new PaymentTransactionOutput(100, OUTPUT_GUARD, constants.ZERO_ADDRESS);
+            const transaction = new PaymentTransaction(1, [1000000000], [output, output], EMPTY_BYTES32);
+            const dummyTxBytes = web3.utils.bytesToHex(transaction.rlpEncoded());
+
+            const isDeposit = false;
+            const outputIndex = 0;
+            const dummyUtxoPos = 123;
+
+            expect(await this.contract.compute(isDeposit, dummyTxBytes, outputIndex, dummyUtxoPos))
+                .to.equal(computeNormalOutputId(dummyTxBytes, outputIndex));
+        });
+
+        it('should get the correct output id for non deposit tx output when output index is not 0', async () => {
+            const output = new PaymentTransactionOutput(100, OUTPUT_GUARD, constants.ZERO_ADDRESS);
+            const transaction = new PaymentTransaction(1, [1000000000], [output, output], EMPTY_BYTES32);
+            const dummyTxBytes = web3.utils.bytesToHex(transaction.rlpEncoded());
+
+            const isDeposit = false;
+            const outputIndex = 1;
+            const dummyUtxoPos = 123;
+
+            expect(await this.contract.compute(isDeposit, dummyTxBytes, outputIndex, dummyUtxoPos))
+                .to.equal(computeNormalOutputId(dummyTxBytes, outputIndex));
+        });
+
+        it('should get the same output id for non deposit tx output no matter what utxo pos is passed in', async () => {
+            const output = new PaymentTransactionOutput(100, OUTPUT_GUARD, constants.ZERO_ADDRESS);
+            const transaction = new PaymentTransaction(1, [1000000000], [output, output], EMPTY_BYTES32);
+            const dummyTxBytes = web3.utils.bytesToHex(transaction.rlpEncoded());
+
+            const isDeposit = false;
+            const outputIndex = 1;
+            const dummyUtxoPos = 123;
+            const randomUtxoPos = 456;
+
+            expect(await this.contract.compute(isDeposit, dummyTxBytes, outputIndex, dummyUtxoPos))
+                .to.equal(await this.contract.compute(isDeposit, dummyTxBytes, outputIndex, randomUtxoPos));
+        });
+    });
+});

--- a/plasma_framework/test/src/transactions/eip712Libs/PaymentEip712Lib.test.js
+++ b/plasma_framework/test/src/transactions/eip712Libs/PaymentEip712Lib.test.js
@@ -1,0 +1,53 @@
+const PaymentEip712Lib = artifacts.require('PaymentEip712LibMock');
+
+const { expect } = require('chai');
+const { constants } = require('openzeppelin-test-helpers');
+const {
+    PaymentTransactionOutput, PaymentTransaction, PlasmaDepositTransaction,
+} = require('../../../helpers/transaction.js');
+const { addressToOutputGuard } = require('../../../helpers/utils.js');
+const { buildUtxoPos } = require('../../../helpers/utxoPos.js');
+const { hashTx } = require('../../../helpers/paymentEip712.js');
+
+const OUTPUT_GUARD = `0x${Array(64).fill(1).join('')}`;
+
+contract('PaymentEip712Lib', ([alice]) => {
+    before(async () => {
+        this.verifyingContract = (await PaymentEip712Lib.new(constants.ZERO_ADDRESS)).address;
+        this.contract = await PaymentEip712Lib.new(this.verifyingContract);
+    });
+
+    describe('hashTx', () => {
+        it('should hash normal transaction correctly', async () => {
+            const metaData = `0x${Array(64).fill(2).join('')}`;
+            const output = new PaymentTransactionOutput(100, OUTPUT_GUARD, constants.ZERO_ADDRESS);
+            const utxoPos = buildUtxoPos(10000, 0, 0);
+            const tx = new PaymentTransaction(1, [utxoPos], [output], metaData);
+            const txBytes = web3.utils.bytesToHex(tx.rlpEncoded());
+
+            expect(await this.contract.hashTx(this.verifyingContract, txBytes))
+                .to.equal(hashTx(tx, this.verifyingContract));
+        });
+
+        it('should hash deposit transaction correctly', async () => {
+            const output = new PaymentTransactionOutput(
+                100, addressToOutputGuard(alice), constants.ZERO_ADDRESS,
+            );
+            const tx = new PlasmaDepositTransaction(output);
+            const txBytes = web3.utils.bytesToHex(tx.rlpEncoded());
+
+            expect(await this.contract.hashTx(this.verifyingContract, txBytes))
+                .to.equal(hashTx(tx, this.verifyingContract));
+        });
+
+        it('should hash transaction correctly given transaction has empty metaData', async () => {
+            const output = new PaymentTransactionOutput(100, OUTPUT_GUARD, constants.ZERO_ADDRESS);
+            const utxoPos = buildUtxoPos(10000, 0, 0);
+            const tx = new PaymentTransaction(1, [utxoPos], [output]);
+            const txBytes = web3.utils.bytesToHex(tx.rlpEncoded());
+
+            expect(await this.contract.hashTx(this.verifyingContract, txBytes))
+                .to.equal(hashTx(tx, this.verifyingContract));
+        });
+    });
+});


### PR DESCRIPTION
### Note
**This is now a draft for discussion purpose! (would keep on working to make it review ready, however, want early feedbacks)** 

This draft shows what I think how we can do `outputGuard` and `output predicate` (I named it `SpendingCondition` in the code here).

#### Output type and registries
There are two registries here: Output guard parser + Spending Condition (Output Predicate)

Instead of having those in PlasmaFramework, I think it is fair to just register these two per tx type. First, it saves some gas when getting data, also it mitigate the area how these two registries can impact. This makes `output type` only unique under same `tx type`. I think it is totally fine and good.

#### Output guard
The basic logic does the following:
1. if `outputType` == 0 --> `output.outputGuard` hold owner address directly.
1. else --> parse the output data from `outputGuardParser`

We need to be able to get the `outputGuardParser`, thus a registry for `outputGuardParser`.
So far I only put one function (`parseExitTarget`) in and I think this `IOutputGuardParser` interface should be general enough for all tx types to use (?).

Also, since `output guard` value is verified in the step `startStandardExit`. To save some gas, we save only the hash of all data needed in `challengeStandardExit` step and pass those data as input (check the variable `challengeDataHash`). So we don't need to verify those data again in other steps as well as not need to save multiple data in storage.

#### Spending Condition (Output Predicate)
I made Output Predicate (`SpendingCondition`) bind to tx type.  (see: `IPaymentSpendingCondition`).
I am just not sure whether that is general enough or not as current interface does not pass in whole output data (eg. token and amount) to the `SpendingCondition` contract.

```
function verifyViaOutputGuard(
        bytes calldata _outputGuardData,
        uint256 _utxoPos,
        bytes32 _outputId,
        bytes calldata _consumeTx,
        uint8 _inputIndex,
        bytes calldata _witness
    ) external returns (bool);
```

- In this one, `utxoPos` and `outputId` serves same purpose, where checks with `consumeTx.inputs[inputIndex]`. Only one of them would be used actually. This is how we can support both `utxoPos` and `outputId` to be as input format.
- `outputGuardData`  provide us data of authentication owner, eg. venue address or trader address depends on the need. The SpendingCondition contract would knows how to parse the outputGuardData. (Quite likely reuse the `outputGuardParser`)
- `witness` holds **all** proof data to be used. eg. output owner signature, confirm signature, zk-snark proof data, zk-snark proof public inputs. (is this a good idea?)


The another function `verifyViaOwner` is just a simplified version of the previous one when output guard is not needed.

For DEX tx consuming Payment, it would be using output guard.

For transition to ERC721 tx, I think they can just use output type 0, where owner info is directly in output guard field. Would be using different Spending Condition because the consume tx type of ERC721 tx is different from Payment tx.