### PR TITLE
Upgrade Python RLP encoding library to v1

### DIFF
--- a/plasma_core/constants.py
+++ b/plasma_core/constants.py
@@ -2,45 +2,45 @@ from ethereum import utils as u
 
 AUTHORITY = {
     'address': '0xfd02EcEE62797e75D86BCff1642EB0844afB28c7',
-    'key': u.normalize_key(b'3bb369fecdc16b93b99514d8ed9c2e87c5824cf4a6a98d2e8e91b7dd0c063304')
+    'key': u.normalize_key('0x3bb369fecdc16b93b99514d8ed9c2e87c5824cf4a6a98d2e8e91b7dd0c063304')
 }
 
 ACCOUNTS = [
     {
         'address': '0x4B3eC6c9dC67079E82152d6D55d8dd96a8e6AA26',
-        'key': u.normalize_key(b'b937b2c6a606edf1a4d671485f0fa61dcc5102e1ebca392f5a8140b23a8ac04f')
+        'key': u.normalize_key('0xb937b2c6a606edf1a4d671485f0fa61dcc5102e1ebca392f5a8140b23a8ac04f')
     },
     {
         'address': '0xda20A48913f9031337a5e32325F743e8536860e2',
-        'key': u.normalize_key(b'999ba3f77899ba4802af5109221c64a9238a6772718f287a8bd3ca3d1b68187f')
+        'key': u.normalize_key('0x999ba3f77899ba4802af5109221c64a9238a6772718f287a8bd3ca3d1b68187f')
     },
     {
         'address': '0xF6d8982698dCC46b8E96e34bC2BF3c97302b9923',
-        'key': u.normalize_key(b'ef4134d11aa32bcbd314d3cd94b7a5f93bea2b809007d4307a4393cce0285652')
+        'key': u.normalize_key('0xef4134d11aa32bcbd314d3cd94b7a5f93bea2b809007d4307a4393cce0285652')
     },
     {
         'address': '0x2d75468C0cafA9D41FC5BF3ccA6C292a3cC03d94',
-        'key': u.normalize_key(b'25c8620e5bd51caed1d2ff5e79b43dfbef17d0b4eb38d0db8d834da9de5a6120')
+        'key': u.normalize_key('0x25c8620e5bd51caed1d2ff5e79b43dfbef17d0b4eb38d0db8d834da9de5a6120')
     },
     {
         'address': '0xF05B4B746AAd830062505AD0cFd3619917484E46',
-        'key': u.normalize_key(b'e3d66a68573a85734e80d3de47b82e13374c2a026f219cb766978510a8b8697e')
+        'key': u.normalize_key('0xe3d66a68573a85734e80d3de47b82e13374c2a026f219cb766978510a8b8697e')
     },
     {
         'address': '0x81A9bfA79598f1536B4918A6556e9855c5E141d5',
-        'key': u.normalize_key(b'81e244b79cef097c187d9299a2fc3a680cf1d2637fb7463ca7aa70445a0a0410')
+        'key': u.normalize_key('0x81e244b79cef097c187d9299a2fc3a680cf1d2637fb7463ca7aa70445a0a0410')
     },
     {
         'address': '0xa669513ad878cC0891d8C305CC21903068a9AFe9',
-        'key': u.normalize_key(b'ebcaa9c519c2aaa27e7c1656451b9c72167cadf0fd30bc4bcc3bda6d6fcbd507')
+        'key': u.normalize_key('0xebcaa9c519c2aaa27e7c1656451b9c72167cadf0fd30bc4bcc3bda6d6fcbd507')
     },
     {
         'address': '0xC3AaE3a9be258BD485105ef81EB0D5b677EE26fd',
-        'key': u.normalize_key(b'b991543d47829ea4f296d182dfa7088303fb3f04dd0c95a5cb7132397e4a008d')
+        'key': u.normalize_key('0xb991543d47829ea4f296d182dfa7088303fb3f04dd0c95a5cb7132397e4a008d')
     },
     {
         'address': '0xB9DB71c2D02a1B30dfE29C90738b3228Dd9d2ec2',
-        'key': u.normalize_key(b'484eb2f0465e7357575f05bf5af5e77cb4b678fb774dd127d9d99e3d31c5f80e')
+        'key': u.normalize_key('0x484eb2f0465e7357575f05bf5af5e77cb4b678fb774dd127d9d99e3d31c5f80e')
     }
 ]
 
