### PR TITLE
feat: rename 'token' to 'ercContract' in framework

### DIFF
--- a/plasma_framework/contracts/mocks/exits/SpyPlasmaFrameworkForExitGame.sol
+++ b/plasma_framework/contracts/mocks/exits/SpyPlasmaFrameworkForExitGame.sol
@@ -10,7 +10,7 @@ contract SpyPlasmaFrameworkForExitGame is PlasmaFramework {
     mapping (uint256 => BlockModel.Block) public blocks;
 
     event EnqueueTriggered(
-        address token,
+        address ercContract,
         uint64 exitableAt,
         uint256 txPos,
         uint256 exitId,
@@ -24,13 +24,13 @@ contract SpyPlasmaFrameworkForExitGame is PlasmaFramework {
     }
 
     /** override for test */
-    function enqueue(address _token, uint64 _exitableAt, TxPosLib.TxPos calldata _txPos, uint192 _exitId, IExitProcessor _exitProcessor)
+    function enqueue(address _ercContract, uint64 _exitableAt, TxPosLib.TxPos calldata _txPos, uint192 _exitId, IExitProcessor _exitProcessor)
         external
         returns (uint256)
     {
         enqueuedCount += 1;
         emit EnqueueTriggered(
-            _token,
+            _ercContract,
             _exitableAt,
             _txPos.value,
             _exitId,

--- a/plasma_framework/contracts/mocks/framework/DummyExitGame.sol
+++ b/plasma_framework/contracts/mocks/framework/DummyExitGame.sol
@@ -40,8 +40,8 @@ contract DummyExitGame is IExitProcessor {
         exitGameController = ExitGameController(_contract);
     }
 
-    function enqueue(address _token, uint64 _exitableAt, uint256 _txPos, uint192 _exitId, IExitProcessor _exitProcessor) public {
-        uniquePriorityFromEnqueue = exitGameController.enqueue(_token, _exitableAt, TxPosLib.TxPos(_txPos), _exitId, _exitProcessor);
+    function enqueue(address _ercContract, uint64 _exitableAt, uint256 _txPos, uint192 _exitId, IExitProcessor _exitProcessor) public {
+        uniquePriorityFromEnqueue = exitGameController.enqueue(_ercContract, _exitableAt, TxPosLib.TxPos(_txPos), _exitId, _exitProcessor);
     }
 
     function proxyBatchFlagOutputsSpent(bytes32[] memory _outputIds) public {

--- a/plasma_framework/contracts/mocks/framework/ReentracyExitGame.sol
+++ b/plasma_framework/contracts/mocks/framework/ReentracyExitGame.sol
@@ -10,22 +10,22 @@ import "../../src/utils/TxPosLib.sol";
 
 contract ReentrancyExitGame is IExitProcessor {
     ExitGameController public exitGameController;
-    address public testToken;
+    address public testErcContract;
     uint256 public reentryMaxExitToProcess;
 
-    constructor(ExitGameController _controller, address _token, uint256 _reentryMaxExitToProcess) public {
+    constructor(ExitGameController _controller, address _ercContract, uint256 _reentryMaxExitToProcess) public {
         exitGameController = _controller;
-        testToken = _token;
+        testErcContract = _ercContract;
         reentryMaxExitToProcess = _reentryMaxExitToProcess;
     }
 
     // override ExitProcessor interface
     // This would call the processExits back to mimic reentracy attack
     function processExit(uint192, address) public {
-        exitGameController.processExits(testToken, 0, reentryMaxExitToProcess);
+        exitGameController.processExits(testErcContract, 0, reentryMaxExitToProcess);
     }
 
-    function enqueue(address _token, uint64 _exitableAt, uint256 _txPos, uint192 _exitId, IExitProcessor _exitProcessor) public {
-        exitGameController.enqueue(_token, _exitableAt, TxPosLib.TxPos(_txPos), _exitId, _exitProcessor);
+    function enqueue(address _ercContract, uint64 _exitableAt, uint256 _txPos, uint192 _exitId, IExitProcessor _exitProcessor) public {
+        exitGameController.enqueue(_ercContract, _exitableAt, TxPosLib.TxPos(_txPos), _exitId, _exitProcessor);
     }
 }

--- a/plasma_framework/test/src/exits/payment/PaymentExitGame.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentExitGame.test.js
@@ -432,13 +432,13 @@ contract('PaymentExitGame - End to End Tests', ([_, richFather, bob]) => {
                 expect(erc20VaultBalanceAfterDeposit).to.be.bignumber.equal(expectedErc20VaultBalance);
             });
 
-            describe('Given ERC20 token added to the PlasmaFramework', () => {
+            describe('Given ERC20 token contract is added to the PlasmaFramework', () => {
                 beforeEach(async () => {
-                    await this.framework.addToken(this.erc20.address);
+                    await this.framework.addErcContract(this.erc20.address);
                 });
 
-                it('should have the ERC20 token', async () => {
-                    expect(await this.framework.hasToken(this.erc20.address)).to.be.true;
+                it('should have the exit queue for the ERC20 token', async () => {
+                    expect(await this.framework.hasQueueForErcContract(this.erc20.address)).to.be.true;
                 });
 
                 describe('When Alice starts standard exit on the ERC20 deposit tx', () => {

--- a/plasma_framework/test/src/exits/payment/PaymentPiggybackInFlightExitOnInput.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentPiggybackInFlightExitOnInput.test.js
@@ -254,7 +254,7 @@ contract('PaymentInFlightExitRouter', ([_, alice, inputOwner, nonInputOwner, out
                     SpyPlasmaFramework,
                     'EnqueueTriggered',
                     {
-                        token: ETH,
+                        ercContract: ETH,
                         exitableAt: new BN(exitableAt),
                         txPos: new BN(utxoPosToTxPos(INFLIGHT_EXIT_YOUNGEST_INPUT_POSITION)),
                         exitProcessor: this.exitGame.address,

--- a/plasma_framework/test/src/exits/payment/PaymentPiggybackInFlightExitOnOutput.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentPiggybackInFlightExitOnOutput.test.js
@@ -340,7 +340,7 @@ contract('PaymentInFlightExitRouter', ([_, alice, inputOwner, outputOwner, nonOu
                     SpyPlasmaFramework,
                     'EnqueueTriggered',
                     {
-                        token: ETH,
+                        ercContract: ETH,
                         exitableAt: new BN(exitableAt),
                         txPos: new BN(utxoPosToTxPos(INFLIGHT_EXIT_YOUNGEST_INPUT_POSITION)),
                         exitProcessor: this.exitGame.address,

--- a/plasma_framework/test/src/exits/payment/PaymentStartStandardExit.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentStartStandardExit.test.js
@@ -301,7 +301,7 @@ contract('PaymentStandardExitRouter', ([_, outputOwner, nonOutputOwner]) => {
                 SpyPlasmaFramework,
                 'EnqueueTriggered',
                 {
-                    token: ETH,
+                    ercContract: ETH,
                     exitableAt,
                     txPos: new BN(utxoPosToTxPos(args.utxoPos)),
                     exitProcessor: this.exitGame.address,


### PR DESCRIPTION
### Note
We are renaming 'token' to 'ercContract' as the word 'token' might not be appropriate when it is
not using for ERC20 tokens on `PlasmaFramework`.

closes issue: https://github.com/omisego/plasma-contracts/issues/273

(PS. if anyone has better naming idea please let me know)