### PR TITLE
feat: emit ExitQueued event on enqueue

### DIFF
--- a/plasma_framework/contracts/src/framework/ExitGameController.sol
+++ b/plasma_framework/contracts/src/framework/ExitGameController.sol
@@ -27,6 +27,11 @@ contract ExitGameController is ExitGameRegistry {
         address token
     );
 
+    event ExitQueued(
+        uint192 indexed exitId,
+        uint256 uniquePriority
+    );
+
     constructor(uint256 _minExitPeriod, uint256 _initialImmuneExitGames)
         public
         ExitGameRegistry(_minExitPeriod, _initialImmuneExitGames)
@@ -85,6 +90,8 @@ contract ExitGameController is ExitGameRegistry {
             exitProcessor: _exitProcessor,
             exitId: _exitId
         });
+
+        emit ExitQueued(_exitId, uniquePriority);
 
         return uniquePriority;
     }

--- a/plasma_framework/contracts/src/framework/utils/PriorityQueue.sol
+++ b/plasma_framework/contracts/src/framework/utils/PriorityQueue.sol
@@ -26,6 +26,10 @@ contract PriorityQueue is Ownable {
         return queue.currentSize;
     }
 
+    function heapList() external view returns (uint256[] memory) {
+        return queue.heapList;
+    }
+
     /**
      * @notice Inserts an element into the queue by the owner.
      * @dev Does not perform deduplication.

--- a/plasma_framework/test/src/framework/ExitGameController.test.js
+++ b/plasma_framework/test/src/framework/ExitGameController.test.js
@@ -144,32 +144,11 @@ contract('ExitGameController', () => {
             expect(await priorityQueue.currentSize()).to.be.bignumber.equal(new BN(2));
         });
 
-        it('emits an ExitEnqueued event', async () => {
-            const { receipt } = await this.dummyExitGame.enqueue(
-                this.dummyExit.token,
-                this.dummyExit.exitableAt,
-                this.dummyExit.txPos,
-                this.dummyExit.exitId,
-                this.dummyExit.exitProcessor,
-            );
-
-            const uniquePriority = await this.dummyExitGame.uniquePriorityFromEnqueue();
-
-            await expectEvent.inTransaction(
-                receipt.transactionHash,
-                ExitGameController,
-                'ExitQueued', {
-                    uniquePriority,
-                    exitId: new BN(this.dummyExit.exitId),
-                },
-            );
-        });
-
         describe('when successfully enqueued', () => {
             beforeEach(async () => {
                 this.originExitQueueNonce = await this.controller.exitQueueNonce();
 
-                await this.dummyExitGame.enqueue(
+                this.enqueueTx = await this.dummyExitGame.enqueue(
                     this.dummyExit.token,
                     this.dummyExit.exitableAt,
                     this.dummyExit.txPos,
@@ -199,6 +178,19 @@ contract('ExitGameController', () => {
 
                 expect(exit.exitProcessor).to.equal(this.dummyExit.exitProcessor);
                 expect(exit.exitId).to.be.bignumber.equal(new BN(this.dummyExit.exitId));
+            });
+
+            it('emits an ExitEnqueued event', async () => {
+                const uniquePriority = await this.dummyExitGame.uniquePriorityFromEnqueue();
+
+                await expectEvent.inTransaction(
+                    this.enqueueTx.receipt.transactionHash,
+                    ExitGameController,
+                    'ExitQueued', {
+                        uniquePriority,
+                        exitId: new BN(this.dummyExit.exitId),
+                    },
+                );
             });
 
             it('should be able to find the exit in the priority queue given exitId', async () => {

--- a/plasma_framework/test/src/framework/ExitGameController.test.js
+++ b/plasma_framework/test/src/framework/ExitGameController.test.js
@@ -144,7 +144,28 @@ contract('ExitGameController', () => {
             expect(await priorityQueue.currentSize()).to.be.bignumber.equal(new BN(2));
         });
 
-        describe('when successully enqueued', () => {
+        it('emits an ExitEnqueued event', async () => {
+            const { receipt } = await this.dummyExitGame.enqueue(
+                this.dummyExit.token,
+                this.dummyExit.exitableAt,
+                this.dummyExit.txPos,
+                this.dummyExit.exitId,
+                this.dummyExit.exitProcessor,
+            );
+
+            const uniquePriority = await this.dummyExitGame.uniquePriorityFromEnqueue();
+
+            await expectEvent.inTransaction(
+                receipt.transactionHash,
+                ExitGameController,
+                'ExitQueued', {
+                    uniquePriority,
+                    exitId: new BN(this.dummyExit.exitId),
+                },
+            );
+        });
+
+        describe('when successfully enqueued', () => {
             beforeEach(async () => {
                 this.originExitQueueNonce = await this.controller.exitQueueNonce();
 
@@ -178,6 +199,26 @@ contract('ExitGameController', () => {
 
                 expect(exit.exitProcessor).to.equal(this.dummyExit.exitProcessor);
                 expect(exit.exitId).to.be.bignumber.equal(new BN(this.dummyExit.exitId));
+            });
+
+            it('should be able to find the exit in the priority queue given exitId', async () => {
+                // Search for and ExitQueued event with the exitId
+                const events = await this.controller.getPastEvents('ExitQueued', {
+                    filter: { exitId: this.dummyExit.exitId },
+                });
+
+                // There should be only one ExitQueued event
+                expect(events.length).to.equal(1);
+
+                // Get the exit's uniquePriority from the ExitQueued event
+                const { uniquePriority } = events[0].args;
+
+                // Find the exit's uniquePriority in the priority queue
+                const priorityQueueAddress = await this.controller.exitsQueues(this.dummyToken);
+                const priorityQueue = await PriorityQueue.at(priorityQueueAddress);
+                const heapList = await priorityQueue.heapList();
+                const foundInQueue = heapList.find(e => e.eq(uniquePriority));
+                expect(foundInQueue).not.null;
             });
         });
     });


### PR DESCRIPTION
# Note
Make exits traceable in the priority queue by emitting an `ExitQueued` event that contains the exit's `uniquePriority`

# Tests
```
 Contract: ExitGameController
    enqueue
      ✓ emits an ExitEnqueued event
    find exit in the priority queue
      ✓ should be able to find the exit in the priority queue 
```
 
Closes: #198 