### PR TITLE
Some Minor fixes

### DIFF
--- a/plasma_framework/contracts/mocks/exits/SpendingConditionMock.sol
+++ b/plasma_framework/contracts/mocks/exits/SpendingConditionMock.sol
@@ -50,8 +50,6 @@ contract SpendingConditionMock is ISpendingCondition {
         returns (bool)
     {
         if (shouldRevert) {
-            // TODO: solhint disabled for now due to bug, https://github.com/protofire/solhint/issues/157
-            // solhint-disable-next-line reason-string
             revert(REVERT_MESSAGE);
         }
 

--- a/plasma_framework/contracts/mocks/exits/StateTransitionVerifierMock.sol
+++ b/plasma_framework/contracts/mocks/exits/StateTransitionVerifierMock.sol
@@ -41,8 +41,6 @@ contract StateTransitionVerifierMock is IStateTransitionVerifier {
         returns (bool)
     {
         if (shouldRevert) {
-            // TODO: solhint disabled for now due to bug, https://github.com/protofire/solhint/issues/157
-            // solhint-disable-next-line reason-string
             revert("Failing on purpose");
         }
 

--- a/plasma_framework/contracts/mocks/utils/BondSizeMock.sol
+++ b/plasma_framework/contracts/mocks/utils/BondSizeMock.sol
@@ -7,8 +7,8 @@ contract BondSizeMock {
 
     BondSize.Params public bond;
 
-    constructor (uint128 _initialBondSize, uint16 _lowerBoundDivisor, uint16 _upperBoundMultiplier) public {
-        bond = BondSize.buildParams(_initialBondSize, _lowerBoundDivisor, _upperBoundMultiplier);
+    constructor (uint128 initialBondSize, uint16 lowerBoundDivisor, uint16 upperBoundMultiplier) public {
+        bond = BondSize.buildParams(initialBondSize, lowerBoundDivisor, upperBoundMultiplier);
     }
 
     function bondSize() public view returns (uint128) {

--- a/plasma_framework/contracts/src/exits/utils/BondSize.sol
+++ b/plasma_framework/contracts/src/exits/utils/BondSize.sol
@@ -50,7 +50,7 @@ library BondSize {
     function updateBondSize(Params storage self, uint128 newBondSize) internal {
         validateBondSize(self, newBondSize);
 
-        if (self.updatedBondSize != 0 && now > self.effectiveUpdateTime) {
+        if (self.updatedBondSize != 0 && now >= self.effectiveUpdateTime) {
             self.previousBondSize = self.updatedBondSize;
         }
         self.updatedBondSize = newBondSize;

--- a/plasma_framework/contracts/src/exits/utils/BondSize.sol
+++ b/plasma_framework/contracts/src/exits/utils/BondSize.sol
@@ -26,7 +26,7 @@ library BondSize {
         uint16 upperBoundMultiplier;
     }
 
-    function buildParams(uint128 _initialBondSize, uint16 _lowerBoundDivisor, uint16 _upperBoundMultiplier)
+    function buildParams(uint128 initialBondSize, uint16 lowerBoundDivisor, uint16 upperBoundMultiplier)
         internal
         pure
         returns (Params memory)
@@ -34,44 +34,44 @@ library BondSize {
         // Set the initial value to far in the future
         uint128 initialEffectiveUpdateTime = 2 ** 63;
         return Params({
-            previousBondSize: _initialBondSize,
+            previousBondSize: initialBondSize,
             updatedBondSize: 0,
             effectiveUpdateTime: initialEffectiveUpdateTime,
-            lowerBoundDivisor: _lowerBoundDivisor,
-            upperBoundMultiplier: _upperBoundMultiplier
+            lowerBoundDivisor: lowerBoundDivisor,
+            upperBoundMultiplier: upperBoundMultiplier
         });
     }
 
     /**
     * @notice Updates the bond size.
-    * @notice The new value is bounded by 0.5 and 2x of current bond size.
-    * @notice There is a waiting period of 2 days before the new value goes into effect.
+    * @dev There is a waiting period of 2 days before the new value goes into effect.
     * @param newBondSize the new bond size.
     */
-    function updateBondSize(Params storage _self, uint128 newBondSize) internal {
-        validateBondSize(_self, newBondSize);
+    function updateBondSize(Params storage self, uint128 newBondSize) internal {
+        validateBondSize(self, newBondSize);
 
-        if (_self.updatedBondSize != 0 && now > _self.effectiveUpdateTime) {
-            _self.previousBondSize = _self.updatedBondSize;
+        if (self.updatedBondSize != 0 && now > self.effectiveUpdateTime) {
+            self.previousBondSize = self.updatedBondSize;
         }
-        _self.updatedBondSize = newBondSize;
-        _self.effectiveUpdateTime = uint64(now) + WAITING_PERIOD;
+        self.updatedBondSize = newBondSize;
+        self.effectiveUpdateTime = uint64(now) + WAITING_PERIOD;
     }
 
     /**
     * @notice Returns the current bond size.
     */
-    function bondSize(Params memory _self) internal view returns (uint128) {
-        if (now < _self.effectiveUpdateTime) {
-            return _self.previousBondSize;
+    function bondSize(Params memory self) internal view returns (uint128) {
+        if (now < self.effectiveUpdateTime) {
+            return self.previousBondSize;
         } else {
-            return _self.updatedBondSize;
+            return self.updatedBondSize;
         }
     }
 
-    function validateBondSize(Params memory _self, uint128 newBondSize) private view {
-        uint128 currentBondSize = bondSize(_self);
-        require(newBondSize >= currentBondSize / _self.lowerBoundDivisor, "Bond size is too low");
-        require(uint256(newBondSize) <= uint256(currentBondSize) * _self.upperBoundMultiplier, "Bond size is too high");
+    function validateBondSize(Params memory self, uint128 newBondSize) private view {
+        uint128 currentBondSize = bondSize(self);
+        require(newBondSize > 0, "Bond size cannot be zero");
+        require(newBondSize >= currentBondSize / self.lowerBoundDivisor, "Bond size is too low");
+        require(uint256(newBondSize) <= uint256(currentBondSize) * self.upperBoundMultiplier, "Bond size is too high");
     }
 }

--- a/plasma_framework/contracts/src/exits/utils/TxFinalizationVerifier.sol
+++ b/plasma_framework/contracts/src/exits/utils/TxFinalizationVerifier.sol
@@ -25,12 +25,8 @@ contract TxFinalizationVerifier is ITxFinalizationVerifier {
         if (data.protocol == Protocol.MORE_VP()) {
             return checkInclusionProof(data);
         } else if (data.protocol == Protocol.MVP()) {
-            // TODO: solhint disabled for now due to bug, https://github.com/protofire/solhint/issues/157
-            // solhint-disable-next-line reason-string
             revert("not supporting MVP yet");
         } else {
-            // TODO: solhint disabled for now due to bug, https://github.com/protofire/solhint/issues/157
-            // solhint-disable-next-line reason-string
             revert("invalid protocol value");
         }
     }
@@ -44,12 +40,8 @@ contract TxFinalizationVerifier is ITxFinalizationVerifier {
         if (data.protocol == Protocol.MORE_VP()) {
             return data.txBytes.length > 0;
         } else if (data.protocol == Protocol.MVP()) {
-            // TODO: solhint disabled for now due to bug, https://github.com/protofire/solhint/issues/157
-            // solhint-disable-next-line reason-string
             revert("not supporting MVP yet");
         } else {
-            // TODO: solhint disabled for now due to bug, https://github.com/protofire/solhint/issues/157
-            // solhint-disable-next-line reason-string
             revert("invalid protocol value");
         }
     }

--- a/plasma_framework/contracts/src/vaults/Vault.sol
+++ b/plasma_framework/contracts/src/vaults/Vault.sol
@@ -62,10 +62,10 @@ contract Vault is Operated {
      * @return contract address of deposit verifier.
      */
     function getEffectiveDepositVerifier() public view returns (address) {
-        if (now > newDepositVerifierMaturityTimestamp) {
-            return depositVerifiers[1];
-        } else {
+        if (now < newDepositVerifierMaturityTimestamp) {
             return depositVerifiers[0];
+        } else {
+            return depositVerifiers[1];
         }
     }
 

--- a/plasma_framework/test/src/exits/utils/BondSize.test.js
+++ b/plasma_framework/test/src/exits/utils/BondSize.test.js
@@ -6,7 +6,7 @@ contract('BondSize', () => {
     const WAITING_PERIOD = time.duration.days(2);
     const HALF_WAITING_PERIOD = WAITING_PERIOD.divn(2);
 
-    describe('in general...', () => {
+    describe('with normal cases', () => {
         beforeEach(async () => {
             this.initialBondSize = new BN(20000000000);
             this.lowerBoundDivisor = 2;
@@ -116,9 +116,9 @@ contract('BondSize', () => {
 
     describe('with boundary size of numbers', () => {
         it('should able to update to max number of uint128 without having overflow issue', async () => {
-            const maxSizeOfUint256 = (new BN(2)).pow(new BN(128)).sub(new BN(1)); // 2^128 - 1
+            const maxSizeOfUint128 = (new BN(2)).pow(new BN(128)).sub(new BN(1)); // 2^128 - 1
 
-            const initialBondSize = maxSizeOfUint256.sub(new BN(10000));
+            const initialBondSize = maxSizeOfUint128.sub(new BN(10000));
             const lowerBoundDivisor = 2;
             const upperBoundMultiplier = 3;
             const contract = await BondSizeMock.new(
@@ -127,10 +127,10 @@ contract('BondSize', () => {
                 upperBoundMultiplier,
             );
 
-            await contract.updateBondSize(maxSizeOfUint256);
+            await contract.updateBondSize(maxSizeOfUint128);
             await time.increase(WAITING_PERIOD);
             const bondSize = await contract.bondSize();
-            expect(bondSize).to.be.bignumber.equal(maxSizeOfUint256);
+            expect(bondSize).to.be.bignumber.equal(maxSizeOfUint128);
         });
 
         it('should be able to update to 1', async () => {

--- a/plasma_framework/test/src/utils/BondSize.test.js
+++ b/plasma_framework/test/src/utils/BondSize.test.js
@@ -6,87 +6,165 @@ contract('BondSize', () => {
     const WAITING_PERIOD = time.duration.days(2);
     const HALF_WAITING_PERIOD = WAITING_PERIOD.divn(2);
 
-    beforeEach(async () => {
-        this.initialBondSize = new BN(20000000000);
-        this.lowerBoundDivisor = 2;
-        this.upperBoundMultiplier = 3;
-        this.contract = await BondSizeMock.new(
-            this.initialBondSize,
-            this.lowerBoundDivisor,
-            this.upperBoundMultiplier,
-        );
+    describe('in general...', () => {
+        beforeEach(async () => {
+            this.initialBondSize = new BN(20000000000);
+            this.lowerBoundDivisor = 2;
+            this.upperBoundMultiplier = 3;
+            this.contract = await BondSizeMock.new(
+                this.initialBondSize,
+                this.lowerBoundDivisor,
+                this.upperBoundMultiplier,
+            );
+        });
+
+        it('should return the initial bond size', async () => {
+            const bondSize = await this.contract.bondSize();
+            expect(bondSize).to.be.bignumber.equal(this.initialBondSize);
+        });
+
+        it('should be able to update the bond to upperBoundMultiplier times its current value', async () => {
+            const newBondSize = new BN(this.initialBondSize).muln(this.upperBoundMultiplier);
+            await this.contract.updateBondSize(newBondSize);
+        });
+
+        it('should fail to update bond to more than upperBoundMultiplier times its current value', async () => {
+            const newBondSize = new BN(this.initialBondSize).muln(this.upperBoundMultiplier).addn(1);
+            await expectRevert(
+                this.contract.updateBondSize(newBondSize),
+                'Bond size is too high',
+            );
+        });
+
+        it('should be able to update the bond to lowerBoundDivisor of its current value', async () => {
+            const newBondSize = new BN(this.initialBondSize).divn(this.lowerBoundDivisor);
+            await this.contract.updateBondSize(newBondSize);
+        });
+
+        it('should fail to update bond to less than lowerBoundDivisor of its current value', async () => {
+            const newBondSize = new BN(this.initialBondSize).divn(this.lowerBoundDivisor).subn(1);
+            await expectRevert(
+                this.contract.updateBondSize(newBondSize),
+                'Bond size is too low',
+            );
+        });
+
+        it('should not update the actual bond value until after the waiting period', async () => {
+            const newBondSize = new BN(this.initialBondSize).muln(2);
+            await this.contract.updateBondSize(newBondSize);
+
+            await time.increase(WAITING_PERIOD.sub(time.duration.seconds(5)));
+            const bondSize = await this.contract.bondSize();
+            expect(bondSize).to.be.bignumber.equal(this.initialBondSize);
+        });
+
+        it('should update the actual bond value after the waiting period', async () => {
+            const newBondSize = new BN(this.initialBondSize).muln(2);
+            await this.contract.updateBondSize(newBondSize);
+
+            await time.increase(WAITING_PERIOD);
+            const bondSize = await this.contract.bondSize();
+            expect(bondSize).to.be.bignumber.equal(newBondSize);
+        });
+
+        it('should update the actual bond value after the waiting period', async () => {
+            const newBondSize = new BN(this.initialBondSize).muln(2);
+            await this.contract.updateBondSize(newBondSize);
+
+            // Wait half the waiting period
+            await time.increase(HALF_WAITING_PERIOD);
+
+            // Update again while the first update is in progress.
+            const secondNewBondSize = new BN(this.initialBondSize).muln(1.5);
+            await this.contract.updateBondSize(secondNewBondSize);
+
+            // Wait half the waiting period again.
+            await time.increase(HALF_WAITING_PERIOD);
+            // Even though the first update's waiting period is over, the second
+            // update is in progress so the bond size should not have changed yet.
+            let bondSize = await this.contract.bondSize();
+            expect(bondSize).to.be.bignumber.equal(this.initialBondSize);
+
+            // Wait the remaining waiting period
+            await time.increase(HALF_WAITING_PERIOD);
+            bondSize = await this.contract.bondSize();
+            expect(bondSize).to.be.bignumber.equal(secondNewBondSize);
+        });
+
+        it('should be able to update continuosly', async () => {
+            const newBondSize1 = new BN(this.initialBondSize).muln(2);
+            await this.contract.updateBondSize(newBondSize1);
+            await time.increase(WAITING_PERIOD);
+
+            let bondSize = await this.contract.bondSize();
+            expect(bondSize).to.be.bignumber.equal(newBondSize1);
+
+            const newBondSize2 = newBondSize1.muln(2);
+            await this.contract.updateBondSize(newBondSize2);
+
+            // Before a full waiting period is finished, it would still not update to latest
+            await time.increase(HALF_WAITING_PERIOD);
+            bondSize = await this.contract.bondSize();
+            expect(bondSize, 'should not update to latest yet').to.be.bignumber.equal(newBondSize1);
+
+            // update to latest after full waiting period is done
+            await time.increase(HALF_WAITING_PERIOD);
+            bondSize = await this.contract.bondSize();
+            expect(bondSize, 'should update to latest').to.be.bignumber.equal(newBondSize2);
+        });
     });
 
-    it('should return the initial bond size', async () => {
-        const bondSize = await this.contract.bondSize();
-        expect(bondSize).to.be.bignumber.equal(this.initialBondSize);
-    });
+    describe('with boundary size of numbers', () => {
+        it('should able to update to max number of uint128 without having overflow issue', async () => {
+            const maxSizeOfUint256 = (new BN(2)).pow(new BN(128)).sub(new BN(1)); // 2^128 - 1
 
-    it('should be able to update the bond to upperBoundMultiplier times its current value', async () => {
-        const newBondSize = new BN(this.initialBondSize).muln(this.upperBoundMultiplier);
-        await this.contract.updateBondSize(newBondSize);
-    });
+            const initialBondSize = maxSizeOfUint256.sub(new BN(10000));
+            const lowerBoundDivisor = 2;
+            const upperBoundMultiplier = 3;
+            const contract = await BondSizeMock.new(
+                initialBondSize,
+                lowerBoundDivisor,
+                upperBoundMultiplier,
+            );
 
-    it('should fail to update bond to more than upperBoundMultiplier times its current value', async () => {
-        const newBondSize = new BN(this.initialBondSize).muln(this.upperBoundMultiplier).addn(1);
-        await expectRevert(
-            this.contract.updateBondSize(newBondSize),
-            'Bond size is too high',
-        );
-    });
+            await contract.updateBondSize(maxSizeOfUint256);
+            await time.increase(WAITING_PERIOD);
+            const bondSize = await contract.bondSize();
+            expect(bondSize).to.be.bignumber.equal(maxSizeOfUint256);
+        });
 
-    it('should be able to update the bond to lowerBoundDivisor of its current value', async () => {
-        const newBondSize = new BN(this.initialBondSize).divn(this.lowerBoundDivisor);
-        await this.contract.updateBondSize(newBondSize);
-    });
+        it('should be able to update to 1', async () => {
+            const initialBondSize = new BN(2);
+            const lowerBoundDivisor = 2;
+            const upperBoundMultiplier = 3;
+            const contract = await BondSizeMock.new(
+                initialBondSize,
+                lowerBoundDivisor,
+                upperBoundMultiplier,
+            );
+            const bondSizeOne = new BN(1);
 
-    it('should fail to update bond to less than lowerBoundDivisor of its current value', async () => {
-        const newBondSize = new BN(this.initialBondSize).divn(this.lowerBoundDivisor).subn(1);
-        await expectRevert(
-            this.contract.updateBondSize(newBondSize),
-            'Bond size is too low',
-        );
-    });
+            await contract.updateBondSize(bondSizeOne);
+            await time.increase(WAITING_PERIOD);
+            const bondSize = await contract.bondSize();
+            expect(bondSize).to.be.bignumber.equal(bondSizeOne);
+        });
 
-    it('should not update the actual bond value until after the waiting period', async () => {
-        const newBondSize = new BN(this.initialBondSize).muln(2);
-        await this.contract.updateBondSize(newBondSize);
+        it('should NOT be able to update to 0', async () => {
+            const initialBondSize = new BN(2);
+            const lowerBoundDivisor = 2;
+            const upperBoundMultiplier = 3;
+            const contract = await BondSizeMock.new(
+                initialBondSize,
+                lowerBoundDivisor,
+                upperBoundMultiplier,
+            );
+            const bondSizeZero = new BN(0);
 
-        await time.increase(WAITING_PERIOD.sub(time.duration.seconds(5)));
-        const bondSize = await this.contract.bondSize();
-        expect(bondSize).to.be.bignumber.equal(this.initialBondSize);
-    });
-
-    it('should update the actual bond value after the waiting period', async () => {
-        const newBondSize = new BN(this.initialBondSize).muln(2);
-        await this.contract.updateBondSize(newBondSize);
-
-        await time.increase(WAITING_PERIOD);
-        const bondSize = await this.contract.bondSize();
-        expect(bondSize).to.be.bignumber.equal(newBondSize);
-    });
-
-    it('should update the actual bond value after the waiting period', async () => {
-        const newBondSize = new BN(this.initialBondSize).muln(2);
-        await this.contract.updateBondSize(newBondSize);
-
-        // Wait half the waiting period
-        await time.increase(HALF_WAITING_PERIOD);
-
-        // Update again while the first update is in progress.
-        const secondNewBondSize = new BN(this.initialBondSize).muln(1.5);
-        await this.contract.updateBondSize(secondNewBondSize);
-
-        // Wait half the waiting period again.
-        await time.increase(HALF_WAITING_PERIOD);
-        // Even though the first update's waiting period is over, the second
-        // update is in progress so the bond size should not have changed yet.
-        let bondSize = await this.contract.bondSize();
-        expect(bondSize).to.be.bignumber.equal(this.initialBondSize);
-
-        // Wait the remaining waiting period
-        await time.increase(HALF_WAITING_PERIOD);
-        bondSize = await this.contract.bondSize();
-        expect(bondSize).to.be.bignumber.equal(secondNewBondSize);
+            await expectRevert(
+                contract.updateBondSize(bondSizeZero),
+                'Bond size cannot be zero',
+            );
+        });
     });
 });

--- a/plasma_framework/test/src/utils/BondSize.test.js
+++ b/plasma_framework/test/src/utils/BondSize.test.js
@@ -2,7 +2,7 @@ const BondSizeMock = artifacts.require('BondSizeMock');
 const { BN, expectRevert, time } = require('openzeppelin-test-helpers');
 const { expect } = require('chai');
 
-contract.only('BondSize', () => {
+contract('BondSize', () => {
     const WAITING_PERIOD = time.duration.days(2);
     const HALF_WAITING_PERIOD = WAITING_PERIOD.divn(2);
 

--- a/plasma_framework/test/src/utils/BondSize.test.js
+++ b/plasma_framework/test/src/utils/BondSize.test.js
@@ -2,7 +2,7 @@ const BondSizeMock = artifacts.require('BondSizeMock');
 const { BN, expectRevert, time } = require('openzeppelin-test-helpers');
 const { expect } = require('chai');
 
-contract('BondSize', () => {
+contract.only('BondSize', () => {
     const WAITING_PERIOD = time.duration.days(2);
     const HALF_WAITING_PERIOD = WAITING_PERIOD.divn(2);
 

--- a/plasma_framework/test/src/vaults/EthVault.test.js
+++ b/plasma_framework/test/src/vaults/EthVault.test.js
@@ -152,7 +152,7 @@ contract('EthVault', ([_, alice]) => {
             expect(await this.ethVault.getEffectiveDepositVerifier()).to.equal(this.currentDepositVerifier);
             await expectEvent.inLogs(tx.logs, 'SetDepositVerifierCalled', { nextDepositVerifier: newDepositVerifier.address });
 
-            await time.increase(MIN_EXIT_PERIOD + 1);
+            await time.increase(MIN_EXIT_PERIOD);
             expect(await this.ethVault.getEffectiveDepositVerifier()).to.equal(newDepositVerifier.address);
         });
     });


### PR DESCRIPTION
### Note
- remove some solhint workaround as latest version fixes the bug. @kevsul 's PR has been merged and released.
- take care of BondSize boundary number, closes #296. End up not using `SafeMath` as it is really meaning less since it only protects `uint256` but we are using `uint128`. Instead, I add tests on that we support edge case of upgrade to max num of `uint128`.
- Add boundary of the BondSize to not be 0 during update. Thus with min size 1.
- fix bug around comparing time in BondSize. There was a bug when `now == effectiveUpdateTime` the update would be broken. Found this while trying to add tests for coverage : )
- make `depositVerifier` be updated right at `newDepositVerifierMaturityTimestamp`

---
- ~upgrade to solidity 0.5.12~ see this comment: https://github.com/omisego/plasma-contracts/pull/328#issuecomment-537399670
- ~make compiler happy when optimizer is off. Somehow it failed to compile when the optimizer is tuned off with the change on BondSize. (Whenever there is a `require` inside `buildParams` it fails to compile....). Found this because the [coverage tool forces optimizer to be off](https://github.com/sc-forks/solidity-coverage/issues/417). Seems like it cannot be called in a constructor. So I change the constructor for `Routers` to become `init` function instead.~ Reverting this as it end up increase deployment gas quite a lot, and we don't really have security issue as the params are fixed in PaymentExitGame contract now.
