### PR TITLE
refactor: tests for vault and exit game registry

### DIFF
--- a/plasma_framework/contracts/mocks/framework/DummyExitGame.sol
+++ b/plasma_framework/contracts/mocks/framework/DummyExitGame.sol
@@ -25,8 +25,8 @@ contract DummyExitGame is IExitProcessor {
         exitGameRegistry = ExitGameRegistryMock(_contract);
     }
 
-    function checkOnlyFromExitGame() public {
-        exitGameRegistry.checkOnlyFromExitGame();
+    function checkOnlyFromExitGame() public view returns (bool) {
+        return exitGameRegistry.checkOnlyFromExitGame();
     }
 
     // setter function only for test, not a real Exit Game function

--- a/plasma_framework/contracts/mocks/framework/DummyVault.sol
+++ b/plasma_framework/contracts/mocks/framework/DummyVault.sol
@@ -12,8 +12,8 @@ contract DummyVault {
         vaultRegistry = VaultRegistryMock(_contract);
     }
 
-    function checkOnlyFromVault() public {
-        vaultRegistry.checkOnlyFromVault();
+    function checkOnlyFromNonQuarantinedVault() public view returns (bool) {
+        return vaultRegistry.checkOnlyFromNonQuarantinedVault();
     }
 
     // setter function only for test, not a real Vault function

--- a/plasma_framework/contracts/mocks/framework/registries/ExitGameRegistryMock.sol
+++ b/plasma_framework/contracts/mocks/framework/registries/ExitGameRegistryMock.sol
@@ -3,9 +3,7 @@ pragma solidity ^0.5.0;
 import "../../../src/framework/registries/ExitGameRegistry.sol";
 
 contract ExitGameRegistryMock is ExitGameRegistry {
-    event OnlyFromExitGameChecked();
-
-    function checkOnlyFromExitGame() public onlyFromExitGame {
-        emit OnlyFromExitGameChecked();
+    function checkOnlyFromExitGame() public onlyFromExitGame view returns (bool) {
+        return true;
     }
 }

--- a/plasma_framework/contracts/mocks/framework/registries/VaultRegistryMock.sol
+++ b/plasma_framework/contracts/mocks/framework/registries/VaultRegistryMock.sol
@@ -3,15 +3,10 @@ pragma solidity ^0.5.0;
 import "../../../src/framework/registries/VaultRegistry.sol";
 
 contract VaultRegistryMock is VaultRegistry {
-    uint256 public constant QUARANTINE_PERIOD = 0;
-    uint256 public constant INITIAL_IMMUNE_VAULTS = 0;
+    constructor (uint256 _minExitPeriod, uint256 _initialImmuneVaults)
+        VaultRegistry(_minExitPeriod, _initialImmuneVaults) public {}
 
-    event OnlyFromVaultChecked();
-
-    constructor () VaultRegistry(QUARANTINE_PERIOD, INITIAL_IMMUNE_VAULTS) public {
-    }
-
-    function checkOnlyFromVault() public onlyFromNonQuarantinedVault {
-        emit OnlyFromVaultChecked();
+    function checkOnlyFromNonQuarantinedVault() public onlyFromNonQuarantinedVault view returns (bool) {
+        return true;
     }
 }

--- a/plasma_framework/contracts/mocks/framework/registries/VaultRegistryMock.sol
+++ b/plasma_framework/contracts/mocks/framework/registries/VaultRegistryMock.sol
@@ -4,7 +4,8 @@ import "../../../src/framework/registries/VaultRegistry.sol";
 
 contract VaultRegistryMock is VaultRegistry {
     constructor (uint256 _minExitPeriod, uint256 _initialImmuneVaults)
-        VaultRegistry(_minExitPeriod, _initialImmuneVaults) public {}
+        VaultRegistry(_minExitPeriod, _initialImmuneVaults) public {
+    }
 
     function checkOnlyFromNonQuarantinedVault() public onlyFromNonQuarantinedVault view returns (bool) {
         return true;

--- a/plasma_framework/contracts/src/framework/registries/VaultRegistry.sol
+++ b/plasma_framework/contracts/src/framework/registries/VaultRegistry.sol
@@ -4,10 +4,11 @@ import "../utils/Operated.sol";
 import "../utils/Quarantine.sol";
 
 contract VaultRegistry is Operated {
+    using Quarantine for Quarantine.Data;
+
     mapping(uint256 => address) private _vaults;
     mapping(address => uint256) private _vaultToId;
-    using Quarantine for Quarantine.Data;
-    Quarantine.Data internal _quarantine;
+    Quarantine.Data private _quarantine;
 
     event VaultRegistered(
         uint256 vaultId,

--- a/plasma_framework/test/src/framework/BlockController.test.js
+++ b/plasma_framework/test/src/framework/BlockController.test.js
@@ -115,16 +115,7 @@ contract('BlockController', ([_, other]) => {
             );
         });
 
-        it('reverts when not called by registered vault', async () => {
-            await expectRevert(
-                this.blockController.submitDepositBlock(this.dummyBlockHash),
-                'Not being called by registered vaults',
-            );
-        });
-    });
-
-    describe('registerVault', () => {
-        it('should not store a deposit in a newly registered vault', async () => {
+        it('should revert when called from a newly registered (still quarantined) vault', async () => {
             const newDummyVault = await DummyVault.new();
             newDummyVault.setBlockController(this.blockController.address);
             const newDummyVaultId = 2;
@@ -132,6 +123,13 @@ contract('BlockController', ([_, other]) => {
             await expectRevert(
                 newDummyVault.submitDepositBlock(this.dummyBlockHash),
                 'Vault is quarantined.',
+            );
+        });
+
+        it('reverts when not called by registered vault', async () => {
+            await expectRevert(
+                this.blockController.submitDepositBlock(this.dummyBlockHash),
+                'Not being called by registered vaults',
             );
         });
     });

--- a/plasma_framework/test/src/framework/registries/ExitGameRegistry.test.js
+++ b/plasma_framework/test/src/framework/registries/ExitGameRegistry.test.js
@@ -20,13 +20,7 @@ contract('ExitGameRegistry', ([_, other]) => {
         });
 
         it('accepts call when called by registered exit game contract', async () => {
-            const { receipt } = await this.dummyExitGame.checkOnlyFromExitGame();
-            await expectEvent.inTransaction(
-                receipt.transactionHash,
-                ExitGameRegistry,
-                'OnlyFromExitGameChecked',
-                {},
-            );
+            expect(await this.dummyExitGame.checkOnlyFromExitGame()).to.be.true;
         });
 
         it('reverts when not called by registered exit game contract', async () => {


### PR DESCRIPTION
### Note
This is some follow up clean up with the PR: https://github.com/omisego/plasma-contracts/pull/176

1. rename 'onlyFromVault' -> 'onlyFromNonQuarantinedVault'
2. for 'onlyXXX' tests, in the mock registries, it returns bool instead of testing via emitting event. This simplifies the code.
3. Move test for "rejecting still quarantined vault" to be under 'submitDepositBlock'