@@ -49,6 +49,7 @@ NULL_HASH = NULL_BYTE * 32
 NULL_SIGNATURE = NULL_BYTE * 65
 NULL_ADDRESS = NULL_BYTE * 20
 NULL_ADDRESS_HEX = '0x' + NULL_ADDRESS.hex()
+EMPTY_METADATA = NULL_BYTE * 32
 
 MINUTE = 60
 DAY = 60 * 60 * 24

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ eth-keys==0.2.4
 eth-rlp==0.1.2
 eth-typing==2.1.0
 eth-utils==1.6.1
-ethereum==2.3.0
+ethereum==2.3.2
 flake8==3.7.7
 future==0.17.1
 hexbytes==0.2.0
@@ -46,7 +46,7 @@ pytest==4.6.3
 PyYAML==5.1.1
 repoze.lru==0.7
 requests==2.22.0
-rlp==0.6.0
+rlp==1.1.0
 scrypt==0.8.13
 semantic-version==2.6.0
 six==1.12.0

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,9 @@ setup(
     keywords='plasma contracts ethereum development solidity',
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     install_requires=[
-        'ethereum==2.3.0',
+        'ethereum==2.3.2',
         'web3==4.8.2',
-        'rlp==0.6.0',
+        'rlp==1.1.0',
         'py-solc-simple==0.0.14',
         'eip712-structs==1.1.0'
     ],

--- a/testlang/testlang.py
+++ b/testlang/testlang.py
@@ -98,7 +98,7 @@ class InFlightExit(object):
         input_info = self.inputs.get(index)
         if not input_info:
             input_info = TransactionOutput(*self.root_chain.getInFlightExitOutput(self.in_flight_tx.encoded, index))
-            input_info.owner = address_to_hex(input_info.owner)
+            # input_info.owner = address_to_hex(input_info.owner)
             self.inputs[index] = input_info
         return input_info
 
@@ -153,14 +153,14 @@ class TestingLanguage(object):
         signer = signer or self.operator
         blknum = self.root_chain.nextChildBlock()
         block = Block(transactions, number=blknum)
-        block.sign(signer.key)
-        self.root_chain.submitBlock(block.root, sender=signer.key)
+        signed_block = block.sign(signer.key)
+        self.root_chain.submitBlock(signed_block.root, sender=signer.key)
         if force_invalid:
-            self.child_chain.blocks[self.child_chain.next_child_block] = block
+            self.child_chain.blocks[self.child_chain.next_child_block] = signed_block
             self.child_chain.next_deposit_block = self.child_chain.next_child_block + 1
             self.child_chain.next_child_block += self.child_chain.child_block_interval
         else:
-            assert self.child_chain.add_block(block)
+            assert self.child_chain.add_block(signed_block)
         return blknum
 
     @property

--- a/tests/contracts/rlp/test_plasma_core.py
+++ b/tests/contracts/rlp/test_plasma_core.py
@@ -26,10 +26,10 @@ def test_slice_signature(plasma_core_test):
 
 def test_get_output(plasma_core_test):
     null = '0x0000000000000000000000000000000000000000'
-    owner = b'0x82a978b3f5962a5b0957d9ee9eef472ee55b42f1'
+    owner = '0x82a978b3f5962a5b0957d9ee9eef472ee55b42f1'
     amount = 100
     tx = Transaction(outputs=[(owner, null, amount)])
-    assert plasma_core_test.getOutput(tx.encoded, 0) == [owner.decode("utf-8"), null, amount]
+    assert plasma_core_test.getOutput(tx.encoded, 0) == [owner, null, amount]
     assert plasma_core_test.getOutput(tx.encoded, 1) == [null, null, 0]
 
 

--- a/tests/contracts/rlp/test_rlp.py
+++ b/tests/contracts/rlp/test_rlp.py
@@ -5,10 +5,17 @@ Regression test for bug in RLP decoder.
 import pytest
 import rlp
 
-from eth_utils import encode_hex
+from eth_utils import encode_hex, is_address, to_canonical_address
+from rlp.sedes import big_endian_int, Binary
 
-from rlp.sedes import big_endian_int
-from ethereum import utils
+
+def normalize_args(args):
+    def _normalize_arg(arg):
+        if is_address(arg):
+            return to_canonical_address(arg)
+        else:
+            return arg
+    return tuple(map(_normalize_arg, args))
 
 
 class Eight(rlp.Serializable):
@@ -19,19 +26,13 @@ class Eight(rlp.Serializable):
         ('f3', big_endian_int),
         ('f4', big_endian_int),
         ('f5', big_endian_int),
-        ('f6', utils.address),
-        ('f7', utils.address)
+        ('f6', Binary.fixed_length(20)),
+        ('f7', Binary.fixed_length(20))
     ]
 
