### PR TITLE
Fix InFlightExit id miscalculation

### DIFF
--- a/contracts/RootChain.sol
+++ b/contracts/RootChain.sol
@@ -841,7 +841,7 @@ contract RootChain {
         pure
         returns (uint192)
     {
-        return uint192((uint256(keccak256(_tx)) >> 151).setBit(152));
+        return uint192((uint256(keccak256(_tx)) >> 105).setBit(152));
     }
 
     /**

--- a/contracts/RootChain.sol
+++ b/contracts/RootChain.sol
@@ -841,7 +841,7 @@ contract RootChain {
         pure
         returns (uint192)
     {
-        return uint192((uint256(keccak256(_tx)) >> 105).setBit(152));
+        return uint192((uint256(keccak256(_tx)) >> 105).setBit(151));
     }
 
     /**
@@ -906,7 +906,7 @@ contract RootChain {
         returns (uint64, uint192, bool)
     {
         uint64 exitableTimestamp = uint64(priority >> 214);
-        bool inFlight = priority.getBit(152) == 1;
+        bool inFlight = priority.getBit(151) == 1;
 
         // get 160 least significant bits
         uint192 exitId = uint192((priority << 96) >> 96);


### PR DESCRIPTION
We stated that the least 151 significant bits in exit id are reserved to
the tx's hash, but due to a bug it was no more that 105 bits of hash
used.

Shifting 256-bit left by 151 means that the 151 most significant bits
become zeroes and only 101 bits from the initial value are used (256 - 151 = 105).