### PR TITLE
refactor: use bool for isFinalized in IFE

### DIFF
--- a/plasma_framework/contracts/mocks/exits/payment/routers/PaymentInFlightExitRouterMock.sol
+++ b/plasma_framework/contracts/mocks/exits/payment/routers/PaymentInFlightExitRouterMock.sol
@@ -16,7 +16,7 @@ contract PaymentInFlightExitRouterMock is PaymentInFlightExitRouter {
 
     function finalizeExit(uint192 exitId) public {
         inFlightExitMap.exits[exitId].exitStartTimestamp = 1;
-        inFlightExitMap.exits[exitId].exitMap = Bits.setBit(inFlightExitMap.exits[exitId].exitMap, 255);
+        inFlightExitMap.exits[exitId].isFinalized = true;
     }
 
     function getInFlightExitInput(uint192 exitId, uint8 inputIndex) public view returns (PaymentOutputModel.Output memory) {

--- a/plasma_framework/contracts/src/exits/payment/PaymentExitDataModel.sol
+++ b/plasma_framework/contracts/src/exits/payment/PaymentExitDataModel.sol
@@ -26,11 +26,11 @@ library PaymentExitDataModel {
     }
 
     struct InFlightExit {
-        uint64 exitStartTimestamp;
         // Canonicity is assumed at start, then can be challenged and is set to `false`.
         // Response to non-canonical challenge can set it back to `true`.
         bool isCanonical;
-
+        bool isFinalized;
+        uint64 exitStartTimestamp;
         /**
          * exit map stores piggybacks and finalized exits
          * bit 255 is set only when in-flight exit has finalized

--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentStartInFlightExit.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentStartInFlightExit.sol
@@ -169,11 +169,7 @@ library PaymentStartInFlightExit {
     {
         PaymentExitDataModel.InFlightExit storage exit = inFlightExitMap.exits[exitId];
         require(exit.exitStartTimestamp == 0, "There is an active in-flight exit from this transaction");
-        require(!isFinalized(exit), "This in-flight exit has already been finalized");
-    }
-
-    function isFinalized(PaymentExitDataModel.InFlightExit storage ife) private view returns (bool) {
-        return Bits.bitSet(ife.exitMap, 255);
+        require(!exit.isFinalized, "This in-flight exit has already been finalized");
     }
 
     function verifyNumberOfInputsMatchesNumberOfInFlightTransactionInputs(StartExitData memory exitData) private pure {


### PR DESCRIPTION
### Note
Since there are still some space to fit in a 32bytes slot to pack with the
uint64 exitStartTimestamp. Make it a bool for clearer readibility.