-    def __init__(self, f0, f1, f2, f3, f4, f5, f6, f7):
-        self.f0 = f0
-        self.f1 = f1
-        self.f2 = f2
-        self.f3 = f3
-        self.f4 = f4
-        self.f5 = f5
-        self.f6 = f6
-        self.f7 = f7
+    def __init__(self, *args):
+        args = normalize_args(args)
+        super().__init__(*args)
 
 
 class Eleven(rlp.Serializable):
@@ -44,23 +45,14 @@ class Eleven(rlp.Serializable):
         ('f5', big_endian_int),
         ('f6', big_endian_int),
         ('f7', big_endian_int),
-        ('f8', utils.address),
-        ('f9', utils.address),
-        ('f10', utils.address)
+        ('f8', Binary.fixed_length(20)),
+        ('f9', Binary.fixed_length(20)),
+        ('f10', Binary.fixed_length(20))
     ]
 
-    def __init__(self, f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10):
-        self.f0 = f0
-        self.f1 = f1
-        self.f2 = f2
-        self.f3 = f3
-        self.f4 = f4
-        self.f5 = f5
-        self.f6 = f6
-        self.f7 = f7
-        self.f8 = f8
-        self.f9 = f9
-        self.f10 = f10
+    def __init__(self, *args):
+        args = normalize_args(args)
+        super().__init__(*args)
 
 
 @pytest.fixture

--- a/tests/contracts/root_chain/test_process_exits.py
+++ b/tests/contracts/root_chain/test_process_exits.py
@@ -1,5 +1,5 @@
 from plasma_core.constants import NULL_ADDRESS, NULL_ADDRESS_HEX, MIN_EXIT_PERIOD
-from eth_utils import encode_hex
+from eth_utils import encode_hex, to_canonical_address
 import pytest
 from ethereum.tools.tester import TransactionFailed
 
@@ -57,11 +57,11 @@ def test_process_exits_in_flight_exit_should_succeed(testlang):
 
     for i in range(4):
         input_info = in_flight_exit.get_input(i)
-        assert input_info.owner == NULL_ADDRESS_HEX
+        assert input_info.owner == NULL_ADDRESS
         assert input_info.amount == 0
 
         output_info = in_flight_exit.get_output(i)
-        assert output_info.owner == NULL_ADDRESS_HEX
+        assert output_info.owner == NULL_ADDRESS
         assert output_info.amount == 0
 
     expected_balance = pre_balance + amount + testlang.root_chain.inFlightExitBond() + testlang.root_chain.piggybackBond()
