### PR TITLE
Makes metadata field mandatory for rlp-encoded tx

### DIFF
--- a/plasma_framework/contracts/src/transactions/PaymentTransactionModel.sol
+++ b/plasma_framework/contracts/src/transactions/PaymentTransactionModel.sol
@@ -13,7 +13,6 @@ library PaymentTransactionModel {
     uint8 constant public MAX_OUTPUT_NUM = 4;
 
     uint8 constant private ENCODED_LENGTH_WITH_METADATA = 4;
-    uint8 constant private ENCODED_LENGTH_WITHOUT_METADATA = 3;
 
     struct Transaction {
         uint256 txType;
@@ -24,10 +23,7 @@ library PaymentTransactionModel {
 
     function decode(bytes memory _tx) internal pure returns (PaymentTransactionModel.Transaction memory) {
         RLP.RLPItem[] memory rlpTx = _tx.toRLPItem().toList();
-        require(
-            rlpTx.length == ENCODED_LENGTH_WITH_METADATA || rlpTx.length == ENCODED_LENGTH_WITHOUT_METADATA,
-            "Invalid encoding of transaction"
-        );
+        require(rlpTx.length == ENCODED_LENGTH_WITH_METADATA, "Invalid encoding of transaction");
 
         RLP.RLPItem[] memory rlpInputs = rlpTx[1].toList();
         require(rlpInputs.length <= MAX_INPUT_NUM, "Transaction inputs num exceeds limit");
@@ -49,12 +45,7 @@ library PaymentTransactionModel {
             outputs[i] = output;
         }
 
-        bytes32 metaData;
-        if (rlpTx.length == ENCODED_LENGTH_WITH_METADATA) {
-            metaData = rlpTx[3].toBytes32();
-        } else {
-            metaData = bytes32(0);
-        }
+        bytes32 metaData = rlpTx[3].toBytes32();
 
         return Transaction({txType: txType, inputs: inputs, outputs: outputs, metaData: metaData});
     }

--- a/plasma_framework/contracts/src/transactions/PaymentTransactionModel.sol
+++ b/plasma_framework/contracts/src/transactions/PaymentTransactionModel.sol
@@ -12,7 +12,7 @@ library PaymentTransactionModel {
     uint8 constant public MAX_INPUT_NUM = 4;
     uint8 constant public MAX_OUTPUT_NUM = 4;
 
-    uint8 constant private ENCODED_LENGTH_WITH_METADATA = 4;
+    uint8 constant private ENCODED_LENGTH = 4;
 
     struct Transaction {
         uint256 txType;
@@ -23,7 +23,7 @@ library PaymentTransactionModel {
 
     function decode(bytes memory _tx) internal pure returns (PaymentTransactionModel.Transaction memory) {
         RLP.RLPItem[] memory rlpTx = _tx.toRLPItem().toList();
-        require(rlpTx.length == ENCODED_LENGTH_WITH_METADATA, "Invalid encoding of transaction");
+        require(rlpTx.length == ENCODED_LENGTH, "Invalid encoding of transaction");
 
         RLP.RLPItem[] memory rlpInputs = rlpTx[1].toList();
         require(rlpInputs.length <= MAX_INPUT_NUM, "Transaction inputs num exceeds limit");

--- a/plasma_framework/test/src/transactions/PaymentTransactionModel.test.js
+++ b/plasma_framework/test/src/transactions/PaymentTransactionModel.test.js
@@ -74,6 +74,23 @@ contract('PaymentTransactionModel', () => {
         );
     });
 
+    it('should fail when transaction does not contain metadata', async () => {
+        const transaction = new PaymentTransaction(1, [EMPTY_BYTES32], [OUTPUT, OUTPUT], EMPTY_BYTES32);
+
+        const wireFormat = [
+            transaction.transactionType,
+            transaction.inputs,
+            PaymentTransaction.formatForRlpEncoding(transaction.outputs),
+        ];
+
+        const encoded = web3.utils.bytesToHex(rlp.encode(wireFormat));
+
+        await expectRevert(
+            this.test.decode(encoded),
+            'Invalid encoding of transaction',
+        );
+    });
+
     it('should fail when decoding invalid transaction', async () => {
         const encoded = web3.utils.bytesToHex(rlp.encode([0, 0]));
 


### PR DESCRIPTION
Fixes #189 

This change requires that rlp-encoded transaction contains 4 fields: type, inputs, outputs & metadata.
Metadata is decoded to `bytes32`.

## Testing
By an accident we always passing 32-zero bytes as [metadata from truffle tests](https://github.com/omisego/plasma-contracts/blob/ae4545c504ce7ca680d26cbccd36e575d66c59a7/plasma_framework/test/helpers/transaction.js#L30) so no changes requires in tests.
