### PR TITLE
feat: emit event on ExitGame and Vault registering

### DIFF
--- a/plasma_framework/contracts/src/framework/registries/ExitGameRegistry.sol
+++ b/plasma_framework/contracts/src/framework/registries/ExitGameRegistry.sol
@@ -6,6 +6,11 @@ contract ExitGameRegistry is Operated {
     mapping(uint256 => address) private _exitGames;
     mapping(address => uint256) private _exitGameToTxType;
 
+    event ExitGameRegistered(
+        uint256 txType,
+        address exitGameAddress
+    );
+
     modifier onlyFromExitGame() {
         require(_exitGameToTxType[msg.sender] != 0, "Not being called by registered exit game contract");
         _;
@@ -24,6 +29,8 @@ contract ExitGameRegistry is Operated {
 
         _exitGames[_txType] = _contract;
         _exitGameToTxType[_contract] = _txType;
+
+        emit ExitGameRegistered(_txType, _contract);
     }
 
     function exitGames(uint256 _txType) public view returns (address) {

--- a/plasma_framework/contracts/src/framework/registries/VaultRegistry.sol
+++ b/plasma_framework/contracts/src/framework/registries/VaultRegistry.sol
@@ -6,6 +6,11 @@ contract VaultRegistry is Operated {
     mapping(uint256 => address) private _vaults;
     mapping(address => uint256) private _vaultToId;
 
+    event VaultRegistered(
+        uint256 vaultId,
+        address vaultAddress
+    );
+
     modifier onlyFromVault() {
         require(_vaultToId[msg.sender] > 0, "Not being called by registered vaults");
         _;
@@ -24,6 +29,8 @@ contract VaultRegistry is Operated {
 
         _vaults[_vaultId] = _vaultAddress;
         _vaultToId[_vaultAddress] = _vaultId;
+
+        emit VaultRegistered(_vaultId, _vaultAddress);
     }
 
     function vaults(uint256 _vaultId) public view returns (address) {

--- a/plasma_framework/test/src/framework/registries/ExitGameRegistry.test.js
+++ b/plasma_framework/test/src/framework/registries/ExitGameRegistry.test.js
@@ -61,12 +61,26 @@ contract('ExitGameRegistry', ([_, other]) => {
     });
 
     describe('registerExitGame', () => {
-        it('can register successfully', async () => {
+        it('should save the exit game data correctly', async () => {
             const txType = 1;
             await this.registry.registerExitGame(txType, this.dummyExitGame.address);
             expect(await this.registry.exitGames(txType)).to.equal(this.dummyExitGame.address);
             expect(await this.registry.exitGameToTxType(this.dummyExitGame.address))
                 .to.be.bignumber.equal(new BN(txType));
+        });
+
+        it('should emit ExitGameRegistered event', async () => {
+            const txType = 1;
+            const { receipt } = await this.registry.registerExitGame(txType, this.dummyExitGame.address);
+            await expectEvent.inTransaction(
+                receipt.transactionHash,
+                ExitGameRegistry,
+                'ExitGameRegistered',
+                {
+                    txType: new BN(txType),
+                    exitGameAddress: this.dummyExitGame.address,
+                },
+            );
         });
 
         it('rejects when not registered by operator', async () => {

--- a/plasma_framework/test/src/framework/registries/VaultRegistry.test.js
+++ b/plasma_framework/test/src/framework/registries/VaultRegistry.test.js
@@ -61,12 +61,26 @@ contract('VaultRegistry', ([_, other]) => {
     });
 
     describe('registerVault', () => {
-        it('can register successfully', async () => {
-            const txType = 1;
-            await this.registry.registerVault(txType, this.dummyVault.address);
-            expect(await this.registry.vaults(txType)).to.equal(this.dummyVault.address);
+        it('should save the vault data correctly', async () => {
+            const vaultId = 1;
+            await this.registry.registerVault(vaultId, this.dummyVault.address);
+            expect(await this.registry.vaults(vaultId)).to.equal(this.dummyVault.address);
             expect(await this.registry.vaultToId(this.dummyVault.address))
-                .to.be.bignumber.equal(new BN(txType));
+                .to.be.bignumber.equal(new BN(vaultId));
+        });
+
+        it('should emit VaultRegistered event', async () => {
+            const vaultId = 1;
+            const { receipt } = await this.registry.registerVault(vaultId, this.dummyVault.address);
+            await expectEvent.inTransaction(
+                receipt.transactionHash,
+                VaultRegistry,
+                'VaultRegistered',
+                {
+                    vaultId: new BN(vaultId),
+                    vaultAddress: this.dummyVault.address,
+                },
+            );
         });
 
         it('rejects when not registered by operator', async () => {
@@ -91,11 +105,11 @@ contract('VaultRegistry', ([_, other]) => {
         });
 
         it('rejects when the vault id is already registered', async () => {
-            const txType = 1;
+            const vaultId = 1;
             const secondDummyVaultAddress = (await VaultRegistry.new()).address;
-            await this.registry.registerVault(txType, this.dummyVault.address);
+            await this.registry.registerVault(vaultId, this.dummyVault.address);
             await expectRevert(
-                this.registry.registerVault(txType, secondDummyVaultAddress),
+                this.registry.registerVault(vaultId, secondDummyVaultAddress),
                 'The vault id is already registered',
             );
         });


### PR DESCRIPTION
### Note
Watcher would need to monitor new registered contracts as it can potentially be a byzantine event. This commit adds event to ExitGameRegistry and VaultRegistry.


closes: https://github.com/omisego/plasma-contracts/issues/141
