### PR TITLE
Withdraw can be called only by known, non-quarantined exit games

### DIFF
--- a/plasma_framework/contracts/src/framework/registries/ExitGameRegistry.sol
+++ b/plasma_framework/contracts/src/framework/registries/ExitGameRegistry.sol
@@ -17,7 +17,7 @@ contract ExitGameRegistry is Operated {
     constructor (uint256 _minExitPeriod, uint256 _initialImmuneExitGames)
         public
     {
-        _quarantine.quarantinePeriod = 2 * _minExitPeriod;
+        _quarantine.quarantinePeriod = 3 * _minExitPeriod;
         _quarantine.immunitiesRemaining = _initialImmuneExitGames;
     }
 

--- a/plasma_framework/contracts/src/framework/registries/ExitGameRegistry.sol
+++ b/plasma_framework/contracts/src/framework/registries/ExitGameRegistry.sol
@@ -28,11 +28,11 @@ contract ExitGameRegistry is Operated {
     }
 
     /**
-     * @notice Exposes information about exit games quarantine
+     * @dev Exposes information about exit games quarantine
      * @param _contract address of exit game contract
      * @return A boolean value denoting whether contract is safe to use, is not under quarantine
      */
-     function isSafeToUse(address _contract) public view returns (bool) {
+     function isExitGameSafeToUse(address _contract) public view returns (bool) {
          return _exitGameToTxType[_contract] != 0 && !_quarantine.isQuarantined(_contract);
      }
 

--- a/plasma_framework/contracts/src/framework/registries/ExitGameRegistry.sol
+++ b/plasma_framework/contracts/src/framework/registries/ExitGameRegistry.sol
@@ -28,6 +28,15 @@ contract ExitGameRegistry is Operated {
     }
 
     /**
+     * @notice Exposes information about exit games quarantine
+     * @param _contract address of exit game contract
+     * @return A boolean value denoting whether contract is safe to use, is not under quarantine
+     */
+     function isSafeToUse(address _contract) public view returns (bool) {
+         return _exitGameToTxType[_contract] != 0 && !_quarantine.isQuarantined(_contract);
+     }
+
+    /**
      * @notice Register the exit game to Plasma framework. This can be only called by contract admin.
      * @param _txType tx type that the exit game want to register to.
      * @param _contract Address of the exit game contract.

--- a/plasma_framework/contracts/src/vaults/Erc20Vault.sol
+++ b/plasma_framework/contracts/src/vaults/Erc20Vault.sol
@@ -37,7 +37,7 @@ contract Erc20Vault is Vault {
     * @param _token Address of ERC20 token contract.
     * @param _amount Amount to transfer.
     */
-    function withdraw(address payable _target, address _token, uint256 _amount) external onlyFromExitGame {
+    function withdraw(address payable _target, address _token, uint256 _amount) external onlyFromNonQuarantinedExitGame {
         IERC20(_token).safeTransfer(_target, _amount);
         emit Erc20Withdrawn(_target, _token, _amount);
     }

--- a/plasma_framework/contracts/src/vaults/EthVault.sol
+++ b/plasma_framework/contracts/src/vaults/EthVault.sol
@@ -27,7 +27,7 @@ contract EthVault is Vault {
     * @param _target Place to transfer eth.
     * @param _amount Amount of eth to transfer.
     */
-    function withdraw(address payable _target, uint256 _amount) external onlyFromExitGame {
+    function withdraw(address payable _target, uint256 _amount) external onlyFromNonQuarantinedExitGame {
         _target.transfer(_amount);
         emit EthWithdrawn(_target, _amount);
     }

--- a/plasma_framework/contracts/src/vaults/Vault.sol
+++ b/plasma_framework/contracts/src/vaults/Vault.sol
@@ -24,7 +24,7 @@ contract Vault is Operated {
     modifier onlyFromNonQuarantinedExitGame() {
         require(
             ExitGameRegistry(framework).isSafeToUse(msg.sender),
-            "Not called from a registered Exit Game contract"
+            "Called from a nonregistered or quarantined Exit Game contract"
         );
         _;
     }

--- a/plasma_framework/contracts/src/vaults/Vault.sol
+++ b/plasma_framework/contracts/src/vaults/Vault.sol
@@ -23,7 +23,7 @@ contract Vault is Operated {
 
     modifier onlyFromNonQuarantinedExitGame() {
         require(
-            ExitGameRegistry(framework).isSafeToUse(msg.sender),
+            ExitGameRegistry(framework).isExitGameSafeToUse(msg.sender),
             "Called from a nonregistered or quarantined Exit Game contract"
         );
         _;

--- a/plasma_framework/contracts/src/vaults/Vault.sol
+++ b/plasma_framework/contracts/src/vaults/Vault.sol
@@ -21,9 +21,9 @@ contract Vault is Operated {
         zeroHashes = ZeroHashesProvider.getZeroHashes();
     }
 
-    modifier onlyFromExitGame() {
+    modifier onlyFromNonQuarantinedExitGame() {
         require(
-            framework.exitGameToTxType(msg.sender) != 0,
+            ExitGameRegistry(framework).isSafeToUse(msg.sender),
             "Not called from a registered Exit Game contract"
         );
         _;

--- a/plasma_framework/test/src/framework/registries/ExitGameRegistry.test.js
+++ b/plasma_framework/test/src/framework/registries/ExitGameRegistry.test.js
@@ -30,7 +30,7 @@ contract('ExitGameRegistry', ([_, other]) => {
         });
 
         it('accepts call when called by registered exit game contract on passed quarantine period', async () => {
-            await time.increase(2 * MIN_EXIT_PERIOD + 1);
+            await time.increase(3 * MIN_EXIT_PERIOD + 1);
             expect(await this.dummyExitGame.checkOnlyFromNonQuarantinedExitGame()).to.be.true;
         });
 

--- a/plasma_framework/test/src/vaults/Erc20Vault.test.js
+++ b/plasma_framework/test/src/vaults/Erc20Vault.test.js
@@ -212,7 +212,7 @@ contract('Erc20Vault', (accounts) => {
         });
 
         it('and then quarantine period passes', async () => {
-            await time.increase(2 * MIN_EXIT_PERIOD + 1);
+            await time.increase(3 * MIN_EXIT_PERIOD + 1);
             const { receipt } = await this.newExitGame.proxyErc20Withdraw(
                 alice, this.erc20.address, this.testFundAmount,
             );

--- a/plasma_framework/test/src/vaults/EthVault.test.js
+++ b/plasma_framework/test/src/vaults/EthVault.test.js
@@ -190,7 +190,7 @@ contract('EthVault', ([_, alice]) => {
         });
 
         it('and then quarantine period passes', async () => {
-            await time.increase(2 * MIN_EXIT_PERIOD + 1);
+            await time.increase(3 * MIN_EXIT_PERIOD + 1);
             const { receipt } = await this.newExitGame.proxyEthWithdraw(alice, DEPOSIT_VALUE);
 
             await expectEvent.inTransaction(


### PR DESCRIPTION
Fixes #186 

## Changes 

Vaults uses similar to ExitGameRegisty's modifier `onlyFromNonQuarantinedExitGame`. Info about exit games quarantines are retrieved from `framework` (which extends `ExitGameRegistry`)