### PR TITLE
PlasmaFramework should not be ExitGameRegistry

### DIFF
--- a/plasma_framework/contracts/src/framework/PlasmaFramework.sol
+++ b/plasma_framework/contracts/src/framework/PlasmaFramework.sol
@@ -4,11 +4,10 @@ pragma experimental ABIEncoderV2;
 import "./BlockController.sol";
 import "./ExitGameController.sol";
 import "./registries/VaultRegistry.sol";
-import "./registries/ExitGameRegistry.sol";
 import "./utils/Operated.sol";
 import "./interfaces/IPlasmaFramework.sol";
 
-contract PlasmaFramework is IPlasmaFramework, Operated, VaultRegistry, ExitGameRegistry, ExitGameController, BlockController {
+contract PlasmaFramework is IPlasmaFramework, Operated, VaultRegistry, ExitGameController, BlockController {
     uint256 public constant CHILD_BLOCK_INTERVAL = 1000;
 
     // NOTE: this is the "middle" period.


### PR DESCRIPTION
PlasmaFramework should not be ExitGameRegistry because it's an ExitGameController, which is an ExitGameRegistry.