### PR TITLE
chore: use uint16 for output index

### DIFF
--- a/plasma_framework/contracts/mocks/utils/UtxoPosLibWrapper.sol
+++ b/plasma_framework/contracts/mocks/utils/UtxoPosLibWrapper.sol
@@ -15,7 +15,7 @@ contract UtxoPosLibWrapper {
         return UtxoPosLib.UtxoPos(_utxoPos).txIndex();
     }
 
-    function outputIndex(uint256 _utxoPos) public pure returns (uint8) {
+    function outputIndex(uint256 _utxoPos) public pure returns (uint16) {
         return UtxoPosLib.UtxoPos(_utxoPos).outputIndex();
     }
 

--- a/plasma_framework/contracts/src/exits/utils/ExitId.sol
+++ b/plasma_framework/contracts/src/exits/utils/ExitId.sol
@@ -14,8 +14,8 @@ library ExitId {
      * @param _utxoPos UTXO position of the exiting output.
      * @return _standardExitId Unique standard exit id.
      *     Anatomy of returned value, most significant bits first:
-     *     8 bits - oindex
-     *     1 bit - in-flight flag
+     *     16 bits - output index
+     *     1 bit - in-flight flag (0 for standard exit)
      *     151 bit - hash(tx) or hash(tx|utxo) for deposit
      */
     function getStandardExitId(
@@ -39,7 +39,7 @@ library ExitId {
     Private
     */
 
-    function _computeStandardExitId(bytes32 _txhash, uint8 _outputIndex)
+    function _computeStandardExitId(bytes32 _txhash, uint16 _outputIndex)
         private
         pure
         returns (uint192)

--- a/plasma_framework/contracts/src/utils/UtxoPosLib.sol
+++ b/plasma_framework/contracts/src/utils/UtxoPosLib.sol
@@ -47,9 +47,9 @@ library UtxoPosLib {
     function outputIndex(UtxoPos memory _utxoPos)
         internal
         pure
-        returns (uint8)
+        returns (uint16)
     {
-        return uint8(_utxoPos.value % TX_OFFSET);
+        return uint16(_utxoPos.value % TX_OFFSET);
     }
 
     /**

--- a/plasma_framework/test/helpers/utxoPos.js
+++ b/plasma_framework/test/helpers/utxoPos.js
@@ -1,5 +1,3 @@
-const assert = require('assert');
-
 const BLOCK_OFFSET = 1000000000;
 const TX_OFFSET = 10000;
 
@@ -13,8 +11,6 @@ class UtxoPos {
         this.blockNum = Math.floor(this.utxoPos / BLOCK_OFFSET);
         this.txIndex = Math.floor((this.utxoPos % BLOCK_OFFSET) / TX_OFFSET);
         this.outputIndex = this.utxoPos % TX_OFFSET;
-
-        assert(this.outputIndex < 256, 'output index should be less then 2^8');
     }
 }
 


### PR DESCRIPTION
We were using uint8 for output index which limits the tx output to
around 256. For DEX batch settlement this seems to be small. This commit
extends the field to uint16 and cap the output index to limit of
TX_OFFSET (10000).

closes #168 