### PR TITLE
[WIP] BondSize library

### DIFF
--- a/plasma_framework/contracts/mocks/utils/BondSizeMock.sol
+++ b/plasma_framework/contracts/mocks/utils/BondSizeMock.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.0;
 
-import "../../src/exits/payment/BondSize.sol";
+import "../../src/exits/utils/BondSize.sol";
 
 contract BondSizeMock {
     using BondSize for BondSize.Params;

--- a/plasma_framework/contracts/mocks/utils/BondSizeMock.sol
+++ b/plasma_framework/contracts/mocks/utils/BondSizeMock.sol
@@ -11,13 +11,13 @@ contract BondSizeMock {
 
     constructor (
         uint256 _initialGasPrice,
-        uint256 _challengeGasCost,
-        uint256 _ewmaFactor,
-        uint256 _safetyFactor
+        uint128 _targetGasCost,
+        uint64 _ewmaFactor,
+        uint64 _safetyFactor
     ) public {
         _bondSize = BondSize.Params({
             currentGasPrice: _initialGasPrice,
-            challengeGasCost: _challengeGasCost,
+            targetGasCost: _targetGasCost,
             ewmaFactor: _ewmaFactor,
             safetyFactor: _safetyFactor
         });
@@ -28,7 +28,7 @@ contract BondSizeMock {
     }
 
     function updateGasPrice() public {
-        _bondSize.updateGasPrice();
+        _bondSize.updateGasPrice(tx.gasprice);
 
         emit Updated(tx.gasprice);
     }

--- a/plasma_framework/contracts/mocks/utils/BondSizeMock.sol
+++ b/plasma_framework/contracts/mocks/utils/BondSizeMock.sol
@@ -1,0 +1,35 @@
+pragma solidity ^0.5.0;
+
+import "../../src/exits/payment/BondSize.sol";
+
+contract BondSizeMock {
+    using BondSize for BondSize.Params;
+
+    BondSize.Params private _bondSize;
+
+    event Updated(uint256 gasPrice);
+
+    constructor (
+        uint256 _initialGasPrice,
+        uint256 _challengeGasCost,
+        uint256 _ewmaFactor,
+        uint256 _safetyFactor
+    ) public {
+        _bondSize = BondSize.Params({
+            currentGasPrice: _initialGasPrice,
+            challengeGasCost: _challengeGasCost,
+            ewmaFactor: _ewmaFactor,
+            safetyFactor: _safetyFactor
+        });
+    }
+
+    function bondSize() public view returns (uint) {
+        return _bondSize.bondSize();
+    }
+
+    function updateGasPrice() public {
+        _bondSize.updateGasPrice();
+
+        emit Updated(tx.gasprice);
+    }
+}

--- a/plasma_framework/contracts/src/exits/utils/BondSize.sol
+++ b/plasma_framework/contracts/src/exits/utils/BondSize.sol
@@ -2,28 +2,59 @@ pragma solidity ^0.5.0;
 
 import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
 
+/**
+ * @notice Calculates bond size based on current average gas prices.
+ * @dev An Exponentially Weighted Moving Average is used as it's cheap in terms of storage and resistant to sudden changes.
+ * @dev `updateGasPrice()` must be called regularly to maintain the average gas price.
+ */
 library BondSize {
     using SafeMath for uint256;
 
+    uint256 constant GWEI = 1000000000;
+
+    /**
+    * @param currentGasPrice The current average gas price.
+    * @param targetGasCost The gas cost of the target method that can claim the bond (e.g. challenge).
+    * @param ewmaFactor The 'smoothing' factor for the EWMA algorithm. Higher value means the the average changes more slowly.
+    * @param safetyFactor Adjustment factor to multiply the bond size by. Value is a percentage i.e. 100 means unchanged.
+    */
     struct Params {
         uint256 currentGasPrice;
-        uint256 challengeGasCost;
-        uint256 ewmaFactor;
-        uint256 safetyFactor;
+        uint128 targetGasCost;
+        uint64 ewmaFactor;
+        uint64 safetyFactor;
     }
 
-    function bondSize(Params storage _self) internal view returns (uint256) {
-        return _self.challengeGasCost
-            .mul(_self.currentGasPrice)
-            .mul(_self.safetyFactor)
+    /**
+    * @notice Returns the bond size based on current gas prices.
+    * @dev Rounds down to nearest gwei to avoid small changes in value.
+    * @param _self Described in `Params` above.
+    */
+    function bondSize(Params memory _self) internal pure returns (uint256) {
+        uint256 bond = _self.currentGasPrice
+            .mul(uint256(_self.targetGasCost))
+            .mul(uint256(_self.safetyFactor))
             .div(100);
+
+        return bond.div(GWEI).mul(GWEI);
     }
 
-    function updateGasPrice(Params storage _self) internal {
-        _self.currentGasPrice = ewma(_self.currentGasPrice, tx.gasprice, _self.ewmaFactor);
+    /**
+    * @notice Updates the current gas price average.
+    * @param _self Described in `Params` above.
+    * @param _newGasPrice The new gas price to be included in the average.
+    */
+    function updateGasPrice(Params storage _self, uint256 _newGasPrice) internal {
+        _self.currentGasPrice = ewma(_self.currentGasPrice, _newGasPrice, _self.ewmaFactor);
     }
 
-    function ewma(uint avg, uint value, uint factor) internal pure returns (uint) {
-        return avg.mul(factor - 1).add(value).div(factor);
+    /**
+    * @notice Calculates the Exponentially Weighted Moving Average.
+    * @param _avg The current average.
+    * @param _value The new value to be included.
+    * @param _factor The weighting factor.
+    */
+    function ewma(uint256 _avg, uint256 _value, uint256 _factor) private pure returns (uint) {
+        return _avg.mul(_factor - 1).add(_value).div(_factor);
     }
 }

--- a/plasma_framework/contracts/src/exits/utils/BondSize.sol
+++ b/plasma_framework/contracts/src/exits/utils/BondSize.sol
@@ -1,0 +1,29 @@
+pragma solidity ^0.5.0;
+
+import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
+
+library BondSize {
+    using SafeMath for uint256;
+
+    struct Params {
+        uint256 currentGasPrice;
+        uint256 challengeGasCost;
+        uint256 ewmaFactor;
+        uint256 safetyFactor;
+    }
+
+    function bondSize(Params storage _self) internal view returns (uint256) {
+        return _self.challengeGasCost
+            .mul(_self.currentGasPrice)
+            .mul(_self.safetyFactor)
+            .div(100);
+    }
+
+    function updateGasPrice(Params storage _self) internal {
+        _self.currentGasPrice = ewma(_self.currentGasPrice, tx.gasprice, _self.ewmaFactor);
+    }
+
+    function ewma(uint avg, uint value, uint factor) internal pure returns (uint) {
+        return avg.mul(factor - 1).add(value).div(factor);
+    }
+}

--- a/plasma_framework/test/src/utils/BondSize.test.js
+++ b/plasma_framework/test/src/utils/BondSize.test.js
@@ -1,0 +1,43 @@
+const BondSizeMock = artifacts.require('BondSizeMock');
+const { BN } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
+
+contract('BondSize', () => {
+    beforeEach(async () => {
+        this.initialGasPrice = 20000000000; // 20 gwei
+        this.challengeGasCost = 300000;
+        this.ewmaFactor = 2;
+        this.safetyFactor = 100;
+
+        this.contract = await BondSizeMock.new(
+            this.initialGasPrice,
+            this.challengeGasCost,
+            this.ewmaFactor,
+            this.safetyFactor,
+        );
+
+        this.initialBondSize = new BN(this.initialGasPrice)
+            .muln(this.challengeGasCost)
+            .muln(this.safetyFactor)
+            .divn(100);
+    });
+
+    it('should return the initial bond size', async () => {
+        const bondSize = await this.contract.bondSize();
+        expect(bondSize).to.be.bignumber.equal(this.initialBondSize);
+    });
+
+    it('should lower the bond size when average gas price decreases', async () => {
+        const LOW_GAS = new BN(this.initialGasPrice).divn(2);
+        await this.contract.updateGasPrice({ gasPrice: LOW_GAS });
+        const bondSize = await this.contract.bondSize();
+        expect(bondSize).to.be.bignumber.lt(this.initialBondSize);
+    });
+
+    it('should raise the bond size when average gas price increases', async () => {
+        const HIGH_GAS = new BN(this.initialGasPrice).muln(2);
+        await this.contract.updateGasPrice({ gasPrice: HIGH_GAS });
+        const bondSize = await this.contract.bondSize();
+        expect(bondSize).to.be.bignumber.gt(this.initialBondSize);
+    });
+});

--- a/plasma_framework/test/src/utils/BondSize.test.js
+++ b/plasma_framework/test/src/utils/BondSize.test.js
@@ -2,6 +2,8 @@ const BondSizeMock = artifacts.require('BondSizeMock');
 const { BN } = require('openzeppelin-test-helpers');
 const { expect } = require('chai');
 
+const GWEI = new BN(1000000000);
+
 contract('BondSize', () => {
     beforeEach(async () => {
         this.initialGasPrice = 20000000000; // 20 gwei
@@ -19,7 +21,9 @@ contract('BondSize', () => {
         this.initialBondSize = new BN(this.initialGasPrice)
             .muln(this.challengeGasCost)
             .muln(this.safetyFactor)
-            .divn(100);
+            .divn(100)
+            .div(GWEI)
+            .mul(GWEI);
     });
 
     it('should return the initial bond size', async () => {


### PR DESCRIPTION
## Overview
 Implement BondSize lib, as discussed [here](https://github.com/omisego/research/issues/107)

The idea is:

1. Maintain an average gas price (exponential weighted moving average is cheap) using e.g. startExit calls.
2. Calculate bond size as: Bond size = average gas price * gas cost for challenge * safety multiplier (e.g. 1.5)
