### PR TITLE
Separation of maintainer and authority addresses

### DIFF
--- a/plasma_framework/contracts/src/framework/BlockController.sol
+++ b/plasma_framework/contracts/src/framework/BlockController.sol
@@ -37,6 +37,16 @@ contract BlockController is Operated, VaultRegistry {
     }
 
     /**
+     * @notice Allows the operator to set a new authority address. This allows to implement mechanical
+     * re-org protection mechanism, explained in https://github.com/omisego/plasma-contracts/issues/118
+     * @param newAuthority address of new authority, cannot be blank.
+     */
+    function setAuthority(address newAuthority) external onlyOperator {
+        require(newAuthority != address(0), "Authority cannot be zero-address.");
+        authority = newAuthority;
+    }
+
+    /**
      * @notice Allows operator's authority address to submit a child chain block.
      * @dev Block number jumps 'childBlockInterval' per submission.
      * @dev see discussion in https://github.com/omisego/plasma-contracts/issues/233

--- a/plasma_framework/contracts/src/framework/BlockController.sol
+++ b/plasma_framework/contracts/src/framework/BlockController.sol
@@ -31,7 +31,7 @@ contract BlockController is Operated, VaultRegistry {
      * @dev All block submission then needs to be send from msg.sender address.
      * @dev see discussion in https://github.com/omisego/plasma-contracts/issues/233
      */
-    function init() external {
+    function initAuthority() external {
         require(authority == address(0), "Authority address has been already set.");
         authority = msg.sender;
     }

--- a/plasma_framework/contracts/src/framework/BlockController.sol
+++ b/plasma_framework/contracts/src/framework/BlockController.sol
@@ -5,6 +5,7 @@ import "./registries/VaultRegistry.sol";
 import "./utils/Operated.sol";
 
 contract BlockController is Operated, VaultRegistry {
+    address public authority;
     uint256 public childBlockInterval;
     uint256 public nextChildBlock;
     uint256 public nextDepositBlock;
@@ -25,11 +26,24 @@ contract BlockController is Operated, VaultRegistry {
     }
 
     /**
-     * @notice Allows operator to submit a child chain block.
+     * @notice Sets the operator's authority address and unlocks block submission.
+     * @dev Can be called only once, before any call to `submitBlock`.
+     * @dev All block submission then needs to be send from msg.sender address.
+     * @dev see discussion in https://github.com/omisego/plasma-contracts/issues/233
+     */
+    function init() external {
+        require(authority == address(0), "Authority address has been already set.");
+        authority = msg.sender;
+    }
+
+    /**
+     * @notice Allows operator's authority address to submit a child chain block.
      * @dev Block number jumps 'childBlockInterval' per submission.
+     * @dev see discussion in https://github.com/omisego/plasma-contracts/issues/233
      * @param _blockRoot Merkle root of the block.
      */
-    function submitBlock(bytes32 _blockRoot) external onlyOperator {
+    function submitBlock(bytes32 _blockRoot) external {
+        require(msg.sender == authority, "Can be called only by the Authority.");
         uint256 submittedBlockNumber = nextChildBlock;
 
         blocks[submittedBlockNumber] = BlockModel.Block({

--- a/plasma_framework/test/src/exits/payment/PaymentExitGame.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentExitGame.test.js
@@ -81,6 +81,7 @@ contract('PaymentExitGame - End to End Tests', ([_, richFather, bob]) => {
 
     const setupContracts = async () => {
         this.framework = await PlasmaFramework.new(MIN_EXIT_PERIOD, INITIAL_IMMUNE_VAULTS, INITIAL_IMMUNE_EXIT_GAMES);
+        await this.framework.init();
 
         const ethDepositVerifier = await EthDepositVerifier.new();
         this.ethVault = await EthVault.new(this.framework.address);

--- a/plasma_framework/test/src/exits/payment/PaymentExitGame.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentExitGame.test.js
@@ -81,7 +81,7 @@ contract('PaymentExitGame - End to End Tests', ([_, richFather, bob]) => {
 
     const setupContracts = async () => {
         this.framework = await PlasmaFramework.new(MIN_EXIT_PERIOD, INITIAL_IMMUNE_VAULTS, INITIAL_IMMUNE_EXIT_GAMES);
-        await this.framework.init();
+        await this.framework.initAuthority();
 
         const ethDepositVerifier = await EthDepositVerifier.new();
         this.ethVault = await EthVault.new(this.framework.address);

--- a/plasma_framework/test/src/framework/BlockController.test.js
+++ b/plasma_framework/test/src/framework/BlockController.test.js
@@ -25,7 +25,7 @@ contract('BlockController', ([operator, other]) => {
         this.blockController.registerVault(this.dummyVaultId, this.dummyVault.address);
 
         // to make these tests easier authority address will be the same as default caller (account[0])
-        await this.blockController.init();
+        await this.blockController.initAuthority();
     });
 
     describe('constructor', () => {
@@ -40,7 +40,7 @@ contract('BlockController', ([operator, other]) => {
             expect(await this.blockController.authority()).to.equal(operator);
 
             await expectRevert(
-                this.blockController.init(),
+                this.blockController.initAuthority(),
                 'Authority address has been already set.',
             );
         });


### PR DESCRIPTION
Fixes #233 
This :pr: separates `authority` address from the `operator` address.
Where:
- `authority` - an address which publishes new plasma blocks on the Ethereum
- `operator` - an address which deployed `PlasmaFramework` contract and is allow to register components to it such as Exit games, Vaults ...

It's worth to further separate `operator aka maintainer` from the `deployer` address - but this effort failed because of circular dependencies see: #239 