@@ -426,11 +426,11 @@ def test_finalize_in_flight_exit_with_erc20_token_should_succeed(testlang, token
     for i in range(4):
         tx_input = in_flight_exit.get_input(i)
         assert tx_input.amount == 0
-        assert tx_input.owner == NULL_ADDRESS_HEX
+        assert tx_input.owner == NULL_ADDRESS
 
         tx_output = in_flight_exit.get_input(i)
         assert tx_output.amount == 0
-        assert tx_output.owner == NULL_ADDRESS_HEX
+        assert tx_output.owner == NULL_ADDRESS
 
     assert in_flight_exit.bond_owner == NULL_ADDRESS_HEX
     assert in_flight_exit.oldest_competitor == 0
@@ -561,7 +561,7 @@ def test_when_processing_ife_finalization_of_erc20_token_does_not_clean_up_eth_o
     assert in_flight_exit.output_piggybacked(0)
     assert not in_flight_exit.output_piggybacked(1)
 
-    assert in_flight_exit.get_output(0).owner == owner_1.address
+    assert in_flight_exit.get_output(0).owner == to_canonical_address(owner_1.address)
     assert in_flight_exit.get_output(0).amount == amount
 
 

--- a/tests/contracts/root_chain/test_start_in_flight_exit.py
+++ b/tests/contracts/root_chain/test_start_in_flight_exit.py
@@ -1,7 +1,7 @@
 import pytest
+from eth_utils import to_canonical_address
 from ethereum.tools.tester import TransactionFailed
 from plasma_core.constants import NULL_ADDRESS, NULL_ADDRESS_HEX, MIN_EXIT_PERIOD
-from testlang.testlang import address_to_hex
 from tests.conftest import deploy_token
 
 
@@ -29,14 +29,14 @@ def test_start_in_flight_exit_should_succeed(ethtester, testlang, num_inputs):
     # Inputs are correctly set
     for i in range(0, num_inputs):
         input_info = in_flight_exit.get_input(i)
-        assert input_info.owner == owners[i].address
+        assert input_info.owner == to_canonical_address(owners[i].address)
         assert input_info.token == NULL_ADDRESS
         assert input_info.amount == amount
 
     # Remaining inputs are still unset
     for i in range(num_inputs, 4):
         input_info = in_flight_exit.get_input(i)
-        assert input_info.owner == address_to_hex(NULL_ADDRESS)
+        assert input_info.owner == NULL_ADDRESS
         assert input_info.amount == 0
 
 
@@ -64,14 +64,14 @@ def test_start_in_flight_exit_with_erc20_tokens_should_succeed(ethtester, testla
     # Inputs are correctly set
     for i in range(0, num_inputs):
         input_info = in_flight_exit.get_input(i)
-        assert input_info.owner == owners[i].address
+        assert input_info.owner == to_canonical_address(owners[i].address)
         assert input_info.token == token.address
         assert input_info.amount == amount
 
     # Remaining inputs are still unset
     for i in range(num_inputs, 4):
         input_info = in_flight_exit.get_input(i)
-        assert input_info.owner == address_to_hex(NULL_ADDRESS)
+        assert input_info.owner == NULL_ADDRESS
         assert input_info.amount == 0
 
 
@@ -96,19 +96,19 @@ def test_start_in_flight_exit_with_erc20_token_and_eth_should_succeed(ethtester,
 
     # Inputs are correctly set
     input_info = in_flight_exit.get_input(0)
-    assert input_info.owner == owner.address
+    assert input_info.owner == to_canonical_address(owner.address)
     assert input_info.token == NULL_ADDRESS
     assert input_info.amount == 100
 
     input_info = in_flight_exit.get_input(1)
-    assert input_info.owner == owner.address
+    assert input_info.owner == to_canonical_address(owner.address)
     assert input_info.token == token.address
     assert input_info.amount == 110
 
     # Remaining inputs are still unset
     for i in range(2, 4):
         input_info = in_flight_exit.get_input(i)
-        assert input_info.owner == address_to_hex(NULL_ADDRESS)
+        assert input_info.owner == NULL_ADDRESS
         assert input_info.amount == 0
 
 


### PR DESCRIPTION
Upgrade the RLP encoding library to the latest version, so that we can continue with other upgrades and switching into `plasma-framework`. 

The code must have changed a little, as the API of the lib has changed.

Refers to  #28 
I took a little different approach and applied some of the comments that appeared there in a CR.