### PR TITLE
Allow new exit games to be quarantined

### DIFF
--- a/plasma_framework/contracts/mocks/framework/DummyExitGame.sol
+++ b/plasma_framework/contracts/mocks/framework/DummyExitGame.sol
@@ -25,8 +25,8 @@ contract DummyExitGame is IExitProcessor {
         exitGameRegistry = ExitGameRegistryMock(_contract);
     }
 
-    function checkOnlyFromExitGame() public view returns (bool) {
-        return exitGameRegistry.checkOnlyFromExitGame();
+    function checkOnlyFromNonQuarantinedExitGame() public view returns (bool) {
+        return exitGameRegistry.checkOnlyFromNonQuarantinedExitGame();
     }
 
     // setter function only for test, not a real Exit Game function

--- a/plasma_framework/contracts/mocks/framework/registries/ExitGameRegistryMock.sol
+++ b/plasma_framework/contracts/mocks/framework/registries/ExitGameRegistryMock.sol
@@ -7,7 +7,7 @@ contract ExitGameRegistryMock is ExitGameRegistry {
         ExitGameRegistry(_minExitPeriod, _initialImmuneExitGames) public {
     }
 
-    function checkOnlyFromExitGame() public onlyFromNonQuarantinedExitGame view returns (bool) {
+    function checkOnlyFromNonQuarantinedExitGame() public onlyFromNonQuarantinedExitGame view returns (bool) {
         return true;
     }
 }

--- a/plasma_framework/contracts/mocks/framework/registries/ExitGameRegistryMock.sol
+++ b/plasma_framework/contracts/mocks/framework/registries/ExitGameRegistryMock.sol
@@ -3,7 +3,11 @@ pragma solidity ^0.5.0;
 import "../../../src/framework/registries/ExitGameRegistry.sol";
 
 contract ExitGameRegistryMock is ExitGameRegistry {
-    function checkOnlyFromExitGame() public onlyFromExitGame view returns (bool) {
+    constructor (uint256 _minExitPeriod, uint256 _initialImmuneExitGames)
+        ExitGameRegistry(_minExitPeriod, _initialImmuneExitGames) public {
+    }
+
+    function checkOnlyFromExitGame() public onlyFromNonQuarantinedExitGame view returns (bool) {
         return true;
     }
 }

--- a/plasma_framework/contracts/src/framework/ExitGameController.sol
+++ b/plasma_framework/contracts/src/framework/ExitGameController.sol
@@ -21,7 +21,10 @@ contract ExitGameController is ExitGameRegistry {
         address token
     );
 
-    constructor() public {
+    constructor(uint256 _minExitPeriod, uint256 _initialImmuneExitGames)
+        public
+        ExitGameRegistry(_minExitPeriod, _initialImmuneExitGames)
+    {
         address ethToken = address(0);
         exitsQueues[ethToken] = new PriorityQueue();
     }
@@ -58,7 +61,7 @@ contract ExitGameController is ExitGameRegistry {
      * @param _exit Exit data that contains the basic information for exit processor that processes the exit
      * @return a unique priority number computed for the exit
      */
-    function enqueue(uint192 _priority, address _token, ExitModel.Exit memory _exit) public onlyFromExitGame returns (uint256) {
+    function enqueue(uint192 _priority, address _token, ExitModel.Exit memory _exit) public onlyFromNonQuarantinedExitGame returns (uint256) {
         require(hasToken(_token), "Such token has not been added to the plasma framework yet");
 
         PriorityQueue queue = exitsQueues[_token];
@@ -127,7 +130,7 @@ contract ExitGameController is ExitGameRegistry {
      * @notice Batch flags outputs that is spent
      * @param _outputIds Output ids to be flagged
      */
-    function batchFlagOutputsSpent(bytes32[] calldata _outputIds) external onlyFromExitGame {
+    function batchFlagOutputsSpent(bytes32[] calldata _outputIds) external onlyFromNonQuarantinedExitGame {
         for (uint i = 0 ; i < _outputIds.length ; i++) {
             isOutputSpent[_outputIds[i]] = true;
         }
@@ -137,7 +140,7 @@ contract ExitGameController is ExitGameRegistry {
      * @notice Flags a single outputs as spent
      * @param _outputId The output id to be flagged as spent
      */
-    function flagOutputSpent(bytes32 _outputId) external onlyFromExitGame {
+    function flagOutputSpent(bytes32 _outputId) external onlyFromNonQuarantinedExitGame {
         isOutputSpent[_outputId] = true;
     }
 }

--- a/plasma_framework/contracts/src/framework/PlasmaFramework.sol
+++ b/plasma_framework/contracts/src/framework/PlasmaFramework.sol
@@ -15,9 +15,10 @@ contract PlasmaFramework is IPlasmaFramework, Operated, VaultRegistry, ExitGameR
     // Exit period for fresh utxos is double of that while IFE phase is half of that
     uint256 public minExitPeriod;
 
-    constructor(uint256 _minExitPeriod, uint256 _initialImmuneVaults)
+    constructor(uint256 _minExitPeriod, uint256 _initialImmuneVaults, uint256 _initialImmuneExitGames)
         public
         BlockController(CHILD_BLOCK_INTERVAL, _minExitPeriod, _initialImmuneVaults)
+        ExitGameController(_minExitPeriod, _initialImmuneExitGames)
     {
         minExitPeriod = _minExitPeriod;
     }

--- a/plasma_framework/contracts/src/framework/registries/ExitGameRegistry.sol
+++ b/plasma_framework/contracts/src/framework/registries/ExitGameRegistry.sol
@@ -7,7 +7,7 @@ contract ExitGameRegistry is Operated {
     mapping(uint256 => address) private _exitGames;
     mapping(address => uint256) private _exitGameToTxType;
     using Quarantine for Quarantine.Data;
-    Quarantine.Data internal _quarantine;
+    Quarantine.Data private _quarantine;
 
     event ExitGameRegistered(
         uint256 txType,
@@ -17,7 +17,7 @@ contract ExitGameRegistry is Operated {
     constructor (uint256 _minExitPeriod, uint256 _initialImmuneExitGames)
         public
     {
-        _quarantine.quarantinePeriod = _minExitPeriod;
+        _quarantine.quarantinePeriod = 2 * _minExitPeriod;
         _quarantine.immunitiesRemaining = _initialImmuneExitGames;
     }
 

--- a/plasma_framework/contracts/src/framework/registries/ExitGameRegistry.sol
+++ b/plasma_framework/contracts/src/framework/registries/ExitGameRegistry.sol
@@ -1,18 +1,29 @@
 pragma solidity ^0.5.0;
 
 import "../utils/Operated.sol";
+import "../utils/Quarantine.sol";
 
 contract ExitGameRegistry is Operated {
     mapping(uint256 => address) private _exitGames;
     mapping(address => uint256) private _exitGameToTxType;
+    using Quarantine for Quarantine.Data;
+    Quarantine.Data internal _quarantine;
 
     event ExitGameRegistered(
         uint256 txType,
         address exitGameAddress
     );
 
-    modifier onlyFromExitGame() {
+    constructor (uint256 _minExitPeriod, uint256 _initialImmuneExitGames)
+        public
+    {
+        _quarantine.quarantinePeriod = _minExitPeriod;
+        _quarantine.immunitiesRemaining = _initialImmuneExitGames;
+    }
+
+    modifier onlyFromNonQuarantinedExitGame() {
         require(_exitGameToTxType[msg.sender] != 0, "Not being called by registered exit game contract");
+        require(!_quarantine.isQuarantined(msg.sender), "ExitGame is quarantined.");
         _;
     }
 
@@ -29,6 +40,7 @@ contract ExitGameRegistry is Operated {
 
         _exitGames[_txType] = _contract;
         _exitGameToTxType[_contract] = _txType;
+        _quarantine.quarantine(_contract);
 
         emit ExitGameRegistered(_txType, _contract);
     }

--- a/plasma_framework/package.json
+++ b/plasma_framework/package.json
@@ -20,7 +20,8 @@
     "truffle": "^5.0.25"
   },
   "scripts": {
-    "test": "truffle test"
+    "test": "truffle test",
+    "linter": "node_modules/eslint/bin/eslint.js . --fix"
   },
   "repository": {
     "type": "git",

--- a/plasma_framework/test/src/exits/payment/PaymentExitGame.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentExitGame.test.js
@@ -26,6 +26,7 @@ contract('PaymentExitGame - End to End Tests', ([_, richFather, bob]) => {
     const EMPTY_BYTES = '0x';
     const PAYMENT_TX_TYPE = 1;
     const INITIAL_IMMUNE_VAULTS = 1;
+    const INITIAL_IMMUNE_EXIT_GAMES = 1;
 
     const alicePrivateKey = '0x7151e5dab6f8e95b5436515b83f423c4df64fe4c6149f864daa209b26adb10ca';
     let alice;
@@ -41,7 +42,7 @@ contract('PaymentExitGame - End to End Tests', ([_, richFather, bob]) => {
     });
 
     const setupContracts = async () => {
-        this.framework = await PlasmaFramework.new(MIN_EXIT_PERIOD, INITIAL_IMMUNE_VAULTS);
+        this.framework = await PlasmaFramework.new(MIN_EXIT_PERIOD, INITIAL_IMMUNE_VAULTS, INITIAL_IMMUNE_EXIT_GAMES);
         this.exitGame = await PaymentExitGame.new(this.framework.address);
 
         this.toPaymentCondition = await PaymentOutputToPaymentTxCondition.new(this.framework.address);

--- a/plasma_framework/test/src/framework/ExitGameController.test.js
+++ b/plasma_framework/test/src/framework/ExitGameController.test.js
@@ -88,6 +88,17 @@ contract('ExitGameController', () => {
             );
         });
 
+        it('rejects when called from a newly registered (still quarantined) exit game', async () => {
+            const newDummyExitGame = await DummyExitGame.new();
+            newDummyExitGame.setExitGameController(this.controller.address);
+            const newDummyExitGameId = 2;
+            await this.controller.registerExitGame(newDummyExitGameId, newDummyExitGame.address);
+            await expectRevert(
+                newDummyExitGame.enqueue(0, this.dummyToken, this.dummyExit),
+                'ExitGame is quarantined.',
+            );
+        });
+
         it('increases `exitQueueNonce` once', async () => {
             const originExitQueueNonce = await this.controller.exitQueueNonce();
 

--- a/plasma_framework/test/src/framework/ExitGameController.test.js
+++ b/plasma_framework/test/src/framework/ExitGameController.test.js
@@ -8,8 +8,11 @@ const {
 const { expect } = require('chai');
 
 contract('ExitGameController', () => {
+    const MIN_EXIT_PERIOD = 10;
+    const INITIAL_IMMUNE_EXIT_GAMES = 1;
+
     beforeEach(async () => {
-        this.controller = await ExitGameController.new();
+        this.controller = await ExitGameController.new(MIN_EXIT_PERIOD, INITIAL_IMMUNE_EXIT_GAMES);
         this.dummyExitGame = await DummyExitGame.new();
         this.dummyExitGame.setExitGameController(this.controller.address);
 

--- a/plasma_framework/test/src/framework/ExitGameController.test.js
+++ b/plasma_framework/test/src/framework/ExitGameController.test.js
@@ -345,6 +345,19 @@ contract('ExitGameController', () => {
                 'Not being called by registered exit game contract',
             );
         });
+
+        it('should revert when called on quarantined Exit Game contract', async () => {
+            const dummyOutputId1 = web3.utils.sha3('output id 1');
+            const dummyOutputId2 = web3.utils.sha3('output id 2');
+            const newDummyExitGame = await DummyExitGame.new();
+            newDummyExitGame.setExitGameController(this.controller.address);
+            const newDummyExitGameId = 2;
+            await this.controller.registerExitGame(newDummyExitGameId, newDummyExitGame.address);
+            await expectRevert(
+                newDummyExitGame.proxyBatchFlagOutputsSpent([dummyOutputId1, dummyOutputId2]),
+                'ExitGame is quarantined.',
+            );
+        });
     });
 
     describe('flagOutputSpent', () => {
@@ -359,6 +372,18 @@ contract('ExitGameController', () => {
             await expectRevert(
                 this.controller.flagOutputSpent(dummyOutputId),
                 'Not being called by registered exit game contract',
+            );
+        });
+
+        it('should revert when called on quarantined Exit Game contract', async () => {
+            const dummyOutputId = web3.utils.sha3('output id');
+            const newDummyExitGame = await DummyExitGame.new();
+            newDummyExitGame.setExitGameController(this.controller.address);
+            const newDummyExitGameId = 2;
+            await this.controller.registerExitGame(newDummyExitGameId, newDummyExitGame.address);
+            await expectRevert(
+                newDummyExitGame.proxyFlagOutputSpent(dummyOutputId),
+                'ExitGame is quarantined.',
             );
         });
     });

--- a/plasma_framework/test/src/framework/PlasmaFramework.test.js
+++ b/plasma_framework/test/src/framework/PlasmaFramework.test.js
@@ -5,10 +5,13 @@ const { expect } = require('chai');
 
 contract('PlasmaFramework', () => {
     const INITIAL_IMMUNE_VAULTS = 1;
+    const INITIAL_IMMUNE_EXIT_GAMES = 1;
     describe('constructor', () => {
         it('should set the min exit period', async () => {
             const testMinExitPeriod = 1000;
-            const framework = await PlasmaFramework.new(testMinExitPeriod, INITIAL_IMMUNE_VAULTS);
+            const framework = await PlasmaFramework.new(
+                testMinExitPeriod, INITIAL_IMMUNE_VAULTS, INITIAL_IMMUNE_EXIT_GAMES,
+            );
             expect(await framework.minExitPeriod()).to.be.bignumber.equal(new BN(testMinExitPeriod));
         });
     });

--- a/plasma_framework/test/src/framework/registries/ExitGameRegistry.test.js
+++ b/plasma_framework/test/src/framework/registries/ExitGameRegistry.test.js
@@ -7,12 +7,15 @@ const {
 const { expect } = require('chai');
 
 contract('ExitGameRegistry', ([_, other]) => {
+    const MIN_EXIT_PERIOD = 60 * 60 * 24 * 7; // 1 week
+    const INITIAL_IMMUNE_EXIT_GAMES_NUM = 1;
+
     beforeEach(async () => {
-        this.registry = await ExitGameRegistry.new();
+        this.registry = await ExitGameRegistry.new(MIN_EXIT_PERIOD, INITIAL_IMMUNE_EXIT_GAMES_NUM);
         this.dummyExitGame = (await DummyExitGame.new());
     });
 
-    describe('onlyFromExitGame', () => {
+    describe('onlyFromNonQuarantinedExitGame', () => {
         beforeEach(async () => {
             this.dummyTxType = 1;
             await this.registry.registerExitGame(this.dummyTxType, this.dummyExitGame.address);


### PR DESCRIPTION
Fixes #172 

## Overview

New exit game must wait certain period to be able to take effect

## Changes

Reuses the `Quarantine` library for exit games.

## Testing
* ExitGameRegistry - checks that exit game is rejected when under quarantine
* ExitGameRegistry - checks that exit game passed when quarantine is over
* ExitGameController - rejects enqueue exit on quarantined ExitGame
