### PR TITLE
Figure out better use spending condition

### DIFF
--- a/plasma_framework/contracts/src/exits/payment/PaymentInFlightExitable.sol
+++ b/plasma_framework/contracts/src/exits/payment/PaymentInFlightExitable.sol
@@ -229,8 +229,8 @@ contract PaymentInFlightExitable is
 
             bool isSpentByInFlightTx = condition.verify(
                 outputGuard,
-                exitData.inputUtxosPos[i].value,
-                exitData.outputIds[i],
+                uint256(0), // should not be used
+                bytes32(exitData.inputUtxosPos[i].value),
                 exitData.inFlightTxRaw,
                 uint8(i),
                 exitData.inFlightTxWitnesses[i]

--- a/plasma_framework/contracts/src/exits/payment/PaymentStandardExitable.sol
+++ b/plasma_framework/contracts/src/exits/payment/PaymentStandardExitable.sol
@@ -333,8 +333,8 @@ contract PaymentStandardExitable is
 
         bool isSpentByChallengeTx = condition.verify(
             args.outputGuard,
-            data.exitData.utxoPos,
-            data.exitData.outputId,
+            uint256(0), // should not be used
+            bytes32(uint256(data.exitData.utxoPos)),
             args.challengeTx,
             args.inputIndex,
             args.witness

--- a/plasma_framework/contracts/src/exits/payment/spendingConditions/PaymentOutputToPaymentTxCondition.sol
+++ b/plasma_framework/contracts/src/exits/payment/spendingConditions/PaymentOutputToPaymentTxCondition.sol
@@ -20,15 +20,16 @@ contract PaymentOutputToPaymentTxCondition is IPaymentSpendingCondition {
     /**
      * @notice Checks if given output has been spent by owner in given spending transaction.
      * @param _outputGuard bytes that hold the address of owner directly.
-     * @param _utxoPos serves as the identifier of output.
+     * @dev _utxoPos not used, serves as the position identifier of output.
+     * @param _outputId serves as the identifier of output (input pointer).
      * @param _spendingTx The rlp encoded transaction that spends the output.
      * @param _inputIndex The input index of the spending transaction that points to the output.
      * @param _signature The signature of the output owner.
      */
     function verify(
         bytes32 _outputGuard,
-        uint256 _utxoPos,
-        bytes32 /*_outputId*/,
+        uint256, /*_utxoPos  NOTE: It's unclear how & if this will be used at all, see: https://github.com/omisego/plasma-contracts/pull/212*/
+        bytes32 _outputId,
         bytes calldata _spendingTx,
         uint8 _inputIndex,
         bytes calldata _signature
@@ -39,7 +40,7 @@ contract PaymentOutputToPaymentTxCondition is IPaymentSpendingCondition {
     {
         PaymentTransactionModel.Transaction memory spendingTx = PaymentTransactionModel.decode(_spendingTx);
         require(spendingTx.txType == PAYMENT_TX_TYPE, "The spending tx is not of payment tx type");
-        require(spendingTx.inputs[_inputIndex] == bytes32(_utxoPos), "The spending tx does not spend the output at this utxo pos");
+        require(spendingTx.inputs[_inputIndex] == _outputId, "The spending tx does not spend the output at this utxo pos");
 
         address payable owner = AddressPayable.convert(address(uint256(_outputGuard)));
         require(owner == ECDSA.recover(eip712.hashTx(spendingTx), _signature), "Tx not correctly signed");

--- a/plasma_framework/test/src/exits/payment/PaymentStandardExitable.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentStandardExitable.test.js
@@ -352,8 +352,8 @@ contract('PaymentStandardExitable', ([_, alice, bob]) => {
 
         const getExpectedConditionInputArgs = (input, exitData) => ({
             outputGuard: input.outputGuard,
-            utxoPos: exitData.utxoPos,
-            outputId: exitData.outputId,
+            utxoPos: 0, // should not be used, see: https://github.com/omisego/plasma-contracts/pull/212
+            outputId: web3.eth.abi.encodeParameter('uint256', exitData.utxoPos.toString()),
             spendingTx: input.challengeTx,
             inputIndex: input.inputIndex,
             witness: input.witness,

--- a/plasma_framework/test/src/exits/payment/spendingConditions/PaymentOutputToPaymentTxCondition.test.js
+++ b/plasma_framework/test/src/exits/payment/spendingConditions/PaymentOutputToPaymentTxCondition.test.js
@@ -11,8 +11,9 @@ const { sign } = require('../../../../helpers/sign.js');
 
 contract('PaymentOutputToPaymentTxCondition', ([richFather]) => {
     const ETH = constants.ZERO_ADDRESS;
-    const EMPTY_OUTPUT_ID = '0x';
+    const EMPTY_UTXO_POS = 0;
     const alicePrivateKey = '0x7151e5dab6f8e95b5436515b83f423c4df64fe4c6149f864daa209b26adb10ca';
+    const utxoPosToBytes32 = utxoPos => web3.eth.abi.encodeParameter('uint256', utxoPos.toString());
     let alice;
 
     before('setup alice account with custom private key', async () => {
@@ -45,7 +46,7 @@ contract('PaymentOutputToPaymentTxCondition', ([richFather]) => {
             const txBytes = web3.utils.bytesToHex(tx.rlpEncoded());
             await expectRevert(
                 this.condition.verify(
-                    outputGuard, utxoPos, EMPTY_OUTPUT_ID,
+                    outputGuard, EMPTY_UTXO_POS, utxoPosToBytes32(utxoPos),
                     txBytes, inputIndex, '0x',
                 ),
                 'The spending tx is not of payment tx type',
@@ -64,7 +65,7 @@ contract('PaymentOutputToPaymentTxCondition', ([richFather]) => {
             const txBytes = web3.utils.bytesToHex(tx.rlpEncoded());
             await expectRevert(
                 this.condition.verify(
-                    outputGuard, utxoPos, EMPTY_OUTPUT_ID,
+                    outputGuard, EMPTY_UTXO_POS, utxoPosToBytes32(utxoPos),
                     txBytes, inputIndex, '0x',
                 ),
                 'The spending tx does not spend the output at this utxo pos',
@@ -85,7 +86,7 @@ contract('PaymentOutputToPaymentTxCondition', ([richFather]) => {
             const wrongSignature = sign(txHash, wrongPrivateKey);
             await expectRevert(
                 this.condition.verify(
-                    outputGuard, utxoPos, EMPTY_OUTPUT_ID,
+                    outputGuard, EMPTY_UTXO_POS, utxoPosToBytes32(utxoPos),
                     txBytes, inputIndex, wrongSignature,
                 ),
                 'Tx not correctly signed',
@@ -105,7 +106,7 @@ contract('PaymentOutputToPaymentTxCondition', ([richFather]) => {
             const signature = sign(txHash, alicePrivateKey);
 
             const result = await this.condition.verify(
-                outputGuard, utxoPos, EMPTY_OUTPUT_ID,
+                outputGuard, EMPTY_UTXO_POS, utxoPosToBytes32(utxoPos),
                 txBytes, inputIndex, signature,
             );
             expect(result).to.be.true;

--- a/plasma_framework/test/src/exits/payment/spendingConditions/PaymentOutputToPaymentTxCondition.test.js
+++ b/plasma_framework/test/src/exits/payment/spendingConditions/PaymentOutputToPaymentTxCondition.test.js
@@ -68,7 +68,7 @@ contract('PaymentOutputToPaymentTxCondition', ([richFather]) => {
                     outputGuard, EMPTY_UTXO_POS, utxoPosToBytes32(utxoPos),
                     txBytes, inputIndex, '0x',
                 ),
-                'The spending tx does not spend the output at this utxo pos',
+                'The spending tx does not spend the output specified by output identifier',
             );
         });
 


### PR DESCRIPTION
Signature of `IPaymentSpendingCondition.verify` was controversial because it requires 2 arguments for parameters `utxoPos` and `outputId`.

@pdobacz help me to figure out the meaning of these two :point_up: and that they are both needed there.
So as I'm understanding the matter at the moment (assuming spending condition for Payment transaction):
* Spending condition responsibility is to check: 
   * that provided transaction spends provided input,
   * and provided guard unlocks utxo for spending (in old words: owner of utxo signs tx)
* Spending condition is registered for concrete Tx type so it knows how to decode passed transaction,
* meaning of `outputId` is an input pointer to check that provided tx indeed spends that input 
  `tx.inputs[inputIndex] == expected_input_pointer`
* meaning of `utxoPos` - not used at the moment, but could serve as point in time (or age) of the input.

:notebook: Please note that as currently implemented our **`PaymentTransaction` inputs are pointed also by utxo position - however this will change toward `outputId`**, so it makes sense to treat the parameters to `verify` aligned with theirs meaning