### PR TITLE
Elevate private fields to public

### DIFF
--- a/plasma_framework/contracts/src/framework/BlockController.sol
+++ b/plasma_framework/contracts/src/framework/BlockController.sol
@@ -46,7 +46,7 @@ contract BlockController is Operated, VaultRegistry {
      * @param _blockRoot Merkle root of the block.
      */
     function submitDepositBlock(bytes32 _blockRoot) public onlyFromVault {
-        require(nextDepositBlock < childBlockInterval, "Exceed limit of deposits per child block interval");
+        require(nextDepositBlock < childBlockInterval, "Exceeded limit of deposits per child block interval");
 
         uint256 blknum = nextChildBlock - childBlockInterval + nextDepositBlock;
         blocks[blknum] = BlockModel.Block({

--- a/plasma_framework/test/src/framework/BlockController.test.js
+++ b/plasma_framework/test/src/framework/BlockController.test.js
@@ -104,7 +104,7 @@ contract('BlockController', ([_, other]) => {
 
             await expectRevert(
                 this.dummyVault.submitDepositBlock(this.dummyBlockHash),
-                'Exceed limit of deposits per child block interval',
+                'Exceeded limit of deposits per child block interval',
             );
         });
 


### PR DESCRIPTION
This PR changes `private` access modifiers into `public`, where the fields did have publicly available getters. We now use getters implicitly provided by Solidity.