### PR TITLE
feat: set default gas to 6000000 for local network

### DIFF
--- a/truffle-config.js
+++ b/truffle-config.js
@@ -18,6 +18,7 @@ module.exports = {
       host: process.env.ETH_CLIENT_HOST || '127.0.0.1',
       port: process.env.ETH_CLIENT_PORT || 8545,
       from: process.env.DEPLOYER_ADDRESS,
+      gas: 6000000, // reasoning of the gas here: https://github.com/omisego/plasma-contracts/issues/199
       network_id: '*'
     },
     mainnet: {


### PR DESCRIPTION
### Note
Local geth would start the chain with gas limit around 600000. Even passing
in some flags to set the target block gas limit it would still take some time
for the geth to adjust to such block gas limit. Default truffle is using gas
of 6721975 which would need to wait for the geth to increase its gas limit.

This commit alter the gas to 6000000 for faster local development experience.

closes: https://github.com/omisego/plasma-contracts/issues/199

### Test
run the following commands in two terminals:
```
ganache-cli -gaslimit 620000
```
```
npx truffle migrate --network local --reset
```
For environment variable: `.env` file
```
AUTHORITY_PASSPHRASE=ThisIsATestnetPassphrase
MIN_EXIT_PERIOD=600
```