### PR TITLE
Deposit verifier waits certain period to take effect

### DIFF
--- a/plasma_framework/contracts/src/vaults/Erc20Vault.sol
+++ b/plasma_framework/contracts/src/vaults/Erc20Vault.sol
@@ -8,7 +8,7 @@ import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/SafeERC20.sol";
 
 contract Erc20Vault is Vault {
-    IErc20DepositVerifier private _depositVerifier;
+    //IErc20DepositVerifier private _depositVerifier;
 
     using SafeERC20 for IERC20;
 
@@ -21,19 +21,12 @@ contract Erc20Vault is Vault {
     constructor(PlasmaFramework _framework) Vault(_framework) public {}
 
     /**
-     * @notice Set the deposit verifier contract. This can be only called by the operator.
-     * @param _contract address of the verifier contract.
-     */
-    function setDepositVerifier(address _contract) public onlyOperator {
-        _depositVerifier = IErc20DepositVerifier(_contract);
-    }
-
-    /**
      * @notice Deposits approved amount of ERC20 token. Approve must have been called first.
      * @param _depositTx RLP encoded transaction to act as the deposit.
      */
     function deposit(bytes calldata _depositTx) external {
-        (address owner, address token, uint256 amount) = _depositVerifier.verify(_depositTx, msg.sender, address(this));
+        (address owner, address token, uint256 amount) = IErc20DepositVerifier(getDepositVerifier())
+            .verify(_depositTx, msg.sender, address(this));
 
         IERC20(token).safeTransferFrom(owner, address(this), amount);
 

--- a/plasma_framework/contracts/src/vaults/Erc20Vault.sol
+++ b/plasma_framework/contracts/src/vaults/Erc20Vault.sol
@@ -8,8 +8,6 @@ import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/SafeERC20.sol";
 
 contract Erc20Vault is Vault {
-    //IErc20DepositVerifier private _depositVerifier;
-
     using SafeERC20 for IERC20;
 
     event Erc20Withdrawn(
@@ -25,6 +23,7 @@ contract Erc20Vault is Vault {
      * @param _depositTx RLP encoded transaction to act as the deposit.
      */
     function deposit(bytes calldata _depositTx) external {
+        swapDepositVerifiersIfNewerGetsEffective();
         (address owner, address token, uint256 amount) = IErc20DepositVerifier(getDepositVerifier())
             .verify(_depositTx, msg.sender, address(this));
 

--- a/plasma_framework/contracts/src/vaults/Erc20Vault.sol
+++ b/plasma_framework/contracts/src/vaults/Erc20Vault.sol
@@ -23,8 +23,7 @@ contract Erc20Vault is Vault {
      * @param _depositTx RLP encoded transaction to act as the deposit.
      */
     function deposit(bytes calldata _depositTx) external {
-        swapDepositVerifiersIfNewerGetsEffective();
-        (address owner, address token, uint256 amount) = IErc20DepositVerifier(getDepositVerifier())
+        (address owner, address token, uint256 amount) = IErc20DepositVerifier(getEffectiveDepositVerifier())
             .verify(_depositTx, msg.sender, address(this));
 
         IERC20(token).safeTransferFrom(owner, address(this), amount);

--- a/plasma_framework/contracts/src/vaults/EthVault.sol
+++ b/plasma_framework/contracts/src/vaults/EthVault.sol
@@ -17,8 +17,7 @@ contract EthVault is Vault {
      * @param _depositTx RLP encoded transaction to act as the deposit.
      */
     function deposit(bytes calldata _depositTx) external payable {
-        swapDepositVerifiersIfNewerGetsEffective();
-        IEthDepositVerifier(getDepositVerifier()).verify(_depositTx, msg.value, msg.sender);
+        IEthDepositVerifier(getEffectiveDepositVerifier()).verify(_depositTx, msg.value, msg.sender);
 
         super._submitDepositBlock(_depositTx);
     }

--- a/plasma_framework/contracts/src/vaults/EthVault.sol
+++ b/plasma_framework/contracts/src/vaults/EthVault.sol
@@ -5,7 +5,7 @@ import "./verifiers/IEthDepositVerifier.sol";
 import "../framework/PlasmaFramework.sol";
 
 contract EthVault is Vault {
-    IEthDepositVerifier private _depositVerifier;
+    //IEthDepositVerifier private _depositVerifier;
 
     event EthWithdrawn(
         address payable indexed target,
@@ -15,19 +15,11 @@ contract EthVault is Vault {
     constructor(PlasmaFramework _framework) Vault(_framework) public {}
 
     /**
-     * @notice Set the deposit verifier contract. This can be only called by the operator.
-     * @param _contract address of the verifier contract.
-     */
-    function setDepositVerifier(address _contract) public onlyOperator {
-        _depositVerifier = IEthDepositVerifier(_contract);
-    }
-
-    /**
      * @notice Allows a user to submit a deposit.
      * @param _depositTx RLP encoded transaction to act as the deposit.
      */
     function deposit(bytes calldata _depositTx) external payable {
-        _depositVerifier.verify(_depositTx, msg.value, msg.sender);
+        IEthDepositVerifier(getDepositVerifier()).verify(_depositTx, msg.value, msg.sender);
 
         super._submitDepositBlock(_depositTx);
     }

--- a/plasma_framework/contracts/src/vaults/EthVault.sol
+++ b/plasma_framework/contracts/src/vaults/EthVault.sol
@@ -5,8 +5,6 @@ import "./verifiers/IEthDepositVerifier.sol";
 import "../framework/PlasmaFramework.sol";
 
 contract EthVault is Vault {
-    //IEthDepositVerifier private _depositVerifier;
-
     event EthWithdrawn(
         address payable indexed target,
         uint256 amount
@@ -19,6 +17,7 @@ contract EthVault is Vault {
      * @param _depositTx RLP encoded transaction to act as the deposit.
      */
     function deposit(bytes calldata _depositTx) external payable {
+        swapDepositVerifiersIfNewerGetsEffective();
         IEthDepositVerifier(getDepositVerifier()).verify(_depositTx, msg.value, msg.sender);
 
         super._submitDepositBlock(_depositTx);

--- a/plasma_framework/contracts/src/vaults/Vault.sol
+++ b/plasma_framework/contracts/src/vaults/Vault.sol
@@ -14,7 +14,7 @@ contract Vault is Operated {
      *  `newDepositVerifierMaturityTimestamp` point of time and second become effective after
     */
     address[2] public depositVerifiers;
-    uint256 public newDepositVerifierMaturityTimestamp = 2 ** 256 - 1; // point far in the future
+    uint256 public newDepositVerifierMaturityTimestamp = 2 ** 255; // point far in the future
 
     constructor(PlasmaFramework _framework) public {
         framework = _framework;
@@ -41,19 +41,19 @@ contract Vault is Operated {
     /**
      * @notice Sets the deposit verifier contract. This can be only called by the operator.
      * @notice When one contract is already set next will be effective after MIN_EXIT_PERIOD.
-     * @param _contract address of the verifier contract.
+     * @param _verifier address of the verifier contract.
      */
-    function setDepositVerifier(address _contract) public onlyOperator {
-        require(_contract != address(0), "Cannot set an empty address as deposit verifier");
+    function setDepositVerifier(address _verifier) public onlyOperator {
+        require(_verifier != address(0), "Cannot set an empty address as deposit verifier");
 
         if (depositVerifiers[0] != address(0)) {
             depositVerifiers[0] = getEffectiveDepositVerifier();
-            depositVerifiers[1] = _contract;
+            depositVerifiers[1] = _verifier;
             newDepositVerifierMaturityTimestamp = now + framework.minExitPeriod();
 
             emit SetDepositVerifierCalled(depositVerifiers[1]);
         } else {
-            depositVerifiers[0] = _contract;
+            depositVerifiers[0] = _verifier;
         }
     }
 

--- a/plasma_framework/contracts/src/vaults/Vault.sol
+++ b/plasma_framework/contracts/src/vaults/Vault.sol
@@ -8,6 +8,10 @@ contract Vault is Operated {
     PlasmaFramework framework;
     bytes32[16] zeroHashes;
 
+    address private _currentDepositVerifier;
+    address private _newDepositVerifier;
+    uint256 private _newDepositVerifierEffectivePeriod;
+
     constructor(PlasmaFramework _framework) public {
         framework = _framework;
         zeroHashes = ZeroHashesProvider.getZeroHashes();
@@ -28,5 +32,18 @@ contract Vault is Operated {
         }
 
         framework.submitDepositBlock(root);
+    }
+
+    /**
+     * @notice Set the deposit verifier contract. This can be only called by the operator.
+     * @param _contract address of the verifier contract.
+     */
+    function setDepositVerifier(address _contract) public onlyOperator {
+        _currentDepositVerifier = _contract;
+        //_depositVerifier = IErc20DepositVerifier(_contract);
+    }
+
+    function getDepositVerifier() internal view returns (address) {
+        return _currentDepositVerifier;
     }
 }

--- a/plasma_framework/contracts/src/vaults/Vault.sol
+++ b/plasma_framework/contracts/src/vaults/Vault.sol
@@ -43,7 +43,7 @@ contract Vault is Operated {
         //_depositVerifier = IErc20DepositVerifier(_contract);
     }
 
-    function getDepositVerifier() internal view returns (address) {
+    function getDepositVerifier() public view returns (address) {
         return _currentDepositVerifier;
     }
 }

--- a/plasma_framework/test/src/vaults/Erc20Vault.test.js
+++ b/plasma_framework/test/src/vaults/Erc20Vault.test.js
@@ -6,7 +6,7 @@ const BadERC20 = artifacts.require('BadERC20');
 const DummyExitGame = artifacts.require('DummyExitGame');
 
 const {
-    BN, constants, expectEvent, expectRevert,
+    BN, constants, expectEvent, expectRevert, time,
 } = require('openzeppelin-test-helpers');
 const { expect } = require('chai');
 
@@ -19,13 +19,16 @@ contract('Erc20Vault', (accounts) => {
     const INITIAL_SUPPLY = 1000000;
     const INITIAL_IMMUNE_VAULTS = 1;
     const INITIAL_IMMUNE_EXIT_GAMES = 0;
+    const MIN_EXIT_PERIOD = 10;
+
 
     beforeEach('setup contracts', async () => {
-        this.framework = await PlasmaFramework.new(10, INITIAL_IMMUNE_VAULTS, INITIAL_IMMUNE_EXIT_GAMES);
+        this.framework = await PlasmaFramework.new(MIN_EXIT_PERIOD, INITIAL_IMMUNE_VAULTS, INITIAL_IMMUNE_EXIT_GAMES);
         this.erc20Vault = await Erc20Vault.new(this.framework.address);
         const depositVerifier = await Erc20DepositVerifier.new();
         await this.erc20Vault.setDepositVerifier(depositVerifier.address);
         await this.framework.registerVault(2, this.erc20Vault.address);
+        this.currentDepositVerifier = depositVerifier.address;
 
         this.exitGame = await DummyExitGame.new();
         await this.exitGame.setErc20Vault(this.erc20Vault.address);
@@ -126,6 +129,26 @@ contract('Erc20Vault', (accounts) => {
                 this.erc20Vault.deposit(deposit.rlpEncoded(), { from: alice }),
                 'Must have only one output',
             );
+        });
+
+        it('deposit verifier waits a period of time before takes effect', async () => {
+            const depositValue = DEPOSIT_VALUE / 2;
+            const deposit = Testlang.deposit(depositValue, alice, this.erc20.address);
+            await this.erc20.approve(this.erc20Vault.address, depositValue, { from: alice });
+            expect(this.currentDepositVerifier).to.not.equal(null);
+
+            const newDepositVerifier = await Erc20DepositVerifier.new();
+            await this.erc20Vault.setDepositVerifier(newDepositVerifier.address);
+
+            await this.erc20Vault.deposit(deposit, { from: alice });
+            expect(await this.erc20Vault.getDepositVerifier()).to.equal(this.currentDepositVerifier);
+
+
+            await time.increase(MIN_EXIT_PERIOD + 1);
+            await this.erc20.approve(this.erc20Vault.address, depositValue, { from: alice });
+            await this.erc20Vault.deposit(deposit, { from: alice });
+
+            expect(await this.erc20Vault.getDepositVerifier()).to.equal(newDepositVerifier.address);
         });
     });
 

--- a/plasma_framework/test/src/vaults/Erc20Vault.test.js
+++ b/plasma_framework/test/src/vaults/Erc20Vault.test.js
@@ -6,7 +6,7 @@ const BadERC20 = artifacts.require('BadERC20');
 const DummyExitGame = artifacts.require('DummyExitGame');
 
 const {
-    BN, constants, expectEvent, expectRevert, time,
+    BN, constants, expectEvent, expectRevert,
 } = require('openzeppelin-test-helpers');
 const { expect } = require('chai');
 
@@ -28,7 +28,6 @@ contract('Erc20Vault', (accounts) => {
         const depositVerifier = await Erc20DepositVerifier.new();
         await this.erc20Vault.setDepositVerifier(depositVerifier.address);
         await this.framework.registerVault(2, this.erc20Vault.address);
-        this.currentDepositVerifier = depositVerifier.address;
 
         this.exitGame = await DummyExitGame.new();
         await this.exitGame.setErc20Vault(this.erc20Vault.address);
@@ -129,26 +128,6 @@ contract('Erc20Vault', (accounts) => {
                 this.erc20Vault.deposit(deposit.rlpEncoded(), { from: alice }),
                 'Must have only one output',
             );
-        });
-
-        it('deposit verifier waits a period of time before takes effect', async () => {
-            const depositValue = DEPOSIT_VALUE / 2;
-            const deposit = Testlang.deposit(depositValue, alice, this.erc20.address);
-            await this.erc20.approve(this.erc20Vault.address, depositValue, { from: alice });
-            expect(this.currentDepositVerifier).to.not.equal(null);
-
-            const newDepositVerifier = await Erc20DepositVerifier.new();
-            await this.erc20Vault.setDepositVerifier(newDepositVerifier.address);
-
-            await this.erc20Vault.deposit(deposit, { from: alice });
-            expect(await this.erc20Vault.getDepositVerifier()).to.equal(this.currentDepositVerifier);
-
-
-            await time.increase(MIN_EXIT_PERIOD + 1);
-            await this.erc20.approve(this.erc20Vault.address, depositValue, { from: alice });
-            await this.erc20Vault.deposit(deposit, { from: alice });
-
-            expect(await this.erc20Vault.getDepositVerifier()).to.equal(newDepositVerifier.address);
         });
     });
 

--- a/plasma_framework/test/src/vaults/EthVault.test.js
+++ b/plasma_framework/test/src/vaults/EthVault.test.js
@@ -118,22 +118,18 @@ contract('EthVault', ([_, alice]) => {
             );
         });
 
+        // NOTE: This test would be the same for `Erc20Vault` as all functionality is in base `Vault` contract
         it('deposit verifier waits a period of time before takes effect', async () => {
-            const depositValue = DEPOSIT_VALUE / 2;
-            const deposit = Testlang.deposit(depositValue, alice);
-            expect(this.currentDepositVerifier).to.not.equal(null);
-
             const newDepositVerifier = await EthDepositVerifier.new();
-            await this.ethVault.setDepositVerifier(newDepositVerifier.address);
 
-            await this.ethVault.deposit(deposit, { from: alice, value: depositValue });
-            expect(await this.ethVault.getDepositVerifier()).to.equal(this.currentDepositVerifier);
+            expect(await this.ethVault.getEffectiveDepositVerifier()).to.equal(this.currentDepositVerifier);
 
+            const tx = await this.ethVault.setDepositVerifier(newDepositVerifier.address);
+            expect(await this.ethVault.getEffectiveDepositVerifier()).to.equal(this.currentDepositVerifier);
+            await expectEvent.inLogs(tx.logs, 'SetDepositVerifierCalled', { nextDepositVerifier: newDepositVerifier.address });
 
             await time.increase(MIN_EXIT_PERIOD + 1);
-            await this.ethVault.deposit(deposit, { from: alice, value: depositValue });
-
-            expect(await this.ethVault.getDepositVerifier()).to.equal(newDepositVerifier.address);
+            expect(await this.ethVault.getEffectiveDepositVerifier()).to.equal(newDepositVerifier.address);
         });
     });
 


### PR DESCRIPTION
Fixes #174 

__Solution description__
Proposed by @boolafish during review. :pray: 

Vault stores both deposit verifier addresses, lower index is earlier set. In-force verifier address is returned by getEffectiveDepositVerifier function, which checks whether _maturity timestamp_ is in future.

When new verifier contract is set, 0-index is assigned to current in-force, 1-index is this new one, maturity timestamp is set accordingly.