### PR TITLE
chore: turn on optimizer + reenable e2e tests

### DIFF
--- a/plasma_framework/contracts/mocks/Imports.sol
+++ b/plasma_framework/contracts/mocks/Imports.sol
@@ -3,3 +3,7 @@ pragma solidity ^0.5.0;
 // Import contracts from third party Solidity libraries to make them available in tests.
 
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20Mintable.sol";
+
+contract Import {
+    // dummy empty contract to allow the compiler not always trying to re-compile this file.
+}

--- a/plasma_framework/test/src/exits/payment/PaymentExitGame.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentExitGame.test.js
@@ -40,8 +40,7 @@ const { hashTx } = require('../../../helpers/paymentEip712.js');
 const { buildUtxoPos, utxoPosToTxPos } = require('../../../helpers/positions.js');
 const Testlang = require('../../../helpers/testlang.js');
 
-// Skipped for now due to https://github.com/omisego/plasma-contracts/issues/287
-contract.skip('PaymentExitGame - End to End Tests', ([_, richFather, bob]) => {
+contract('PaymentExitGame - End to End Tests', ([_, richFather, bob]) => {
     const MIN_EXIT_PERIOD = 60 * 60 * 24 * 7; // 1 week
     const ETH = constants.ZERO_ADDRESS;
     const INITIAL_ERC20_SUPPLY = 10000000000;

--- a/plasma_framework/truffle-config.js
+++ b/plasma_framework/truffle-config.js
@@ -92,15 +92,14 @@ module.exports = {
     // Configure your compilers
     compilers: {
         solc: {
-            // version: "0.5.1",    // Fetch exact version from solc-bin (default: truffle's version)
-            // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
-            // settings: {          // See the solidity docs for advice about optimization and evmVersion
-            //  optimizer: {
-            //    enabled: false,
-            //    runs: 200
-            //  },
-            //  evmVersion: "byzantium"
-            // }
+            version: '0.5.11',
+            settings: {
+                optimizer: {
+                    enabled: true,
+                    runs: 200,
+                },
+                evmVersion: 'byzantium',
+            },
         },
     },
 };

--- a/plasma_framework/truffle-config.js
+++ b/plasma_framework/truffle-config.js
@@ -98,7 +98,6 @@ module.exports = {
                     enabled: true,
                     runs: 200,
                 },
-                evmVersion: 'byzantium',
             },
         },
     },


### PR DESCRIPTION
### Note
Previously the e2e tests cannot be run due to gas limit on contract deployment. With optimizer
turned on, it can be deployed within gas limit.

Also, with latest compiler (0.5.11) it can compile without the previous issue tested in 0.5.8

closes #286