### PR TITLE
feat: add flag output spent function

### DIFF
--- a/plasma_framework/contracts/mocks/framework/DummyExitGame.sol
+++ b/plasma_framework/contracts/mocks/framework/DummyExitGame.sol
@@ -37,4 +37,12 @@ contract DummyExitGame is IExitProcessor {
     function enqueue(uint192 _priority, address _token, ExitModel.Exit memory _exit) public {
         uniquePriorityFromEnqueue = exitGameController.enqueue(_priority, _token, _exit);
     }
+
+    function proxyBatchFlagOutputsSpent(bytes32[] memory _outputIds) public {
+        exitGameController.batchFlagOutputsSpent(_outputIds);
+    }
+
+    function proxyFlagOutputSpent(bytes32 _outputId) public {
+        exitGameController.flagOutputSpent(_outputId);
+    }
 }

--- a/plasma_framework/contracts/src/framework/ExitGameController.sol
+++ b/plasma_framework/contracts/src/framework/ExitGameController.sol
@@ -10,6 +10,7 @@ contract ExitGameController is ExitGameRegistry {
     uint64 public exitQueueNonce = 1;
     mapping (uint256 => ExitModel.Exit) public exits;
     mapping (address => PriorityQueue) public exitsQueues;
+    mapping (bytes32 => bool) public isOutputSpent;
 
     event TokenAdded(
         address token
@@ -107,5 +108,36 @@ contract ExitGameController is ExitGameRegistry {
         }
 
         emit ProcessedExitsNum(processedNum, _token);
+    }
+
+    /**
+     * @notice Checks if any of the output with the given outputIds is spent already.
+     * @param _outputIds Output ids to be checked.
+     */
+    function isAnyOutputsSpent(bytes32[] calldata _outputIds) external view returns (bool) {
+        for (uint i = 0 ; i < _outputIds.length ; i++) {
+            if (isOutputSpent[_outputIds[i]] == true) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @notice Batch flags outputs that is spent
+     * @param _outputIds Output ids to be flagged
+     */
+    function batchFlagOutputsSpent(bytes32[] calldata _outputIds) external onlyFromExitGame {
+        for (uint i = 0 ; i < _outputIds.length ; i++) {
+            isOutputSpent[_outputIds[i]] = true;
+        }
+    }
+
+    /**
+     * @notice Flags a single outputs as spent
+     * @param _outputId The output id to be flagged as spent
+     */
+    function flagOutputSpent(bytes32 _outputId) external onlyFromExitGame {
+        isOutputSpent[_outputId] = true;
     }
 }


### PR DESCRIPTION
### Note
We need to flag output spent when exits are processed. We would
rely on this to resolve interaction between standard exit and
in-flight exit. Also, we would need this to solve the previous
problem that operator can steal fund.

This commit adds both batch and single api to flag. Batch api would
be used in in flight exit and single api for standard exit.

Meanwhile, as we moved some variables to public, which by default
comes with a getter function, remove the test for those getter.

- closes https://github.com/omisego/plasma-contracts/issues/171
- operator steal fund: https://git.io/fj1rz

### Test
```
 Contract: ExitGameController
    flagOutputsSpent
      ✓ should be able to flag single output (114ms)
      ✓ should be able to flag multiple outputs (103ms)
      ✓ should fail when not called by Exit Game contracts (54ms)
```