### PR TITLE
284 document improvement

### DIFF
--- a/plasma_framework/contracts/src/exits/interfaces/ISpendingCondition.sol
+++ b/plasma_framework/contracts/src/exits/interfaces/ISpendingCondition.sol
@@ -1,5 +1,10 @@
 pragma solidity ^0.5.0;
 
+/**
+ * @notice interface of the spending condition.
+ * @dev for the interface design and discussion, see the following GH issue
+ *      https://github.com/omisego/plasma-contracts/issues/214
+ */
 interface ISpendingCondition {
 
     /**

--- a/plasma_framework/contracts/src/exits/models/OutputGuardModel.sol
+++ b/plasma_framework/contracts/src/exits/models/OutputGuardModel.sol
@@ -3,6 +3,7 @@ pragma experimental ABIEncoderV2;
 
 library OutputGuardModel {
     /**
+     * @dev The data structure that is being used for IOutputGuardHandler. Contains essential data related to output guard.
      * @param guard the output guard inside an output
      * @param outputType the output type that the guard holds
      * @param preimage the original data of the output guard aside from output type information

--- a/plasma_framework/contracts/src/exits/registries/OutputGuardHandlerRegistry.sol
+++ b/plasma_framework/contracts/src/exits/registries/OutputGuardHandlerRegistry.sol
@@ -4,7 +4,16 @@ import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import "../../framework/utils/Operated.sol";
 import "../interfaces/IOutputGuardHandler.sol";
 
+/**
+ * @title OutputGuardHandlerRegistry
+ * @notice The registry contracts of outputGuard handler
+ * @dev It is designed to renounce the ownership before injecting the registry contract to ExitGame contracts.
+ *      After registering all the essential condition contracts, the owner should renounce its ownership to
+ *      make sure no further conditions would be registered for an ExitGame contracts.
+ *      https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/ownership/Ownable.sol#L55
+ */
 contract OutputGuardHandlerRegistry is Operated {
+    // mapping of outputType to IOutputGuardHandler
     mapping(uint256 => IOutputGuardHandler) public outputGuardHandlers;
 
     /**

--- a/plasma_framework/contracts/src/exits/registries/OutputGuardHandlerRegistry.sol
+++ b/plasma_framework/contracts/src/exits/registries/OutputGuardHandlerRegistry.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.5.0;
 
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
-import "../../framework/utils/Operated.sol";
 import "../interfaces/IOutputGuardHandler.sol";
 
 /**
@@ -12,7 +11,7 @@ import "../interfaces/IOutputGuardHandler.sol";
  *      make sure no further conditions would be registered for an ExitGame contracts.
  *      https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/ownership/Ownable.sol#L55
  */
-contract OutputGuardHandlerRegistry is Operated {
+contract OutputGuardHandlerRegistry is Ownable {
     // mapping of outputType to IOutputGuardHandler
     mapping(uint256 => IOutputGuardHandler) public outputGuardHandlers;
 
@@ -23,7 +22,7 @@ contract OutputGuardHandlerRegistry is Operated {
      */
     function registerOutputGuardHandler(uint256 outputType, IOutputGuardHandler handler)
         public
-        onlyOperator
+        onlyOwner
     {
         require(outputType != 0, "Should not register with output type 0");
         require(address(handler) != address(0), "Should not register an empty address");

--- a/plasma_framework/contracts/src/exits/registries/SpendingConditionRegistry.sol
+++ b/plasma_framework/contracts/src/exits/registries/SpendingConditionRegistry.sol
@@ -6,11 +6,13 @@ import "../interfaces/ISpendingCondition.sol";
 /**
  * @title SpendingConditionRegistry
  * @notice The registry contracts of spending condition
- * @dev After registering all the essential condition contracts, the owner should renounce its ownership to make sure
- *      no further conditions would be registered for an ExitGame contracts.
+ * @dev It is designed to renounce the ownership before injecting the registry contract to ExitGame contracts.
+ *      After registering all the essential condition contracts, the owner should renounce its ownership to
+ *      make sure no further conditions would be registered for an ExitGame contracts.
  *      https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/ownership/Ownable.sol#L55
  */
 contract SpendingConditionRegistry is Ownable {
+    // mapping of hash(outputType, spendingTxTpye) => ISpendingCondition
     mapping(bytes32 => ISpendingCondition) internal _spendingConditions;
 
     function spendingConditions(uint256 outputType, uint256 spendingTxType) public view returns (ISpendingCondition) {

--- a/plasma_framework/contracts/src/exits/utils/BondSize.sol
+++ b/plasma_framework/contracts/src/exits/utils/BondSize.sol
@@ -2,10 +2,22 @@ pragma solidity ^0.5.0;
 
 /**
  * @notice Stores an updateable bond size.
+ * @dev Design of the bond: https://github.com/omisego/research/issues/107#issuecomment-525267486
+ * @dev Security relies on the min/max value that can be updated to compare to current bond size plus the waiting period.
+ *      The min/max value of the next bond size prevent the possibility to update to a insane high/lower bond that breaks the system.
+ *      The waiting period promises user would not get an unexpected bond without notice.
  */
 library BondSize {
     uint64 constant public WAITING_PERIOD = 2 days;
 
+    /**
+     * @dev It is desinged to be able to be packed into two 32-bytes slot storage. That is the reason of using uint128 and uin16 instead of purely uint256.
+     * @param previousBondSize the bond size before upgrade, should be keep using this before the waiting period has passed
+     * @param updatedBondSize the bond size that should be used after the waiting period has passed
+     * @param effectiveUpdateTime the timestamp when the waiting period would be passed and the updated bondsize taking effect
+     * @param lowerBoundDivisor the divisor used to check the lower bound for an update. Each update cannot be lower than (current bond / lowerBoundDivisor)
+     * @param upperBoundMultiplier the multiplier used to check the upper bound for an update. Each update cannot be larger than (current bond * upperBoundMultiplier)
+     */
     struct Params {
         uint128 previousBondSize;
         uint128 updatedBondSize;
@@ -19,10 +31,12 @@ library BondSize {
         pure
         returns (Params memory)
     {
+        // Set the initial value to far in the future
+        uint128 initialEffectiveUpdateTime = 2 ** 63;
         return Params({
             previousBondSize: _initialBondSize,
             updatedBondSize: 0,
-            effectiveUpdateTime: 2 ** 63, // Initial waiting period is far in the future
+            effectiveUpdateTime: initialEffectiveUpdateTime,
             lowerBoundDivisor: _lowerBoundDivisor,
             upperBoundMultiplier: _upperBoundMultiplier
         });

--- a/plasma_framework/contracts/src/exits/utils/ExitId.sol
+++ b/plasma_framework/contracts/src/exits/utils/ExitId.sol
@@ -8,14 +8,17 @@ library ExitId {
     using Bits for uint192;
     using Bits for uint256;
 
+    /**
+     * @notice Given a exitId, checks whether it is a standard exit id or not.
+     */
     function isStandardExit(uint192 _exitId) internal pure returns (bool) {
         return _exitId.getBit(151) == 0;
     }
 
     /**
      * @notice Given transaction bytes and UTXO position, returns its exit ID.
-     * @dev Id from a deposit is computed differently from any other tx.
-     * @param _isDeposit Predicate to check whether a block num is a deposit block.
+     * @dev Id from a deposit is computed differently from any other tx due to the fact that txBytes of deposit tx can be not unique.
+     * @param _isDeposit whether the tx for the exitId is an deposit tx or not
      * @param _txBytes Transaction bytes.
      * @param _utxoPos UTXO position of the exiting output.
      * @return _standardExitId Unique standard exit id.
@@ -50,9 +53,6 @@ library ExitId {
         return uint192((uint256(keccak256(_txBytes)) >> 105).setBit(151));
     }
 
-    /**
-    Private
-    */
     function _computeStandardExitId(bytes32 _txhash, uint16 _outputIndex)
         private
         pure

--- a/plasma_framework/contracts/src/exits/utils/OutputId.sol
+++ b/plasma_framework/contracts/src/exits/utils/OutputId.sol
@@ -5,6 +5,7 @@ library OutputId {
      * @notice Computes the output id for deposit tx
      * @dev Deposit tx bytes might not be unique because all inputs are empty.
      *      Two deposit with same output value would result in same tx bytes.
+     *      As a result, we need to hash with utxoPos to ensure uniqueness.
      * @param _txBytes Transaction bytes.
      * @param _outputIndex output index of the output.
      * @param _utxoPosValue (optinal) UTXO position of the deposit output.
@@ -19,6 +20,7 @@ library OutputId {
 
     /**
      * @notice Computes the output id for normal (non deposit) tx
+     * @dev Since txBytes for non-deposit tx would be unique, directly hash the txBytes with outputIndex.
      * @param _txBytes Transaction bytes.
      * @param _outputIndex output index of the output.
      */

--- a/plasma_framework/contracts/src/exits/utils/TxFinalization.sol
+++ b/plasma_framework/contracts/src/exits/utils/TxFinalization.sol
@@ -8,9 +8,31 @@ import "../../framework/Protocol.sol";
 import "../../utils/Merkle.sol";
 import "../../utils/TxPosLib.sol";
 
+/**
+ * @notice Libarary that checks finalization status of a transaction
+ * @dev We define two kinds of finalization: standard finalization and protocol finalization.
+ *      1. Protocol Finalization: a transaction is considered finalized for the protocol to spend its input transaction.
+ *      2. Standard Finalization: a protocol finalized transaction has a clear position (being mined) in the plasma block.
+ *      > For MVP:
+ *         a. Protocol finalized: need to have confirm signature signed. Since confirm signature requires the transaction to be mined in a block,
+ *            it will have a clear position as well. Thus protocol finalization would be same as standard finalization for MVP protocol.
+ *         b. Standard finalized: have confirm signature singed plus the transaction mined in a plasma block.
+ *      > For MoreVp:
+ *         a. Protocol finalized: as long as the transaction exists, since we allow in-flight transaction in MoreVp, it would be finalized.
+ *         b. Standard finalized: the transaction is mined in a plasma block.
+ */
 library TxFinalization {
     using TxPosLib for TxPosLib.TxPos;
 
+    /**
+     * @param framework Plasma framework contract
+     * @param protocol Either MVP or MoreVp. see 'Protocol.sol' for the representive value.
+     * @param txBytes Encoded transaction in bytes format that is checking the finalization.
+     * @param txPos (Optional) Tx position of the transaction.
+     * @param inclusionProof (Optional) Inclusion proof of the merkle path of the transaction
+     * @param confirmSig (Optional) Confirm signature of the transaction.
+     * @param confirmSigAddress (Optional) Confirm signature address to check with.
+     */
     struct Verifier {
         PlasmaFramework framework;
         uint8 protocol;
@@ -31,6 +53,7 @@ library TxFinalization {
         pure
         returns (Verifier memory)
     {
+        // MoreVP protocol does not require check on confirm signature, thus putting empty value for related field.
         return Verifier({
             framework: framework,
             protocol: Protocol.MORE_VP(),

--- a/plasma_framework/test/src/exits/registries/OutputGuardHandlerRegistry.test.js
+++ b/plasma_framework/test/src/exits/registries/OutputGuardHandlerRegistry.test.js
@@ -24,10 +24,21 @@ contract('OutputGuardHandlerRegistry', ([_, other]) => {
             expect(await this.registry.outputGuardHandlers(outputType)).to.equal(this.dummyOutputGuardHandler.address);
         });
 
-        it('should reject when not registered by operator', async () => {
+        it('should reject when not registered by owner', async () => {
             await expectRevert(
                 this.registry.registerOutputGuardHandler(1, this.dummyOutputGuardHandler.address, { from: other }),
-                'Not being called by operator',
+                'Ownable: caller is not the owner',
+            );
+        });
+
+        it('should not be able to register after renouncing the ownership', async () => {
+            const outputType = 1;
+            await this.registry.renounceOwnership();
+            await expectRevert(
+                this.registry.registerOutputGuardHandler(
+                    outputType, this.dummyOutputGuardHandler.address,
+                ),
+                'Ownable: caller is not the owner',
             );
         });
 


### PR DESCRIPTION
### Main changes
Add/improve docs to the followings:

- src/exits/interfaces/
- src/exits/models/
- src/exits/registries/
- src/utils/

### Side changes
- Use `Ownable` instead of `Operated` in `OutputGuardHandlerRegistry`

### Side Notes
- I skipped the doc for `ExitableTimestamp` due to current design does not suite well for this issue:
https://github.com/omisego/plasma-contracts/issues/216