### PR TITLE
refactor: rename ercContract to token

### DIFF
--- a/plasma_framework/contracts/src/framework/interfaces/IExitProcessor.sol
+++ b/plasma_framework/contracts/src/framework/interfaces/IExitProcessor.sol
@@ -4,7 +4,7 @@ interface IExitProcessor {
     /**
      * @dev Custom function to process exit. Would do nothing if not able to exit (eg. successfully challenged)
      * @param exitId unique id for exit per tx type.
-     * @param ercContract which ercContract this exit queue is for. We use isolated queue for each erc contract to isolate external call impact.
+     * @param token The address of the contract for the token.
      */
-    function processExit(uint192 exitId, address ercContract) external;
+    function processExit(uint192 exitId, address token) external;
 }


### PR DESCRIPTION
### Note
We had some discussion about the naming on whether it should be 'token' or something else.
Since there is no general consensus on the naming plus etherscan is using the word 'token' pretty broad anyway,
let's stick with it.

discussion: https://git.io/Je3qD
original issue: https://git.io/Je3qy