### PR TITLE
Generate documentation by solidoc

### DIFF
--- a/plasma_framework/docs/Address.md
+++ b/plasma_framework/docs/Address.md
@@ -1,0 +1,107 @@
+# Address.sol
+
+View Source: [openzeppelin-solidity/contracts/utils/Address.sol](../openzeppelin-solidity/contracts/utils/Address.sol)
+
+**Address**
+
+Collection of functions related to the address type,
+
+## Functions
+
+- [isContract(address account)](#iscontract)
+
+### isContract
+
+Returns true if `account` is a contract.
+     * This test is non-exhaustive, and there may be false-negatives: during the
+execution of a contract's constructor, its address will be reported as
+not containing a contract.
+     * > It is unsafe to assume that an address for which this function returns
+false is an externally-owned account (EOA) and not a contract.
+
+```js
+function isContract(address account) internal view
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| account | address |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/AddressPayable.md
+++ b/plasma_framework/docs/AddressPayable.md
@@ -1,0 +1,100 @@
+# AddressPayable.sol
+
+View Source: [contracts/src/utils/AddressPayable.sol](../contracts/src/utils/AddressPayable.sol)
+
+**AddressPayable**
+
+## Functions
+
+- [convert(address account)](#convert)
+
+### convert
+
+Converts an `address` into `address payable`.
+
+```js
+function convert(address account) internal pure
+returns(address payable)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| account | address |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/Bits.md
+++ b/plasma_framework/docs/Bits.md
@@ -1,0 +1,178 @@
+# Bits (Bits.sol)
+
+View Source: [contracts/src/utils/Bits.sol](../contracts/src/utils/Bits.sol)
+
+**Bits**
+
+Operations on individual bits of a word.
+
+## Contract Members
+**Constants & Variables**
+
+```js
+uint256 internal constant ONE;
+
+```
+
+## Functions
+
+- [setBit(uint256 _self, uint8 _index)](#setbit)
+- [clearBit(uint256 _self, uint8 _index)](#clearbit)
+- [getBit(uint256 _self, uint8 _index)](#getbit)
+- [bitSet(uint256 _self, uint8 _index)](#bitset)
+
+### setBit
+
+Sets the bit at the given '_index' in '_self' to '1'.
+
+```js
+function setBit(uint256 _self, uint8 _index) internal pure
+returns(uint256)
+```
+
+**Returns**
+
+The modified value.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _self | uint256 | Uint to modify. | 
+| _index | uint8 | Index of the bit to set. | 
+
+### clearBit
+
+Sets the bit at the given '_index' in '_self' to '0'.
+
+```js
+function clearBit(uint256 _self, uint8 _index) internal pure
+returns(uint256)
+```
+
+**Returns**
+
+The modified value.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _self | uint256 | Uint to modify. | 
+| _index | uint8 | Index of the bit to set. | 
+
+### getBit
+
+Returns the bit at the given '_index' in '_self'.
+
+```js
+function getBit(uint256 _self, uint8 _index) internal pure
+returns(uint8)
+```
+
+**Returns**
+
+The value of the bit at '_index'.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _self | uint256 | Uint to check. | 
+| _index | uint8 | Index of the bit to get. | 
+
+### bitSet
+
+Checks if the bit at the given '_index' in '_self' is '1'.
+
+```js
+function bitSet(uint256 _self, uint8 _index) internal pure
+returns(bool)
+```
+
+**Returns**
+
+True if the bit is '0'. False otherwise.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _self | uint256 | Uint to check. | 
+| _index | uint8 | Index of the bit to check. | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/BlockController.md
+++ b/plasma_framework/docs/BlockController.md
@@ -1,0 +1,187 @@
+# BlockController.sol
+
+View Source: [contracts/src/framework/BlockController.sol](../contracts/src/framework/BlockController.sol)
+
+**↗ Extends: [Operated](Operated.md), [VaultRegistry](VaultRegistry.md)**
+**↘ Derived Contracts: [PlasmaFramework](PlasmaFramework.md)**
+
+**BlockController**
+
+Controls the logic and functions for block submissions in PlasmaFramework
+
+## Contract Members
+**Constants & Variables**
+
+```js
+address public authority;
+uint256 public childBlockInterval;
+uint256 public nextChildBlock;
+uint256 public nextDepositBlock;
+mapping(uint256 => struct BlockModel.Block) public blocks;
+
+```
+
+**Events**
+
+```js
+event BlockSubmitted(uint256  blockNumber);
+```
+
+## Functions
+
+- [(uint256 _interval, uint256 _minExitPeriod, uint256 _initialImmuneVaults)](#)
+- [initAuthority()](#initauthority)
+- [setAuthority(address newAuthority)](#setauthority)
+- [submitBlock(bytes32 _blockRoot)](#submitblock)
+- [submitDepositBlock(bytes32 _blockRoot)](#submitdepositblock)
+
+### 
+
+```js
+function (uint256 _interval, uint256 _minExitPeriod, uint256 _initialImmuneVaults) public nonpayable VaultRegistry 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _interval | uint256 |  | 
+| _minExitPeriod | uint256 |  | 
+| _initialImmuneVaults | uint256 |  | 
+
+### initAuthority
+
+Sets the operator's authority address and unlocks block submission.
+
+```js
+function initAuthority() external nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+
+### setAuthority
+
+Allows the operator to set a new authority address. This allows to implement mechanical
+re-org protection mechanism, explained in https://github.com/omisego/plasma-contracts/issues/118
+
+```js
+function setAuthority(address newAuthority) external nonpayable onlyOperator 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| newAuthority | address | address of new authority, cannot be blank. | 
+
+### submitBlock
+
+Allows the authority to submit the Merkle root of a plasma block.
+
+```js
+function submitBlock(bytes32 _blockRoot) external nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _blockRoot | bytes32 | Merkle root of the plasma block. | 
+
+### submitDepositBlock
+
+Submits a block for deposit.
+
+```js
+function submitDepositBlock(bytes32 _blockRoot) public nonpayable onlyFromNonQuarantinedVault 
+returns(uint256)
+```
+
+**Returns**
+
+the deposit block number
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _blockRoot | bytes32 | Merkle root of the plasma block. | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/BlockModel.md
+++ b/plasma_framework/docs/BlockModel.md
@@ -1,0 +1,93 @@
+# BlockModel.sol
+
+View Source: [contracts/src/framework/models/BlockModel.sol](../contracts/src/framework/models/BlockModel.sol)
+
+**BlockModel**
+
+## Structs
+### Block
+
+```js
+struct Block {
+ bytes32 root,
+ uint256 timestamp
+}
+```
+
+## Functions
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/BondSize.md
+++ b/plasma_framework/docs/BondSize.md
@@ -1,0 +1,169 @@
+# BondSize.sol
+
+View Source: [contracts/src/exits/utils/BondSize.sol](../contracts/src/exits/utils/BondSize.sol)
+
+**BondSize**
+
+Stores an updateable bond size.
+
+## Structs
+### Params
+
+```js
+struct Params {
+ uint128 previousBondSize,
+ uint128 updatedBondSize,
+ uint128 effectiveUpdateTime,
+ uint16 lowerBoundDivisor,
+ uint16 upperBoundMultiplier
+}
+```
+
+## Contract Members
+**Constants & Variables**
+
+```js
+uint64 public constant WAITING_PERIOD;
+
+```
+
+## Functions
+
+- [buildParams(uint128 _initialBondSize, uint16 _lowerBoundDivisor, uint16 _upperBoundMultiplier)](#buildparams)
+- [updateBondSize(struct BondSize.Params _self, uint128 newBondSize)](#updatebondsize)
+- [bondSize(struct BondSize.Params _self)](#bondsize)
+- [validateBondSize(struct BondSize.Params _self, uint128 newBondSize)](#validatebondsize)
+
+### buildParams
+
+```js
+function buildParams(uint128 _initialBondSize, uint16 _lowerBoundDivisor, uint16 _upperBoundMultiplier) internal pure
+returns(struct BondSize.Params)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _initialBondSize | uint128 |  | 
+| _lowerBoundDivisor | uint16 |  | 
+| _upperBoundMultiplier | uint16 |  | 
+
+### updateBondSize
+
+Updates the bond size.
+
+```js
+function updateBondSize(struct BondSize.Params _self, uint128 newBondSize) internal nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _self | struct BondSize.Params |  | 
+| newBondSize | uint128 | the new bond size. | 
+
+### bondSize
+
+Returns the current bond size.
+
+```js
+function bondSize(struct BondSize.Params _self) internal view
+returns(uint128)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _self | struct BondSize.Params |  | 
+
+### validateBondSize
+
+```js
+function validateBondSize(struct BondSize.Params _self, uint128 newBondSize) private view
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _self | struct BondSize.Params |  | 
+| newBondSize | uint128 |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/ECDSA.md
+++ b/plasma_framework/docs/ECDSA.md
@@ -1,0 +1,137 @@
+# ECDSA.sol
+
+View Source: [openzeppelin-solidity/contracts/cryptography/ECDSA.sol](../openzeppelin-solidity/contracts/cryptography/ECDSA.sol)
+
+**ECDSA**
+
+Elliptic Curve Digital Signature Algorithm (ECDSA) operations.
+ * These functions can be used to verify that a message was signed by the holder
+of the private keys of a given address.
+
+## Functions
+
+- [recover(bytes32 hash, bytes signature)](#recover)
+- [toEthSignedMessageHash(bytes32 hash)](#toethsignedmessagehash)
+
+### recover
+
+Returns the address that signed a hashed message (`hash`) with
+`signature`. This address can then be used for verification purposes.
+     * The `ecrecover` EVM opcode allows for malleable (non-unique) signatures:
+this function rejects them by requiring the `s` value to be in the lower
+half order, and the `v` value to be either 27 or 28.
+     * (.note) This call _does not revert_ if the signature is invalid, or
+if the signer is otherwise unable to be retrieved. In those scenarios,
+the zero address is returned.
+     * (.warning) `hash` _must_ be the result of a hash operation for the
+verification to be secure: it is possible to craft signatures that
+recover to arbitrary addresses for non-hashed data. A safe way to ensure
+this is by receiving a hash of the original message (which may otherwise)
+be too long), and then calling `toEthSignedMessageHash` on it.
+
+```js
+function recover(bytes32 hash, bytes signature) internal pure
+returns(address)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| hash | bytes32 |  | 
+| signature | bytes |  | 
+
+### toEthSignedMessageHash
+
+Returns an Ethereum Signed Message, created from a `hash`. This
+replicates the behavior of the
+[`eth_sign`](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sign)
+JSON-RPC method.
+     * See `recover`.
+
+```js
+function toEthSignedMessageHash(bytes32 hash) internal pure
+returns(bytes32)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| hash | bytes32 |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/Erc20DepositVerifier.md
+++ b/plasma_framework/docs/Erc20DepositVerifier.md
@@ -1,0 +1,121 @@
+# Erc20DepositVerifier.sol
+
+View Source: [contracts/src/vaults/verifiers/Erc20DepositVerifier.sol](../contracts/src/vaults/verifiers/Erc20DepositVerifier.sol)
+
+**↗ Extends: [IErc20DepositVerifier](IErc20DepositVerifier.md)**
+
+**Erc20DepositVerifier**
+
+implementation of Erc20 deposit verifier using Payment transaction as the deposit tx
+
+## Contract Members
+**Constants & Variables**
+
+```js
+uint8 private constant DEPOSIT_TX_TYPE;
+
+```
+
+## Functions
+
+- [verify(bytes depositTx, address sender, address vault)](#verify)
+
+### verify
+
+⤾ overrides [IErc20DepositVerifier.verify](IErc20DepositVerifier.md#verify)
+
+Overrides the function of IErc20DepositVerifier and implements the verification logic
+        for Payment transaction
+
+```js
+function verify(bytes depositTx, address sender, address vault) external view
+returns(owner address, token address, amount uint256)
+```
+
+**Returns**
+
+verified (owner, token, amount) of the deposit ERC20 token data
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| depositTx | bytes |  | 
+| sender | address |  | 
+| vault | address |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/Erc20Vault.md
+++ b/plasma_framework/docs/Erc20Vault.md
@@ -1,0 +1,141 @@
+# Erc20Vault.sol
+
+View Source: [contracts/src/vaults/Erc20Vault.sol](../contracts/src/vaults/Erc20Vault.sol)
+
+**↗ Extends: [Vault](Vault.md)**
+
+**Erc20Vault**
+
+**Events**
+
+```js
+event Erc20Withdrawn(address payable indexed receiver, address indexed token, uint256  amount);
+event DepositCreated(address indexed depositor, uint256 indexed blknum, address indexed token, uint256  amount);
+```
+
+## Functions
+
+- [(PlasmaFramework _framework)](#)
+- [deposit(bytes depositTx)](#deposit)
+- [withdraw(address payable receiver, address token, uint256 amount)](#withdraw)
+
+### 
+
+```js
+function (PlasmaFramework _framework) public nonpayable Vault 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _framework | PlasmaFramework |  | 
+
+### deposit
+
+Deposits approved amount of ERC20 token(s) into the contract.
+Once the deposit is recognized, the owner (depositor) is able to make transactions on the OMG network.
+The approve function of the ERC20 token contract needs to be called before this function is called
+for at least the amount that is deposited into the contract.
+
+```js
+function deposit(bytes depositTx) external nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| depositTx | bytes | RLP encoded transaction to act as the deposit. | 
+
+### withdraw
+
+Withdraw ERC20 tokens that have been exited from the OMG network successfully.
+
+```js
+function withdraw(address payable receiver, address token, uint256 amount) external nonpayable onlyFromNonQuarantinedExitGame 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| receiver | address payable | address of the receiver | 
+| token | address | address of ERC20 token contract. | 
+| amount | uint256 | amount to transfer. | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/EthDepositVerifier.md
+++ b/plasma_framework/docs/EthDepositVerifier.md
@@ -1,0 +1,116 @@
+# EthDepositVerifier.sol
+
+View Source: [contracts/src/vaults/verifiers/EthDepositVerifier.sol](../contracts/src/vaults/verifiers/EthDepositVerifier.sol)
+
+**↗ Extends: [IEthDepositVerifier](IEthDepositVerifier.md)**
+
+**EthDepositVerifier**
+
+implementation of Eth deposit verifier using Payment transaction as the deposit tx
+
+## Contract Members
+**Constants & Variables**
+
+```js
+uint8 internal constant DEPOSIT_TX_TYPE;
+
+```
+
+## Functions
+
+- [verify(bytes depositTx, uint256 amount, address sender)](#verify)
+
+### verify
+
+⤾ overrides [IEthDepositVerifier.verify](IEthDepositVerifier.md#verify)
+
+Overrides the function of IEthDepositVerifier and implements the verification logic
+        for Payment transaction.
+
+```js
+function verify(bytes depositTx, uint256 amount, address sender) external view
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| depositTx | bytes |  | 
+| amount | uint256 |  | 
+| sender | address |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/EthVault.md
+++ b/plasma_framework/docs/EthVault.md
@@ -1,0 +1,138 @@
+# EthVault.sol
+
+View Source: [contracts/src/vaults/EthVault.sol](../contracts/src/vaults/EthVault.sol)
+
+**↗ Extends: [Vault](Vault.md)**
+
+**EthVault**
+
+**Events**
+
+```js
+event EthWithdrawn(address payable indexed receiver, uint256  amount);
+event DepositCreated(address indexed depositor, uint256 indexed blknum, address indexed token, uint256  amount);
+```
+
+## Functions
+
+- [(PlasmaFramework _framework)](#)
+- [deposit(bytes _depositTx)](#deposit)
+- [withdraw(address payable receiver, uint256 amount)](#withdraw)
+
+### 
+
+```js
+function (PlasmaFramework _framework) public nonpayable Vault 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _framework | PlasmaFramework |  | 
+
+### deposit
+
+Allows a user to deposit ETH into the contract.
+Once the deposit is recognized, the owner is able to make transactions on the OMG network.
+
+```js
+function deposit(bytes _depositTx) external payable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _depositTx | bytes | RLP encoded transaction to act as the deposit. | 
+
+### withdraw
+
+Withdraw ETH that have been exited from the OMG network successfully.
+
+```js
+function withdraw(address payable receiver, uint256 amount) external nonpayable onlyFromNonQuarantinedExitGame 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| receiver | address payable | address of the transferee | 
+| amount | uint256 | amount of eth to transfer. | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/ExitGameController.md
+++ b/plasma_framework/docs/ExitGameController.md
@@ -1,0 +1,251 @@
+# ExitGameController.sol
+
+View Source: [contracts/src/framework/ExitGameController.sol](../contracts/src/framework/ExitGameController.sol)
+
+**↗ Extends: [ExitGameRegistry](ExitGameRegistry.md)**
+**↘ Derived Contracts: [PlasmaFramework](PlasmaFramework.md)**
+
+**ExitGameController**
+
+Controls the logic and functions for ExitGame to interact with PlasmaFramework.
+        Plasma M(ore)VP relies on exit priority to secure the user from invalid transactions.
+        As a result, priority queue is used here to promise the exit would be processed with the exit priority.
+        For details, see the Plasma MVP spec: https://ethresear.ch/t/minimal-viable-plasma/426
+
+## Contract Members
+**Constants & Variables**
+
+```js
+mapping(uint256 => contract IExitProcessor) public delegations;
+mapping(address => contract PriorityQueue) public exitsQueues;
+mapping(bytes32 => bool) public isOutputSpent;
+
+```
+
+**Events**
+
+```js
+event TokenAdded(address  token);
+event ProcessedExitsNum(uint256  processedNum, address  token);
+event ExitQueued(uint160 indexed exitId, uint256  uniquePriority);
+```
+
+## Functions
+
+- [(uint256 _minExitPeriod, uint256 _initialImmuneExitGames)](#)
+- [addToken(address _token)](#addtoken)
+- [hasToken(address _token)](#hastoken)
+- [enqueue(address _token, uint64 _exitableAt, struct TxPosLib.TxPos _txPos, uint160 _exitId, IExitProcessor _exitProcessor)](#enqueue)
+- [processExits(address _token, uint160 _topExitId, uint256 _maxExitsToProcess)](#processexits)
+- [isAnyOutputsSpent(bytes32[] _outputIds)](#isanyoutputsspent)
+- [batchFlagOutputsSpent(bytes32[] _outputIds)](#batchflagoutputsspent)
+- [flagOutputSpent(bytes32 _outputId)](#flagoutputspent)
+
+### 
+
+```js
+function (uint256 _minExitPeriod, uint256 _initialImmuneExitGames) public nonpayable ExitGameRegistry 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _minExitPeriod | uint256 |  | 
+| _initialImmuneExitGames | uint256 |  | 
+
+### addToken
+
+Add token to the plasma framework and initiate the priority queue.
+
+```js
+function addToken(address _token) external nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _token | address | Address of the token. | 
+
+### hasToken
+
+Checks if the queue for a particular token was created.
+
+```js
+function hasToken(address _token) public view
+returns(bool)
+```
+
+**Returns**
+
+bool whether the queue for a token was created.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _token | address | address of the token. | 
+
+### enqueue
+
+Enqueue exits from exit game contracts. This 'enqueue' function puts the exit into the
+        priority queue to enforce the priority of exit during 'processExits'.
+
+```js
+function enqueue(address _token, uint64 _exitableAt, struct TxPosLib.TxPos _txPos, uint160 _exitId, IExitProcessor _exitProcessor) external nonpayable onlyFromNonQuarantinedExitGame 
+returns(uint256)
+```
+
+**Returns**
+
+a unique priority number computed for the exit
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _token | address | Token for the exit | 
+| _exitableAt | uint64 | The earliest time that such exit can be processed | 
+| _txPos | struct TxPosLib.TxPos | Transaction position for the exit priority. For SE it should be the exit tx, for IFE it should be the youngest input tx position. | 
+| _exitId | uint160 | Id for the exit processor contract to understand how to process such exit | 
+| _exitProcessor | IExitProcessor | The exit processor contract that would be called during "processExits" | 
+
+### processExits
+
+Processes any exits that have completed the challenge period. Exits would be processed according to the exit priority.
+
+```js
+function processExits(address _token, uint160 _topExitId, uint256 _maxExitsToProcess) external nonpayable
+```
+
+**Returns**
+
+total number of processed exits
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _token | address | token type to process. | 
+| _topExitId | uint160 | unique priority of the first exit that should be processed. Set to zero to skip the check. | 
+| _maxExitsToProcess | uint256 | maximal number of exits to process. | 
+
+### isAnyOutputsSpent
+
+Checks if any of the output with the given outputIds is spent already.
+
+```js
+function isAnyOutputsSpent(bytes32[] _outputIds) external view
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _outputIds | bytes32[] | Output ids to be checked. | 
+
+### batchFlagOutputsSpent
+
+Batch flags outputs that are spent
+
+```js
+function batchFlagOutputsSpent(bytes32[] _outputIds) external nonpayable onlyFromNonQuarantinedExitGame 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _outputIds | bytes32[] | Output ids to be flagged | 
+
+### flagOutputSpent
+
+Flags a single output as spent
+
+```js
+function flagOutputSpent(bytes32 _outputId) external nonpayable onlyFromNonQuarantinedExitGame 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _outputId | bytes32 | The output id to be flagged as spent | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/ExitGameRegistry.md
+++ b/plasma_framework/docs/ExitGameRegistry.md
@@ -1,0 +1,224 @@
+# ExitGameRegistry.sol
+
+View Source: [contracts/src/framework/registries/ExitGameRegistry.sol](../contracts/src/framework/registries/ExitGameRegistry.sol)
+
+**↗ Extends: [Operated](Operated.md)**
+**↘ Derived Contracts: [ExitGameController](ExitGameController.md), [PlasmaFramework](PlasmaFramework.md)**
+
+**ExitGameRegistry**
+
+## Contract Members
+**Constants & Variables**
+
+```js
+mapping(uint256 => address) private _exitGames;
+mapping(address => uint256) private _exitGameToTxType;
+mapping(uint256 => uint8) private _protocols;
+struct Quarantine.Data private _exitGameQuarantine;
+
+```
+
+**Events**
+
+```js
+event ExitGameRegistered(uint256  txType, address  exitGameAddress, uint8  protocol);
+```
+
+## Modifiers
+
+- [onlyFromNonQuarantinedExitGame](#onlyfromnonquarantinedexitgame)
+
+### onlyFromNonQuarantinedExitGame
+
+modifier to check the call is from a non-quarantined exit game
+
+```js
+modifier onlyFromNonQuarantinedExitGame() internal
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+
+## Functions
+
+- [(uint256 _minExitPeriod, uint256 _initialImmuneExitGames)](#)
+- [isExitGameSafeToUse(address _contract)](#isexitgamesafetouse)
+- [registerExitGame(uint256 _txType, address _contract, uint8 _protocol)](#registerexitgame)
+- [protocols(uint256 _txType)](#protocols)
+- [exitGames(uint256 _txType)](#exitgames)
+- [exitGameToTxType(address _exitGame)](#exitgametotxtype)
+
+### 
+
+For each new exit game contract, it should take at least 3 * minExitPeriod to start take effect to protect existing transactions.
+     see: https://github.com/omisego/plasma-contracts/issues/172
+          https://github.com/omisego/plasma-contracts/issues/197
+
+```js
+function (uint256 _minExitPeriod, uint256 _initialImmuneExitGames) public nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _minExitPeriod | uint256 |  | 
+| _initialImmuneExitGames | uint256 |  | 
+
+### isExitGameSafeToUse
+
+Checks whether the contract is safe to use and is not under quarantine
+
+```js
+function isExitGameSafeToUse(address _contract) public view
+returns(bool)
+```
+
+**Returns**
+
+boolean whether the contract is safe to use and is not under quarantine.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _contract | address | address of the exit game contract | 
+
+### registerExitGame
+
+Register an exit game within the PlasmaFramework. The function can only be called by the maintainer.
+
+```js
+function registerExitGame(uint256 _txType, address _contract, uint8 _protocol) public nonpayable onlyOperator 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _txType | uint256 | tx type that the exit game want to register to. | 
+| _contract | address | address of the exit game contract. | 
+| _protocol | uint8 | protocol of the transaction, 1 for MVP and 2 for MoreVP. | 
+
+### protocols
+
+public getter for getting protocol with tx type
+
+```js
+function protocols(uint256 _txType) public view
+returns(uint8)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _txType | uint256 |  | 
+
+### exitGames
+
+public getter for getting exit game address with tx type
+
+```js
+function exitGames(uint256 _txType) public view
+returns(address)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _txType | uint256 |  | 
+
+### exitGameToTxType
+
+public getter for getting tx type with exit game address
+
+```js
+function exitGameToTxType(address _exitGame) public view
+returns(uint256)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _exitGame | address |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/ExitId.md
+++ b/plasma_framework/docs/ExitId.md
@@ -1,0 +1,161 @@
+# ExitId.sol
+
+View Source: [contracts/src/exits/utils/ExitId.sol](../contracts/src/exits/utils/ExitId.sol)
+
+**ExitId**
+
+## Functions
+
+- [isStandardExit(uint160 _exitId)](#isstandardexit)
+- [getStandardExitId(bool _isDeposit, bytes _txBytes, struct UtxoPosLib.UtxoPos _utxoPos)](#getstandardexitid)
+- [getInFlightExitId(bytes _txBytes)](#getinflightexitid)
+- [_computeStandardExitId(bytes32 _txhash, uint16 _outputIndex)](#_computestandardexitid)
+
+### isStandardExit
+
+Checks whether exitId is a standard exit id or not.
+
+```js
+function isStandardExit(uint160 _exitId) internal pure
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _exitId | uint160 |  | 
+
+### getStandardExitId
+
+Given transaction bytes and UTXO position, returns its exit ID.
+
+```js
+function getStandardExitId(bool _isDeposit, bytes _txBytes, struct UtxoPosLib.UtxoPos _utxoPos) internal pure
+returns(uint160)
+```
+
+**Returns**
+
+_standardExitId Unique standard exit id.
+    Anatomy of returned value, most significant bits first:
+    8-bits - output index
+    1-bit - in-flight flag (0 for standard exit)
+    151-bits - hash(tx) or hash(tx|utxo) for deposit
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _isDeposit | bool | whether the tx for the exitId is an deposit tx or not | 
+| _txBytes | bytes | Transaction bytes. | 
+| _utxoPos | struct UtxoPosLib.UtxoPos | UTXO position of the exiting output. | 
+
+### getInFlightExitId
+
+Given transaction bytes returns in-flight exit ID.
+
+```js
+function getInFlightExitId(bytes _txBytes) internal pure
+returns(uint160)
+```
+
+**Returns**
+
+Unique in-flight exit id.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _txBytes | bytes | Transaction bytes. | 
+
+### _computeStandardExitId
+
+```js
+function _computeStandardExitId(bytes32 _txhash, uint16 _outputIndex) private pure
+returns(uint160)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _txhash | bytes32 |  | 
+| _outputIndex | uint16 |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/ExitPriority.md
+++ b/plasma_framework/docs/ExitPriority.md
@@ -1,0 +1,138 @@
+# ExitPriority.sol
+
+View Source: [contracts/src/framework/utils/ExitPriority.sol](../contracts/src/framework/utils/ExitPriority.sol)
+
+**ExitPriority**
+
+## Functions
+
+- [computePriority(uint64 exitableAt, struct TxPosLib.TxPos txPos, uint160 exitId)](#computepriority)
+- [parseExitableAt(uint256 priority)](#parseexitableat)
+- [parseExitId(uint256 priority)](#parseexitid)
+
+### computePriority
+
+Full explanation on fields lengths can be found here: https://github.com/omisego/plasma-contracts/pull/303#discussion_r328850572
+
+```js
+function computePriority(uint64 exitableAt, struct TxPosLib.TxPos txPos, uint160 exitId) internal pure
+returns(uint256)
+```
+
+**Returns**
+
+An exit priority.
+  Anatomy of returned value, most significant bits first
+  42 bits  - timestamp in seconds (exitable_at); we can represent dates until year 141431
+  54 bits  - blknum * CHILD_BLOCK_INTERVAL * 10^5 + txindex; 54 bits represent all transactions for 85 years. We are assuming CHILD_BLOCK_INTERVAL = 1000.
+  160 bits - exit id
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| exitableAt | uint64 |  | 
+| txPos | struct TxPosLib.TxPos |  | 
+| exitId | uint160 | unique exit identifier. | 
+
+### parseExitableAt
+
+```js
+function parseExitableAt(uint256 priority) internal pure
+returns(uint64)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| priority | uint256 |  | 
+
+### parseExitId
+
+```js
+function parseExitId(uint256 priority) internal pure
+returns(uint160)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| priority | uint256 |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/ExitableTimestamp.md
+++ b/plasma_framework/docs/ExitableTimestamp.md
@@ -1,0 +1,110 @@
+# ExitableTimestamp.sol
+
+View Source: [contracts/src/exits/utils/ExitableTimestamp.sol](../contracts/src/exits/utils/ExitableTimestamp.sol)
+
+**ExitableTimestamp**
+
+## Structs
+### Calculator
+
+```js
+struct Calculator {
+ uint256 minExitPeriod
+}
+```
+
+## Functions
+
+- [calculate(struct ExitableTimestamp.Calculator _calculator, uint256 _now, uint256 _blockTimestamp, bool _isDeposit)](#calculate)
+
+### calculate
+
+```js
+function calculate(struct ExitableTimestamp.Calculator _calculator, uint256 _now, uint256 _blockTimestamp, bool _isDeposit) internal pure
+returns(uint64)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _calculator | struct ExitableTimestamp.Calculator |  | 
+| _now | uint256 |  | 
+| _blockTimestamp | uint256 |  | 
+| _isDeposit | bool |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/IERC20.md
+++ b/plasma_framework/docs/IERC20.md
@@ -1,0 +1,211 @@
+# IERC20.sol
+
+View Source: [openzeppelin-solidity/contracts/token/ERC20/IERC20.sol](../openzeppelin-solidity/contracts/token/ERC20/IERC20.sol)
+
+**IERC20**
+
+Interface of the ERC20 standard as defined in the EIP. Does not include
+the optional functions; to access them see `ERC20Detailed`.
+
+**Events**
+
+```js
+event Transfer(address indexed from, address indexed to, uint256  value);
+event Approval(address indexed owner, address indexed spender, uint256  value);
+```
+
+## Functions
+
+- [totalSupply()](#totalsupply)
+- [balanceOf(address account)](#balanceof)
+- [transfer(address recipient, uint256 amount)](#transfer)
+- [allowance(address owner, address spender)](#allowance)
+- [approve(address spender, uint256 amount)](#approve)
+- [transferFrom(address sender, address recipient, uint256 amount)](#transferfrom)
+
+### totalSupply
+
+Returns the amount of tokens in existence.
+
+```js
+function totalSupply() external view
+returns(uint256)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+
+### balanceOf
+
+Returns the amount of tokens owned by `account`.
+
+```js
+function balanceOf(address account) external view
+returns(uint256)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| account | address |  | 
+
+### transfer
+
+Moves `amount` tokens from the caller's account to `recipient`.
+     * Returns a boolean value indicating whether the operation succeeded.
+     * Emits a `Transfer` event.
+
+```js
+function transfer(address recipient, uint256 amount) external nonpayable
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| recipient | address |  | 
+| amount | uint256 |  | 
+
+### allowance
+
+Returns the remaining number of tokens that `spender` will be
+allowed to spend on behalf of `owner` through `transferFrom`. This is
+zero by default.
+     * This value changes when `approve` or `transferFrom` are called.
+
+```js
+function allowance(address owner, address spender) external view
+returns(uint256)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| owner | address |  | 
+| spender | address |  | 
+
+### approve
+
+Sets `amount` as the allowance of `spender` over the caller's tokens.
+     * Returns a boolean value indicating whether the operation succeeded.
+     * > Beware that changing an allowance with this method brings the risk
+that someone may use both the old and the new allowance by unfortunate
+transaction ordering. One possible solution to mitigate this race
+condition is to first reduce the spender's allowance to 0 and set the
+desired value afterwards:
+https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     * Emits an `Approval` event.
+
+```js
+function approve(address spender, uint256 amount) external nonpayable
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| spender | address |  | 
+| amount | uint256 |  | 
+
+### transferFrom
+
+Moves `amount` tokens from `sender` to `recipient` using the
+allowance mechanism. `amount` is then deducted from the caller's
+allowance.
+     * Returns a boolean value indicating whether the operation succeeded.
+     * Emits a `Transfer` event.
+
+```js
+function transferFrom(address sender, address recipient, uint256 amount) external nonpayable
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| sender | address |  | 
+| recipient | address |  | 
+| amount | uint256 |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/IErc20DepositVerifier.md
+++ b/plasma_framework/docs/IErc20DepositVerifier.md
@@ -1,0 +1,110 @@
+# IErc20DepositVerifier.sol
+
+View Source: [contracts/src/vaults/verifiers/IErc20DepositVerifier.sol](../contracts/src/vaults/verifiers/IErc20DepositVerifier.sol)
+
+**↘ Derived Contracts: [Erc20DepositVerifier](Erc20DepositVerifier.md)**
+
+**IErc20DepositVerifier**
+
+## Functions
+
+- [verify(bytes depositTx, address sender, address vault)](#verify)
+
+### verify
+
+⤿ Overridden Implementation(s): [Erc20DepositVerifier.verify](Erc20DepositVerifier.md#verify)
+
+Verifies a deposit transaction.
+
+```js
+function verify(bytes depositTx, address sender, address vault) external view
+returns(owner address, token address, amount uint256)
+```
+
+**Returns**
+
+verified (owner, token, amount) of the deposit ERC20 token data
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| depositTx | bytes | The deposit transaction. | 
+| sender | address | The owner of the deposit transaction. | 
+| vault | address | The address of the Erc20Vault contract. | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/IEthDepositVerifier.md
+++ b/plasma_framework/docs/IEthDepositVerifier.md
@@ -1,0 +1,105 @@
+# IEthDepositVerifier.sol
+
+View Source: [contracts/src/vaults/verifiers/IEthDepositVerifier.sol](../contracts/src/vaults/verifiers/IEthDepositVerifier.sol)
+
+**↘ Derived Contracts: [EthDepositVerifier](EthDepositVerifier.md)**
+
+**IEthDepositVerifier**
+
+## Functions
+
+- [verify(bytes depositTx, uint256 amount, address sender)](#verify)
+
+### verify
+
+⤿ Overridden Implementation(s): [EthDepositVerifier.verify](EthDepositVerifier.md#verify)
+
+Verifies a deposit transaction.
+
+```js
+function verify(bytes depositTx, uint256 amount, address sender) external view
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| depositTx | bytes | The deposit transaction. | 
+| amount | uint256 | The amount being of the deposited. | 
+| sender | address | The owner of the deposit transaction. | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/IExitProcessor.md
+++ b/plasma_framework/docs/IExitProcessor.md
@@ -1,0 +1,107 @@
+# IExitProcessor.sol
+
+View Source: [contracts/src/framework/interfaces/IExitProcessor.sol](../contracts/src/framework/interfaces/IExitProcessor.sol)
+
+**↘ Derived Contracts: [PaymentExitGame](PaymentExitGame.md), [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md), [PaymentStandardExitRouter](PaymentStandardExitRouter.md)**
+
+**IExitProcessor**
+
+An interface to allow custom logic for processing exits for different needs.
+     It is used to dispatch to each custom processor when 'processExits' is called on PlasmaFramework.
+
+## Functions
+
+- [processExit(uint160 exitId, address token)](#processexit)
+
+### processExit
+
+⤿ Overridden Implementation(s): [PaymentExitGame.processExit](PaymentExitGame.md#processexit)
+
+function interface to process exits.
+
+```js
+function processExit(uint160 exitId, address token) external nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| exitId | uint160 | unique id for exit per tx type. | 
+| token | address | address of the token contract. | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/IOutputGuardHandler.md
+++ b/plasma_framework/docs/IOutputGuardHandler.md
@@ -1,0 +1,142 @@
+# IOutputGuardHandler.sol
+
+View Source: [contracts/src/exits/interfaces/IOutputGuardHandler.sol](../contracts/src/exits/interfaces/IOutputGuardHandler.sol)
+
+**↘ Derived Contracts: [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)**
+
+**IOutputGuardHandler**
+
+An interface for utils functions needed to process and get essential data from output guard field.
+
+## Functions
+
+- [isValid(struct OutputGuardModel.Data object)](#isvalid)
+- [getExitTarget(struct OutputGuardModel.Data object)](#getexittarget)
+- [getConfirmSigAddress(struct OutputGuardModel.Data object)](#getconfirmsigaddress)
+
+### isValid
+
+⤿ Overridden Implementation(s): [PaymentOutputGuardHandler.isValid](PaymentOutputGuardHandler.md#isvalid)
+
+Checks a given output guard data
+
+```js
+function isValid(struct OutputGuardModel.Data object) external view
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| object | struct OutputGuardModel.Data |  | 
+
+### getExitTarget
+
+⤿ Overridden Implementation(s): [PaymentOutputGuardHandler.getExitTarget](PaymentOutputGuardHandler.md#getexittarget)
+
+Gets the 'exit target' from the data set
+
+```js
+function getExitTarget(struct OutputGuardModel.Data object) external view
+returns(address payable)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| object | struct OutputGuardModel.Data |  | 
+
+### getConfirmSigAddress
+
+⤿ Overridden Implementation(s): [PaymentOutputGuardHandler.getConfirmSigAddress](PaymentOutputGuardHandler.md#getconfirmsigaddress)
+
+Gets the 'confirm signature address' from the data set. Returns address(0) if none.
+
+```js
+function getConfirmSigAddress(struct OutputGuardModel.Data object) external view
+returns(address)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| object | struct OutputGuardModel.Data |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/ISpendingCondition.md
+++ b/plasma_framework/docs/ISpendingCondition.md
@@ -1,0 +1,112 @@
+# ISpendingCondition.sol
+
+View Source: [contracts/src/exits/interfaces/ISpendingCondition.sol](../contracts/src/exits/interfaces/ISpendingCondition.sol)
+
+**↘ Derived Contracts: [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)**
+
+**ISpendingCondition**
+
+interface of the spending condition.
+
+## Functions
+
+- [verify(bytes inputTx, uint16 outputIndex, uint256 inputTxPos, bytes spendingTx, uint16 inputIndex, bytes witness, bytes optionalArgs)](#verify)
+
+### verify
+
+⤿ Overridden Implementation(s): [PaymentOutputToPaymentTxCondition.verify](PaymentOutputToPaymentTxCondition.md#verify)
+
+Verifies the spending condition
+
+```js
+function verify(bytes inputTx, uint16 outputIndex, uint256 inputTxPos, bytes spendingTx, uint16 inputIndex, bytes witness, bytes optionalArgs) external view
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| inputTx | bytes | encoded input transaction in bytes | 
+| outputIndex | uint16 | the output index of the input transaction | 
+| inputTxPos | uint256 | the tx position of the input tx. (0 if in-flight) | 
+| spendingTx | bytes | spending transaction in bytes | 
+| inputIndex | uint16 | the input index of the spending tx that points to the output | 
+| witness | bytes | the witness data of the spending condition | 
+| optionalArgs | bytes | some optional data for the spending condition's need (eg. output guard preimage) | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/IStateTransitionVerifier.md
+++ b/plasma_framework/docs/IStateTransitionVerifier.md
@@ -1,0 +1,102 @@
+# IStateTransitionVerifier.sol
+
+View Source: [contracts/src/exits/interfaces/IStateTransitionVerifier.sol](../contracts/src/exits/interfaces/IStateTransitionVerifier.sol)
+
+**IStateTransitionVerifier**
+
+## Functions
+
+- [isCorrectStateTransition(bytes txBytes, bytes[] inputTxs, uint16[] outputIndexOfInputTxs)](#iscorrectstatetransition)
+
+### isCorrectStateTransition
+
+Verifies state transition logic.
+
+```js
+function isCorrectStateTransition(bytes txBytes, bytes[] inputTxs, uint16[] outputIndexOfInputTxs) external view
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| txBytes | bytes | the targeting transaction that is doing the state transition verification | 
+| inputTxs | bytes[] | input transactions of the targeting transaction checking state transition | 
+| outputIndexOfInputTxs | uint16[] | the output index of the input txs that the transaction input is pointing to | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/ITxFinalizationVerifier.md
+++ b/plasma_framework/docs/ITxFinalizationVerifier.md
@@ -1,0 +1,124 @@
+# ITxFinalizationVerifier.sol
+
+View Source: [contracts/src/exits/interfaces/ITxFinalizationVerifier.sol](../contracts/src/exits/interfaces/ITxFinalizationVerifier.sol)
+
+**↘ Derived Contracts: [TxFinalizationVerifier](TxFinalizationVerifier.md)**
+
+**ITxFinalizationVerifier**
+
+Interface for the code that checks finalization status of a transaction
+
+## Functions
+
+- [isStandardFinalized(struct TxFinalizationModel.Data self)](#isstandardfinalized)
+- [isProtocolFinalized(struct TxFinalizationModel.Data self)](#isprotocolfinalized)
+
+### isStandardFinalized
+
+⤿ Overridden Implementation(s): [TxFinalizationVerifier.isStandardFinalized](TxFinalizationVerifier.md#isstandardfinalized)
+
+Checks a transaction is "standard finalized" or not
+
+```js
+function isStandardFinalized(struct TxFinalizationModel.Data self) external view
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct TxFinalizationModel.Data |  | 
+
+### isProtocolFinalized
+
+⤿ Overridden Implementation(s): [TxFinalizationVerifier.isProtocolFinalized](TxFinalizationVerifier.md#isprotocolfinalized)
+
+Checks a transaction is "protocol finalized" or not
+
+```js
+function isProtocolFinalized(struct TxFinalizationModel.Data self) external view
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct TxFinalizationModel.Data |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/IsDeposit.md
+++ b/plasma_framework/docs/IsDeposit.md
@@ -1,0 +1,110 @@
+# IsDeposit.sol
+
+View Source: [contracts/src/utils/IsDeposit.sol](../contracts/src/utils/IsDeposit.sol)
+
+**IsDeposit**
+
+## Structs
+### Predicate
+
+```js
+struct Predicate {
+ uint256 childBlockInterval
+}
+```
+
+## Functions
+
+- [test(struct IsDeposit.Predicate _predicate, uint256 _blockNum)](#test)
+
+### test
+
+test whether the given block number belongs to a deposit block or not
+
+```js
+function test(struct IsDeposit.Predicate _predicate, uint256 _blockNum) internal pure
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _predicate | struct IsDeposit.Predicate |  | 
+| _blockNum | uint256 |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/Math.md
+++ b/plasma_framework/docs/Math.md
@@ -1,0 +1,138 @@
+# Math.sol
+
+View Source: [openzeppelin-solidity/contracts/math/Math.sol](../openzeppelin-solidity/contracts/math/Math.sol)
+
+**Math**
+
+Standard math utilities missing in the Solidity language.
+
+## Functions
+
+- [max(uint256 a, uint256 b)](#max)
+- [min(uint256 a, uint256 b)](#min)
+- [average(uint256 a, uint256 b)](#average)
+
+### max
+
+Returns the largest of two numbers.
+
+```js
+function max(uint256 a, uint256 b) internal pure
+returns(uint256)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| a | uint256 |  | 
+| b | uint256 |  | 
+
+### min
+
+Returns the smallest of two numbers.
+
+```js
+function min(uint256 a, uint256 b) internal pure
+returns(uint256)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| a | uint256 |  | 
+| b | uint256 |  | 
+
+### average
+
+Returns the average of two numbers. The result is rounded towards
+zero.
+
+```js
+function average(uint256 a, uint256 b) internal pure
+returns(uint256)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| a | uint256 |  | 
+| b | uint256 |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/Merkle.md
+++ b/plasma_framework/docs/Merkle.md
@@ -1,0 +1,109 @@
+# Merkle (Merkle.sol)
+
+View Source: [contracts/src/utils/Merkle.sol](../contracts/src/utils/Merkle.sol)
+
+**Merkle**
+
+Library for working with Merkle trees.
+
+## Functions
+
+- [checkMembership(bytes32 leaf, uint256 index, bytes32 rootHash, bytes proof)](#checkmembership)
+
+### checkMembership
+
+Checks that a leaf hash is contained in a root hash.
+
+```js
+function checkMembership(bytes32 leaf, uint256 index, bytes32 rootHash, bytes proof) internal pure
+returns(bool)
+```
+
+**Returns**
+
+True of the leaf hash is in the Merkle tree. False otherwise.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| leaf | bytes32 | Leaf hash to verify. | 
+| index | uint256 | Position of the leaf hash in the Merkle tree. | 
+| rootHash | bytes32 | Root of the Merkle tree. | 
+| proof | bytes | A Merkle proof demonstrating membership of the leaf hash. | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/Migrations.md
+++ b/plasma_framework/docs/Migrations.md
@@ -1,0 +1,146 @@
+# Migrations.sol
+
+View Source: [contracts/Migrations.sol](../contracts/Migrations.sol)
+
+**Migrations**
+
+## Contract Members
+**Constants & Variables**
+
+```js
+address public owner;
+uint256 public last_completed_migration;
+
+```
+
+## Modifiers
+
+- [restricted](#restricted)
+
+### restricted
+
+```js
+modifier restricted() internal
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+
+## Functions
+
+- [()](#)
+- [setCompleted(uint256 completed)](#setcompleted)
+- [upgrade(address new_address)](#upgrade)
+
+### 
+
+```js
+function () public nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+
+### setCompleted
+
+```js
+function setCompleted(uint256 completed) public nonpayable restricted 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| completed | uint256 |  | 
+
+### upgrade
+
+```js
+function upgrade(address new_address) public nonpayable restricted 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| new_address | address |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/OnlyFromAddress.md
+++ b/plasma_framework/docs/OnlyFromAddress.md
@@ -1,0 +1,101 @@
+# OnlyFromAddress.sol
+
+View Source: [contracts/src/utils/OnlyFromAddress.sol](../contracts/src/utils/OnlyFromAddress.sol)
+
+**↘ Derived Contracts: [PaymentExitGame](PaymentExitGame.md)**
+
+**OnlyFromAddress**
+
+## Modifiers
+
+- [onlyFrom](#onlyfrom)
+
+### onlyFrom
+
+```js
+modifier onlyFrom(address caller) internal
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| caller | address |  | 
+
+## Functions
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/OnlyWithValue.md
+++ b/plasma_framework/docs/OnlyWithValue.md
@@ -1,0 +1,101 @@
+# OnlyWithValue.sol
+
+View Source: [contracts/src/utils/OnlyWithValue.sol](../contracts/src/utils/OnlyWithValue.sol)
+
+**↘ Derived Contracts: [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md), [PaymentStandardExitRouter](PaymentStandardExitRouter.md)**
+
+**OnlyWithValue**
+
+## Modifiers
+
+- [onlyWithValue](#onlywithvalue)
+
+### onlyWithValue
+
+```js
+modifier onlyWithValue(uint256 _value) internal
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _value | uint256 |  | 
+
+## Functions
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/Operated.md
+++ b/plasma_framework/docs/Operated.md
@@ -1,0 +1,134 @@
+# Operated.sol
+
+View Source: [contracts/src/framework/utils/Operated.sol](../contracts/src/framework/utils/Operated.sol)
+
+**↘ Derived Contracts: [BlockController](BlockController.md), [ExitGameRegistry](ExitGameRegistry.md), [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md), [PaymentStandardExitRouter](PaymentStandardExitRouter.md), [PlasmaFramework](PlasmaFramework.md), [Vault](Vault.md), [VaultRegistry](VaultRegistry.md)**
+
+**Operated**
+
+## Contract Members
+**Constants & Variables**
+
+```js
+address private _operator;
+
+```
+
+## Modifiers
+
+- [onlyOperator](#onlyoperator)
+
+### onlyOperator
+
+```js
+modifier onlyOperator() internal
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+
+## Functions
+
+- [()](#)
+- [operator()](#operator)
+
+### 
+
+```js
+function () public nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+
+### operator
+
+```js
+function operator() public view
+returns(address)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/OutputGuardHandlerRegistry.md
+++ b/plasma_framework/docs/OutputGuardHandlerRegistry.md
@@ -1,0 +1,112 @@
+# OutputGuardHandlerRegistry (OutputGuardHandlerRegistry.sol)
+
+View Source: [contracts/src/exits/registries/OutputGuardHandlerRegistry.sol](../contracts/src/exits/registries/OutputGuardHandlerRegistry.sol)
+
+**↗ Extends: [Ownable](Ownable.md)**
+
+**OutputGuardHandlerRegistry**
+
+The registry contracts of outputGuard handler
+
+## Contract Members
+**Constants & Variables**
+
+```js
+mapping(uint256 => contract IOutputGuardHandler) public outputGuardHandlers;
+
+```
+
+## Functions
+
+- [registerOutputGuardHandler(uint256 outputType, IOutputGuardHandler handler)](#registeroutputguardhandler)
+
+### registerOutputGuardHandler
+
+Register the output guard handler.
+
+```js
+function registerOutputGuardHandler(uint256 outputType, IOutputGuardHandler handler) public nonpayable onlyOwner 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| outputType | uint256 | output type that the parser is registered with. | 
+| handler | IOutputGuardHandler | The output guard handler contract. | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/OutputGuardModel.md
+++ b/plasma_framework/docs/OutputGuardModel.md
@@ -1,0 +1,93 @@
+# OutputGuardModel.sol
+
+View Source: [contracts/src/exits/models/OutputGuardModel.sol](../contracts/src/exits/models/OutputGuardModel.sol)
+
+**OutputGuardModel**
+
+## Structs
+### Data
+
+```js
+struct Data {
+ bytes20 guard,
+ bytes preimage
+}
+```
+
+## Functions
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/OutputId.md
+++ b/plasma_framework/docs/OutputId.md
@@ -1,0 +1,119 @@
+# OutputId.sol
+
+View Source: [contracts/src/exits/utils/OutputId.sol](../contracts/src/exits/utils/OutputId.sol)
+
+**OutputId**
+
+## Functions
+
+- [computeDepositOutputId(bytes _txBytes, uint256 _outputIndex, uint256 _utxoPosValue)](#computedepositoutputid)
+- [computeNormalOutputId(bytes _txBytes, uint256 _outputIndex)](#computenormaloutputid)
+
+### computeDepositOutputId
+
+Computes the output id for deposit tx
+
+```js
+function computeDepositOutputId(bytes _txBytes, uint256 _outputIndex, uint256 _utxoPosValue) internal pure
+returns(bytes32)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _txBytes | bytes | Transaction bytes. | 
+| _outputIndex | uint256 | output index of the output. | 
+| _utxoPosValue | uint256 | (optinal) UTXO position of the deposit output. | 
+
+### computeNormalOutputId
+
+Computes the output id for normal (non deposit) tx
+
+```js
+function computeNormalOutputId(bytes _txBytes, uint256 _outputIndex) internal pure
+returns(bytes32)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _txBytes | bytes | Transaction bytes. | 
+| _outputIndex | uint256 | output index of the output. | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/Ownable.md
+++ b/plasma_framework/docs/Ownable.md
@@ -1,0 +1,216 @@
+# Ownable.sol
+
+View Source: [openzeppelin-solidity/contracts/ownership/Ownable.sol](../openzeppelin-solidity/contracts/ownership/Ownable.sol)
+
+**↘ Derived Contracts: [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md), [PriorityQueue](PriorityQueue.md), [SpendingConditionRegistry](SpendingConditionRegistry.md)**
+
+**Ownable**
+
+Contract module which provides a basic access control mechanism, where
+there is an account (an owner) that can be granted exclusive access to
+specific functions.
+ * This module is used through inheritance. It will make available the modifier
+`onlyOwner`, which can be aplied to your functions to restrict their use to
+the owner.
+
+## Contract Members
+**Constants & Variables**
+
+```js
+address private _owner;
+
+```
+
+**Events**
+
+```js
+event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+```
+
+## Modifiers
+
+- [onlyOwner](#onlyowner)
+
+### onlyOwner
+
+Throws if called by any account other than the owner.
+
+```js
+modifier onlyOwner() internal
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+
+## Functions
+
+- [()](#)
+- [owner()](#owner)
+- [isOwner()](#isowner)
+- [renounceOwnership()](#renounceownership)
+- [transferOwnership(address newOwner)](#transferownership)
+- [_transferOwnership(address newOwner)](#_transferownership)
+
+### 
+
+Initializes the contract setting the deployer as the initial owner.
+
+```js
+function () internal nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+
+### owner
+
+Returns the address of the current owner.
+
+```js
+function owner() public view
+returns(address)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+
+### isOwner
+
+Returns true if the caller is the current owner.
+
+```js
+function isOwner() public view
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+
+### renounceOwnership
+
+Leaves the contract without owner. It will not be possible to call
+`onlyOwner` functions anymore. Can only be called by the current owner.
+     * > Note: Renouncing ownership will leave the contract without an owner,
+thereby removing any functionality that is only available to the owner.
+
+```js
+function renounceOwnership() public nonpayable onlyOwner 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+
+### transferOwnership
+
+Transfers ownership of the contract to a new account (`newOwner`).
+Can only be called by the current owner.
+
+```js
+function transferOwnership(address newOwner) public nonpayable onlyOwner 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| newOwner | address |  | 
+
+### _transferOwnership
+
+Transfers ownership of the contract to a new account (`newOwner`).
+
+```js
+function _transferOwnership(address newOwner) internal nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| newOwner | address |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/PaymentChallengeIFEInputSpent.md
+++ b/plasma_framework/docs/PaymentChallengeIFEInputSpent.md
@@ -1,0 +1,192 @@
+# PaymentChallengeIFEInputSpent.sol
+
+View Source: [contracts/src/exits/payment/controllers/PaymentChallengeIFEInputSpent.sol](../contracts/src/exits/payment/controllers/PaymentChallengeIFEInputSpent.sol)
+
+**PaymentChallengeIFEInputSpent**
+
+## Structs
+### Controller
+
+```js
+struct Controller {
+ contract PlasmaFramework framework,
+ struct IsDeposit.Predicate isDeposit,
+ contract SpendingConditionRegistry spendingConditionRegistry,
+ contract OutputGuardHandlerRegistry outputGuardHandlerRegistry,
+ contract ITxFinalizationVerifier txFinalizationVerifier
+}
+```
+
+### ChallengeIFEData
+
+```js
+struct ChallengeIFEData {
+ struct PaymentChallengeIFEInputSpent.Controller controller,
+ struct PaymentInFlightExitRouterArgs.ChallengeInputSpentArgs args,
+ struct PaymentExitDataModel.InFlightExit ife
+}
+```
+
+**Events**
+
+```js
+event InFlightExitInputBlocked(address indexed challenger, bytes32  txHash, uint16  inputIndex);
+```
+
+## Functions
+
+- [buildController(PlasmaFramework framework, SpendingConditionRegistry spendingConditionRegistry, OutputGuardHandlerRegistry outputGuardHandlerRegistry, ITxFinalizationVerifier txFinalizationVerifier)](#buildcontroller)
+- [run(struct PaymentChallengeIFEInputSpent.Controller self, struct PaymentExitDataModel.InFlightExitMap inFlightExitMap, struct PaymentInFlightExitRouterArgs.ChallengeInputSpentArgs args)](#run)
+- [verifySpentInputEqualsIFEInput(struct PaymentChallengeIFEInputSpent.ChallengeIFEData data)](#verifyspentinputequalsifeinput)
+- [verifyChallengingTransactionProtocolFinalized(struct PaymentChallengeIFEInputSpent.ChallengeIFEData data)](#verifychallengingtransactionprotocolfinalized)
+- [verifySpendingCondition(struct PaymentChallengeIFEInputSpent.ChallengeIFEData data)](#verifyspendingcondition)
+
+### buildController
+
+Function that builds the controller struct
+
+```js
+function buildController(PlasmaFramework framework, SpendingConditionRegistry spendingConditionRegistry, OutputGuardHandlerRegistry outputGuardHandlerRegistry, ITxFinalizationVerifier txFinalizationVerifier) public view
+returns(struct PaymentChallengeIFEInputSpent.Controller)
+```
+
+**Returns**
+
+Controller struct of PaymentChallengeIFEInputSpent
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| framework | PlasmaFramework |  | 
+| spendingConditionRegistry | SpendingConditionRegistry |  | 
+| outputGuardHandlerRegistry | OutputGuardHandlerRegistry |  | 
+| txFinalizationVerifier | ITxFinalizationVerifier |  | 
+
+### run
+
+Main logic implementation for 'challengeInFlightExitInputSpent'
+
+```js
+function run(struct PaymentChallengeIFEInputSpent.Controller self, struct PaymentExitDataModel.InFlightExitMap inFlightExitMap, struct PaymentInFlightExitRouterArgs.ChallengeInputSpentArgs args) public nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct PaymentChallengeIFEInputSpent.Controller | the controller struct | 
+| inFlightExitMap | struct PaymentExitDataModel.InFlightExitMap | the storage of all in-flight exit data | 
+| args | struct PaymentInFlightExitRouterArgs.ChallengeInputSpentArgs | arguments of 'challengeInFlightExitInputSpent' function from client. | 
+
+### verifySpentInputEqualsIFEInput
+
+```js
+function verifySpentInputEqualsIFEInput(struct PaymentChallengeIFEInputSpent.ChallengeIFEData data) private pure
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| data | struct PaymentChallengeIFEInputSpent.ChallengeIFEData |  | 
+
+### verifyChallengingTransactionProtocolFinalized
+
+```js
+function verifyChallengingTransactionProtocolFinalized(struct PaymentChallengeIFEInputSpent.ChallengeIFEData data) private view
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| data | struct PaymentChallengeIFEInputSpent.ChallengeIFEData |  | 
+
+### verifySpendingCondition
+
+```js
+function verifySpendingCondition(struct PaymentChallengeIFEInputSpent.ChallengeIFEData data) private view
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| data | struct PaymentChallengeIFEInputSpent.ChallengeIFEData |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/PaymentChallengeIFENotCanonical.md
+++ b/plasma_framework/docs/PaymentChallengeIFENotCanonical.md
@@ -1,0 +1,198 @@
+# PaymentChallengeIFENotCanonical.sol
+
+View Source: [contracts/src/exits/payment/controllers/PaymentChallengeIFENotCanonical.sol](../contracts/src/exits/payment/controllers/PaymentChallengeIFENotCanonical.sol)
+
+**PaymentChallengeIFENotCanonical**
+
+## Structs
+### Controller
+
+```js
+struct Controller {
+ contract PlasmaFramework framework,
+ struct IsDeposit.Predicate isDeposit,
+ contract SpendingConditionRegistry spendingConditionRegistry,
+ contract OutputGuardHandlerRegistry outputGuardHandlerRegistry,
+ contract ITxFinalizationVerifier txFinalizationVerifier,
+ uint256 supportedTxType
+}
+```
+
+**Events**
+
+```js
+event InFlightExitChallenged(address indexed challenger, bytes32  txHash, uint256  challengeTxPosition);
+event InFlightExitChallengeResponded(address  challenger, bytes32  txHash, uint256  challengeTxPosition);
+```
+
+## Functions
+
+- [buildController(PlasmaFramework framework, SpendingConditionRegistry spendingConditionRegistry, OutputGuardHandlerRegistry outputGuardHandlerRegistry, ITxFinalizationVerifier txFinalizationVerifier, uint256 supportedTxType)](#buildcontroller)
+- [challenge(struct PaymentChallengeIFENotCanonical.Controller self, struct PaymentExitDataModel.InFlightExitMap inFlightExitMap, struct PaymentInFlightExitRouterArgs.ChallengeCanonicityArgs args)](#challenge)
+- [respond(struct PaymentChallengeIFENotCanonical.Controller self, struct PaymentExitDataModel.InFlightExitMap inFlightExitMap, bytes inFlightTx, uint256 inFlightTxPos, bytes inFlightTxInclusionProof)](#respond)
+- [verifyAndDeterminePositionOfTransactionIncludedInBlock(bytes txbytes, struct UtxoPosLib.UtxoPos utxoPos, bytes32 root, bytes inclusionProof)](#verifyanddeterminepositionoftransactionincludedinblock)
+- [verifyCompetingTxFinalized(struct PaymentChallengeIFENotCanonical.Controller self, struct PaymentInFlightExitRouterArgs.ChallengeCanonicityArgs args, struct WireTransaction.Output output)](#verifycompetingtxfinalized)
+
+### buildController
+
+Function that builds the controller struct
+
+```js
+function buildController(PlasmaFramework framework, SpendingConditionRegistry spendingConditionRegistry, OutputGuardHandlerRegistry outputGuardHandlerRegistry, ITxFinalizationVerifier txFinalizationVerifier, uint256 supportedTxType) public view
+returns(struct PaymentChallengeIFENotCanonical.Controller)
+```
+
+**Returns**
+
+Controller struct of PaymentChallengeIFENotCanonical
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| framework | PlasmaFramework |  | 
+| spendingConditionRegistry | SpendingConditionRegistry |  | 
+| outputGuardHandlerRegistry | OutputGuardHandlerRegistry |  | 
+| txFinalizationVerifier | ITxFinalizationVerifier |  | 
+| supportedTxType | uint256 |  | 
+
+### challenge
+
+Main logic implementation for 'challengeInFlightExitNotCanonical'
+
+```js
+function challenge(struct PaymentChallengeIFENotCanonical.Controller self, struct PaymentExitDataModel.InFlightExitMap inFlightExitMap, struct PaymentInFlightExitRouterArgs.ChallengeCanonicityArgs args) public nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct PaymentChallengeIFENotCanonical.Controller | the controller struct | 
+| inFlightExitMap | struct PaymentExitDataModel.InFlightExitMap | the storage of all in-flight exit data | 
+| args | struct PaymentInFlightExitRouterArgs.ChallengeCanonicityArgs | arguments of 'challengeInFlightExitNotCanonical' function from client. | 
+
+### respond
+
+Main logic implementation for 'respondToNonCanonicalChallenge'
+
+```js
+function respond(struct PaymentChallengeIFENotCanonical.Controller self, struct PaymentExitDataModel.InFlightExitMap inFlightExitMap, bytes inFlightTx, uint256 inFlightTxPos, bytes inFlightTxInclusionProof) public nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct PaymentChallengeIFENotCanonical.Controller | the controller struct | 
+| inFlightExitMap | struct PaymentExitDataModel.InFlightExitMap | the storage of all in-flight exit data | 
+| inFlightTx | bytes | the in-flight tx in rlp encoded bytes | 
+| inFlightTxPos | uint256 | the UTXO position of the in-flight exit. Should hardcode 0 for the outputIndex. | 
+| inFlightTxInclusionProof | bytes | inclusion proof for the in-flight tx. | 
+
+### verifyAndDeterminePositionOfTransactionIncludedInBlock
+
+```js
+function verifyAndDeterminePositionOfTransactionIncludedInBlock(bytes txbytes, struct UtxoPosLib.UtxoPos utxoPos, bytes32 root, bytes inclusionProof) private pure
+returns(uint256)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| txbytes | bytes |  | 
+| utxoPos | struct UtxoPosLib.UtxoPos |  | 
+| root | bytes32 |  | 
+| inclusionProof | bytes |  | 
+
+### verifyCompetingTxFinalized
+
+```js
+function verifyCompetingTxFinalized(struct PaymentChallengeIFENotCanonical.Controller self, struct PaymentInFlightExitRouterArgs.ChallengeCanonicityArgs args, struct WireTransaction.Output output) private view
+returns(uint256)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct PaymentChallengeIFENotCanonical.Controller |  | 
+| args | struct PaymentInFlightExitRouterArgs.ChallengeCanonicityArgs |  | 
+| output | struct WireTransaction.Output |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/PaymentChallengeIFEOutputSpent.md
+++ b/plasma_framework/docs/PaymentChallengeIFEOutputSpent.md
@@ -1,0 +1,147 @@
+# PaymentChallengeIFEOutputSpent.sol
+
+View Source: [contracts/src/exits/payment/controllers/PaymentChallengeIFEOutputSpent.sol](../contracts/src/exits/payment/controllers/PaymentChallengeIFEOutputSpent.sol)
+
+**PaymentChallengeIFEOutputSpent**
+
+## Structs
+### Controller
+
+```js
+struct Controller {
+ contract PlasmaFramework framework,
+ contract SpendingConditionRegistry spendingConditionRegistry,
+ contract OutputGuardHandlerRegistry outputGuardHandlerRegistry,
+ contract ITxFinalizationVerifier txFinalizationVerifier
+}
+```
+
+**Events**
+
+```js
+event InFlightExitOutputBlocked(address indexed challenger, bytes32  ifeTxHash, uint16  outputIndex);
+```
+
+## Functions
+
+- [run(struct PaymentChallengeIFEOutputSpent.Controller controller, struct PaymentExitDataModel.InFlightExitMap inFlightExitMap, struct PaymentInFlightExitRouterArgs.ChallengeOutputSpent args)](#run)
+- [verifyInFlightTransactionStandardFinalized(struct PaymentChallengeIFEOutputSpent.Controller controller, struct PaymentInFlightExitRouterArgs.ChallengeOutputSpent args)](#verifyinflighttransactionstandardfinalized)
+- [verifyChallengingTransactionSpendsOutput(struct PaymentChallengeIFEOutputSpent.Controller controller, struct PaymentInFlightExitRouterArgs.ChallengeOutputSpent args)](#verifychallengingtransactionspendsoutput)
+
+### run
+
+Main logic implementation for 'challengeInFlightExitOutputSpent'
+
+```js
+function run(struct PaymentChallengeIFEOutputSpent.Controller controller, struct PaymentExitDataModel.InFlightExitMap inFlightExitMap, struct PaymentInFlightExitRouterArgs.ChallengeOutputSpent args) public nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| controller | struct PaymentChallengeIFEOutputSpent.Controller | the controller struct | 
+| inFlightExitMap | struct PaymentExitDataModel.InFlightExitMap | the storage of all in-flight exit data | 
+| args | struct PaymentInFlightExitRouterArgs.ChallengeOutputSpent | arguments of 'challengeInFlightExitOutputSpent' function from client. | 
+
+### verifyInFlightTransactionStandardFinalized
+
+```js
+function verifyInFlightTransactionStandardFinalized(struct PaymentChallengeIFEOutputSpent.Controller controller, struct PaymentInFlightExitRouterArgs.ChallengeOutputSpent args) private view
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| controller | struct PaymentChallengeIFEOutputSpent.Controller |  | 
+| args | struct PaymentInFlightExitRouterArgs.ChallengeOutputSpent |  | 
+
+### verifyChallengingTransactionSpendsOutput
+
+```js
+function verifyChallengingTransactionSpendsOutput(struct PaymentChallengeIFEOutputSpent.Controller controller, struct PaymentInFlightExitRouterArgs.ChallengeOutputSpent args) private view
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| controller | struct PaymentChallengeIFEOutputSpent.Controller |  | 
+| args | struct PaymentInFlightExitRouterArgs.ChallengeOutputSpent |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/PaymentChallengeStandardExit.md
+++ b/plasma_framework/docs/PaymentChallengeStandardExit.md
@@ -1,0 +1,192 @@
+# PaymentChallengeStandardExit.sol
+
+View Source: [contracts/src/exits/payment/controllers/PaymentChallengeStandardExit.sol](../contracts/src/exits/payment/controllers/PaymentChallengeStandardExit.sol)
+
+**PaymentChallengeStandardExit**
+
+## Structs
+### Controller
+
+```js
+struct Controller {
+ contract PlasmaFramework framework,
+ struct IsDeposit.Predicate isDeposit,
+ contract SpendingConditionRegistry spendingConditionRegistry,
+ contract OutputGuardHandlerRegistry outputGuardHandlerRegistry,
+ contract ITxFinalizationVerifier txFinalizationVerifier
+}
+```
+
+### ChallengeStandardExitData
+
+```js
+struct ChallengeStandardExitData {
+ struct PaymentChallengeStandardExit.Controller controller,
+ struct PaymentStandardExitRouterArgs.ChallengeStandardExitArgs args,
+ struct PaymentExitDataModel.StandardExit exitData
+}
+```
+
+**Events**
+
+```js
+event ExitChallenged(uint256 indexed utxoPos);
+```
+
+## Functions
+
+- [buildController(PlasmaFramework framework, SpendingConditionRegistry spendingConditionRegistry, OutputGuardHandlerRegistry outputGuardHandlerRegistry, ITxFinalizationVerifier txFinalizationVerifier)](#buildcontroller)
+- [run(struct PaymentChallengeStandardExit.Controller self, struct PaymentExitDataModel.StandardExitMap exitMap, struct PaymentStandardExitRouterArgs.ChallengeStandardExitArgs args)](#run)
+- [verifyChallengeExitExists(struct PaymentChallengeStandardExit.ChallengeStandardExitData data)](#verifychallengeexitexists)
+- [verifyChallengeTxProtocolFinalized(struct PaymentChallengeStandardExit.ChallengeStandardExitData data)](#verifychallengetxprotocolfinalized)
+- [verifySpendingCondition(struct PaymentChallengeStandardExit.ChallengeStandardExitData data)](#verifyspendingcondition)
+
+### buildController
+
+Function that builds the controller struct
+
+```js
+function buildController(PlasmaFramework framework, SpendingConditionRegistry spendingConditionRegistry, OutputGuardHandlerRegistry outputGuardHandlerRegistry, ITxFinalizationVerifier txFinalizationVerifier) public view
+returns(struct PaymentChallengeStandardExit.Controller)
+```
+
+**Returns**
+
+Controller struct of PaymentChallengeStandardExit
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| framework | PlasmaFramework |  | 
+| spendingConditionRegistry | SpendingConditionRegistry |  | 
+| outputGuardHandlerRegistry | OutputGuardHandlerRegistry |  | 
+| txFinalizationVerifier | ITxFinalizationVerifier |  | 
+
+### run
+
+Main logic function to challenge standard exit
+
+```js
+function run(struct PaymentChallengeStandardExit.Controller self, struct PaymentExitDataModel.StandardExitMap exitMap, struct PaymentStandardExitRouterArgs.ChallengeStandardExitArgs args) public nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct PaymentChallengeStandardExit.Controller | the controller struct | 
+| exitMap | struct PaymentExitDataModel.StandardExitMap | the storage of all standard exit data | 
+| args | struct PaymentStandardExitRouterArgs.ChallengeStandardExitArgs | arguments of challenge standard exit function from client. | 
+
+### verifyChallengeExitExists
+
+```js
+function verifyChallengeExitExists(struct PaymentChallengeStandardExit.ChallengeStandardExitData data) private pure
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| data | struct PaymentChallengeStandardExit.ChallengeStandardExitData |  | 
+
+### verifyChallengeTxProtocolFinalized
+
+```js
+function verifyChallengeTxProtocolFinalized(struct PaymentChallengeStandardExit.ChallengeStandardExitData data) private view
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| data | struct PaymentChallengeStandardExit.ChallengeStandardExitData |  | 
+
+### verifySpendingCondition
+
+```js
+function verifySpendingCondition(struct PaymentChallengeStandardExit.ChallengeStandardExitData data) private view
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| data | struct PaymentChallengeStandardExit.ChallengeStandardExitData |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/PaymentEip712Lib.md
+++ b/plasma_framework/docs/PaymentEip712Lib.md
@@ -1,0 +1,187 @@
+# PaymentEip712Lib (PaymentEip712Lib.sol)
+
+View Source: [contracts/src/transactions/eip712Libs/PaymentEip712Lib.sol](../contracts/src/transactions/eip712Libs/PaymentEip712Lib.sol)
+
+**PaymentEip712Lib**
+
+Utilities for hashing structural data for PaymentTransaction, see EIP-712.
+ *
+
+## Structs
+### Constants
+
+```js
+struct Constants {
+ bytes32 DOMAIN_SEPARATOR
+}
+```
+
+## Contract Members
+**Constants & Variables**
+
+```js
+//public members
+uint8 public constant MAX_INPUT_NUM;
+uint8 public constant MAX_OUTPUT_NUM;
+
+//internal members
+bytes2 internal constant EIP191_PREFIX;
+bytes32 internal constant EIP712_DOMAIN_HASH;
+bytes32 internal constant TX_TYPE_HASH;
+bytes32 internal constant INPUT_TYPE_HASH;
+bytes32 internal constant OUTPUT_TYPE_HASH;
+bytes32 internal constant SALT;
+bytes32 internal constant EMPTY_INPUT_HASH;
+bytes32 internal constant EMPTY_OUTPUT_HASH;
+
+```
+
+## Functions
+
+- [initConstants(address _verifyingContract)](#initconstants)
+- [hashTx(struct PaymentEip712Lib.Constants _eip712, struct PaymentTransactionModel.Transaction _tx)](#hashtx)
+- [_hashTx(struct PaymentTransactionModel.Transaction _tx)](#_hashtx)
+- [_hashInput(bytes32 _input)](#_hashinput)
+- [_hashOutput(struct PaymentOutputModel.Output _output)](#_hashoutput)
+
+### initConstants
+
+```js
+function initConstants(address _verifyingContract) internal pure
+returns(struct PaymentEip712Lib.Constants)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _verifyingContract | address |  | 
+
+### hashTx
+
+```js
+function hashTx(struct PaymentEip712Lib.Constants _eip712, struct PaymentTransactionModel.Transaction _tx) internal pure
+returns(bytes32)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _eip712 | struct PaymentEip712Lib.Constants |  | 
+| _tx | struct PaymentTransactionModel.Transaction |  | 
+
+### _hashTx
+
+```js
+function _hashTx(struct PaymentTransactionModel.Transaction _tx) private pure
+returns(bytes32)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _tx | struct PaymentTransactionModel.Transaction |  | 
+
+### _hashInput
+
+```js
+function _hashInput(bytes32 _input) private pure
+returns(bytes32)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _input | bytes32 |  | 
+
+### _hashOutput
+
+```js
+function _hashOutput(struct PaymentOutputModel.Output _output) private pure
+returns(bytes32)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _output | struct PaymentOutputModel.Output |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/PaymentExitDataModel.md
+++ b/plasma_framework/docs/PaymentExitDataModel.md
@@ -1,0 +1,152 @@
+# PaymentExitDataModel.sol
+
+View Source: [contracts/src/exits/payment/PaymentExitDataModel.sol](../contracts/src/exits/payment/PaymentExitDataModel.sol)
+
+**PaymentExitDataModel**
+
+Model library for PaymentExit
+
+## Structs
+### StandardExit
+
+```js
+struct StandardExit {
+ bool exitable,
+ uint192 utxoPos,
+ bytes32 outputId,
+ address payable exitTarget,
+ uint256 amount,
+ uint256 bondSize
+}
+```
+
+### StandardExitMap
+
+```js
+struct StandardExitMap {
+ mapping(uint192 => struct PaymentExitDataModel.StandardExit) exits
+}
+```
+
+### WithdrawData
+
+```js
+struct WithdrawData {
+ bytes32 outputId,
+ address payable exitTarget,
+ address token,
+ uint256 amount,
+ uint256 piggybackBondSize
+}
+```
+
+### InFlightExit
+
+```js
+struct InFlightExit {
+ bool isCanonical,
+ uint64 exitStartTimestamp,
+ uint256 exitMap,
+ uint256 position,
+ struct PaymentExitDataModel.WithdrawData[4] inputs,
+ struct PaymentExitDataModel.WithdrawData[4] outputs,
+ address payable bondOwner,
+ uint256 bondSize,
+ uint256 oldestCompetitorPosition
+}
+```
+
+### InFlightExitMap
+
+```js
+struct InFlightExitMap {
+ mapping(uint160 => struct PaymentExitDataModel.InFlightExit) exits
+}
+```
+
+## Contract Members
+**Constants & Variables**
+
+```js
+uint8 public constant MAX_INPUT_NUM;
+uint8 public constant MAX_OUTPUT_NUM;
+
+```
+
+## Functions
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/PaymentExitGame.md
+++ b/plasma_framework/docs/PaymentExitGame.md
@@ -1,0 +1,168 @@
+# PaymentExitGame.sol
+
+View Source: [contracts/src/exits/payment/PaymentExitGame.sol](../contracts/src/exits/payment/PaymentExitGame.sol)
+
+**↗ Extends: [IExitProcessor](IExitProcessor.md), [PaymentStandardExitRouter](PaymentStandardExitRouter.md), [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md), [OnlyFromAddress](OnlyFromAddress.md)**
+
+**PaymentExitGame**
+
+The exit game contract implementation for Payment Transaction
+
+## Contract Members
+**Constants & Variables**
+
+```js
+contract PlasmaFramework private plasmaFramework;
+
+```
+
+## Functions
+
+- [(PlasmaFramework framework, EthVault ethVault, Erc20Vault erc20Vault, OutputGuardHandlerRegistry outputGuardHandlerRegistry, SpendingConditionRegistry spendingConditionRegistry, IStateTransitionVerifier stateTransitionVerifier, ITxFinalizationVerifier txFinalizationVerifier, uint256 supportTxType)](#)
+- [processExit(uint160 exitId, address token)](#processexit)
+- [getStandardExitId(bool _isDeposit, bytes _txBytes, uint256 _utxoPos)](#getstandardexitid)
+- [getInFlightExitId(bytes _txBytes)](#getinflightexitid)
+
+### 
+
+```js
+function (PlasmaFramework framework, EthVault ethVault, Erc20Vault erc20Vault, OutputGuardHandlerRegistry outputGuardHandlerRegistry, SpendingConditionRegistry spendingConditionRegistry, IStateTransitionVerifier stateTransitionVerifier, ITxFinalizationVerifier txFinalizationVerifier, uint256 supportTxType) public nonpayable PaymentStandardExitRouter PaymentInFlightExitRouter 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| framework | PlasmaFramework |  | 
+| ethVault | EthVault |  | 
+| erc20Vault | Erc20Vault |  | 
+| outputGuardHandlerRegistry | OutputGuardHandlerRegistry |  | 
+| spendingConditionRegistry | SpendingConditionRegistry |  | 
+| stateTransitionVerifier | IStateTransitionVerifier |  | 
+| txFinalizationVerifier | ITxFinalizationVerifier |  | 
+| supportTxType | uint256 |  | 
+
+### processExit
+
+⤾ overrides [IExitProcessor.processExit](IExitProcessor.md#processexit)
+
+Callback processes exit function for the PlasmaFramework to call.
+
+```js
+function processExit(uint160 exitId, address token) external nonpayable onlyFrom 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| exitId | uint160 | The exit id. | 
+| token | address | The token (ERC20 address or address(0) for ETH) of the exiting output. | 
+
+### getStandardExitId
+
+Helper function to compute standard exit id.
+
+```js
+function getStandardExitId(bool _isDeposit, bytes _txBytes, uint256 _utxoPos) public pure
+returns(uint192)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _isDeposit | bool |  | 
+| _txBytes | bytes |  | 
+| _utxoPos | uint256 |  | 
+
+### getInFlightExitId
+
+Helper function to compute in-flight exit id.
+
+```js
+function getInFlightExitId(bytes _txBytes) public pure
+returns(uint192)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _txBytes | bytes |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/PaymentInFlightExitModelUtils.md
+++ b/plasma_framework/docs/PaymentInFlightExitModelUtils.md
@@ -1,0 +1,223 @@
+# PaymentInFlightExitModelUtils.sol
+
+View Source: [contracts/src/exits/payment/PaymentInFlightExitModelUtils.sol](../contracts/src/exits/payment/PaymentInFlightExitModelUtils.sol)
+
+**PaymentInFlightExitModelUtils**
+
+## Contract Members
+**Constants & Variables**
+
+```js
+uint8 public constant MAX_INPUT_NUM;
+uint8 public constant MAX_OUTPUT_NUM;
+
+```
+
+## Functions
+
+- [isInputPiggybacked(struct PaymentExitDataModel.InFlightExit ife, uint16 index)](#isinputpiggybacked)
+- [isOutputPiggybacked(struct PaymentExitDataModel.InFlightExit ife, uint16 index)](#isoutputpiggybacked)
+- [setInputPiggybacked(struct PaymentExitDataModel.InFlightExit ife, uint16 index)](#setinputpiggybacked)
+- [clearInputPiggybacked(struct PaymentExitDataModel.InFlightExit ife, uint16 index)](#clearinputpiggybacked)
+- [clearOutputPiggyback(struct PaymentExitDataModel.InFlightExit ife, uint16 index)](#clearoutputpiggyback)
+- [setOutputPiggybacked(struct PaymentExitDataModel.InFlightExit ife, uint16 index)](#setoutputpiggybacked)
+- [clearOutputPiggybacked(struct PaymentExitDataModel.InFlightExit ife, uint16 index)](#clearoutputpiggybacked)
+- [isInFirstPhase(struct PaymentExitDataModel.InFlightExit ife, uint256 minExitPeriod)](#isinfirstphase)
+- [isFirstPiggybackOfTheToken(struct PaymentExitDataModel.InFlightExit ife, address token)](#isfirstpiggybackofthetoken)
+
+### isInputPiggybacked
+
+```js
+function isInputPiggybacked(struct PaymentExitDataModel.InFlightExit ife, uint16 index) internal pure
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| ife | struct PaymentExitDataModel.InFlightExit |  | 
+| index | uint16 |  | 
+
+### isOutputPiggybacked
+
+```js
+function isOutputPiggybacked(struct PaymentExitDataModel.InFlightExit ife, uint16 index) internal pure
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| ife | struct PaymentExitDataModel.InFlightExit |  | 
+| index | uint16 |  | 
+
+### setInputPiggybacked
+
+```js
+function setInputPiggybacked(struct PaymentExitDataModel.InFlightExit ife, uint16 index) internal nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| ife | struct PaymentExitDataModel.InFlightExit |  | 
+| index | uint16 |  | 
+
+### clearInputPiggybacked
+
+```js
+function clearInputPiggybacked(struct PaymentExitDataModel.InFlightExit ife, uint16 index) internal nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| ife | struct PaymentExitDataModel.InFlightExit |  | 
+| index | uint16 |  | 
+
+### clearOutputPiggyback
+
+```js
+function clearOutputPiggyback(struct PaymentExitDataModel.InFlightExit ife, uint16 index) internal nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| ife | struct PaymentExitDataModel.InFlightExit |  | 
+| index | uint16 |  | 
+
+### setOutputPiggybacked
+
+```js
+function setOutputPiggybacked(struct PaymentExitDataModel.InFlightExit ife, uint16 index) internal nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| ife | struct PaymentExitDataModel.InFlightExit |  | 
+| index | uint16 |  | 
+
+### clearOutputPiggybacked
+
+```js
+function clearOutputPiggybacked(struct PaymentExitDataModel.InFlightExit ife, uint16 index) internal nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| ife | struct PaymentExitDataModel.InFlightExit |  | 
+| index | uint16 |  | 
+
+### isInFirstPhase
+
+```js
+function isInFirstPhase(struct PaymentExitDataModel.InFlightExit ife, uint256 minExitPeriod) internal view
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| ife | struct PaymentExitDataModel.InFlightExit |  | 
+| minExitPeriod | uint256 |  | 
+
+### isFirstPiggybackOfTheToken
+
+```js
+function isFirstPiggybackOfTheToken(struct PaymentExitDataModel.InFlightExit ife, address token) internal pure
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| ife | struct PaymentExitDataModel.InFlightExit |  | 
+| token | address |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/PaymentInFlightExitRouter.md
+++ b/plasma_framework/docs/PaymentInFlightExitRouter.md
@@ -1,0 +1,336 @@
+# PaymentInFlightExitRouter.sol
+
+View Source: [contracts/src/exits/payment/routers/PaymentInFlightExitRouter.sol](../contracts/src/exits/payment/routers/PaymentInFlightExitRouter.sol)
+
+**↗ Extends: [IExitProcessor](IExitProcessor.md), [Operated](Operated.md), [OnlyWithValue](OnlyWithValue.md)**
+**↘ Derived Contracts: [PaymentExitGame](PaymentExitGame.md)**
+
+**PaymentInFlightExitRouter**
+
+## Contract Members
+**Constants & Variables**
+
+```js
+//public members
+uint128 public constant INITIAL_IFE_BOND_SIZE;
+uint128 public constant INITIAL_PB_BOND_SIZE;
+uint16 public constant BOND_LOWER_BOUND_DIVISOR;
+uint16 public constant BOND_UPPER_BOUND_MULTIPLIER;
+
+//internal members
+struct PaymentExitDataModel.InFlightExitMap internal inFlightExitMap;
+struct PaymentStartInFlightExit.Controller internal startInFlightExitController;
+struct PaymentPiggybackInFlightExit.Controller internal piggybackInFlightExitController;
+struct PaymentChallengeIFENotCanonical.Controller internal challengeCanonicityController;
+struct PaymentChallengeIFEInputSpent.Controller internal challengeInputSpentController;
+struct PaymentProcessInFlightExit.Controller internal processInflightExitController;
+struct PaymentChallengeIFEOutputSpent.Controller internal challengeOutputSpentController;
+struct BondSize.Params internal startIFEBond;
+struct BondSize.Params internal piggybackBond;
+
+```
+
+**Events**
+
+```js
+event IFEBondUpdated(uint128  bondSize);
+event PiggybackBondUpdated(uint128  bondSize);
+```
+
+## Functions
+
+- [(PlasmaFramework framework, EthVault ethVault, Erc20Vault erc20Vault, OutputGuardHandlerRegistry outputGuardHandlerRegistry, SpendingConditionRegistry spendingConditionRegistry, IStateTransitionVerifier stateTransitionVerifier, ITxFinalizationVerifier txFinalizationVerifier, uint256 supportedTxType)](#)
+- [inFlightExits(uint160 exitId)](#inflightexits)
+- [startInFlightExit(struct PaymentInFlightExitRouterArgs.StartExitArgs args)](#startinflightexit)
+- [piggybackInFlightExitOnInput(struct PaymentInFlightExitRouterArgs.PiggybackInFlightExitOnInputArgs args)](#piggybackinflightexitoninput)
+- [piggybackInFlightExitOnOutput(struct PaymentInFlightExitRouterArgs.PiggybackInFlightExitOnOutputArgs args)](#piggybackinflightexitonoutput)
+- [challengeInFlightExitNotCanonical(struct PaymentInFlightExitRouterArgs.ChallengeCanonicityArgs args)](#challengeinflightexitnotcanonical)
+- [respondToNonCanonicalChallenge(bytes inFlightTx, uint256 inFlightTxPos, bytes inFlightTxInclusionProof)](#respondtononcanonicalchallenge)
+- [challengeInFlightExitInputSpent(struct PaymentInFlightExitRouterArgs.ChallengeInputSpentArgs args)](#challengeinflightexitinputspent)
+- [challengeInFlightExitOutputSpent(struct PaymentInFlightExitRouterArgs.ChallengeOutputSpent args)](#challengeinflightexitoutputspent)
+- [processInFlightExit(uint160 exitId, address token)](#processinflightexit)
+- [startIFEBondSize()](#startifebondsize)
+- [updateStartIFEBondSize(uint128 newBondSize)](#updatestartifebondsize)
+- [piggybackBondSize()](#piggybackbondsize)
+- [updatePiggybackBondSize(uint128 newBondSize)](#updatepiggybackbondsize)
+
+### 
+
+```js
+function (PlasmaFramework framework, EthVault ethVault, Erc20Vault erc20Vault, OutputGuardHandlerRegistry outputGuardHandlerRegistry, SpendingConditionRegistry spendingConditionRegistry, IStateTransitionVerifier stateTransitionVerifier, ITxFinalizationVerifier txFinalizationVerifier, uint256 supportedTxType) public nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| framework | PlasmaFramework |  | 
+| ethVault | EthVault |  | 
+| erc20Vault | Erc20Vault |  | 
+| outputGuardHandlerRegistry | OutputGuardHandlerRegistry |  | 
+| spendingConditionRegistry | SpendingConditionRegistry |  | 
+| stateTransitionVerifier | IStateTransitionVerifier |  | 
+| txFinalizationVerifier | ITxFinalizationVerifier |  | 
+| supportedTxType | uint256 |  | 
+
+### inFlightExits
+
+Getter functions to retrieve in-flight exit data of the PaymentExitGame.
+
+```js
+function inFlightExits(uint160 exitId) public view
+returns(struct PaymentExitDataModel.InFlightExit)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| exitId | uint160 | the exit id of the in-flight exit | 
+
+### startInFlightExit
+
+Starts withdrawal from a transaction that might be in-flight.
+
+```js
+function startInFlightExit(struct PaymentInFlightExitRouterArgs.StartExitArgs args) public payable onlyWithValue 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| args | struct PaymentInFlightExitRouterArgs.StartExitArgs | input argument data to challenge. See struct 'StartExitArgs' for detailed info. | 
+
+### piggybackInFlightExitOnInput
+
+Piggyback on an input of an in-flight exiting tx. Would be processed if the in-flight exit is non-canonical.
+
+```js
+function piggybackInFlightExitOnInput(struct PaymentInFlightExitRouterArgs.PiggybackInFlightExitOnInputArgs args) public payable onlyWithValue 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| args | struct PaymentInFlightExitRouterArgs.PiggybackInFlightExitOnInputArgs | input argument data to piggyback. See struct 'PiggybackInFlightExitOnInputArgs' for detailed info. | 
+
+### piggybackInFlightExitOnOutput
+
+Piggyback on an output of an in-flight exiting tx. Would be processed if the in-flight exit is canonical.
+
+```js
+function piggybackInFlightExitOnOutput(struct PaymentInFlightExitRouterArgs.PiggybackInFlightExitOnOutputArgs args) public payable onlyWithValue 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| args | struct PaymentInFlightExitRouterArgs.PiggybackInFlightExitOnOutputArgs | input argument data to piggyback. See struct 'PiggybackInFlightExitOnOutputArgs' for detailed info. | 
+
+### challengeInFlightExitNotCanonical
+
+Challenges an in-flight exit to be non canonical.
+
+```js
+function challengeInFlightExitNotCanonical(struct PaymentInFlightExitRouterArgs.ChallengeCanonicityArgs args) public nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| args | struct PaymentInFlightExitRouterArgs.ChallengeCanonicityArgs | input argument data to challenge. See struct 'ChallengeCanonicityArgs' for detailed info. | 
+
+### respondToNonCanonicalChallenge
+
+Respond to a non canonical challenge by providing position and proving the correctness of it.
+
+```js
+function respondToNonCanonicalChallenge(bytes inFlightTx, uint256 inFlightTxPos, bytes inFlightTxInclusionProof) public nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| inFlightTx | bytes | the rlp encoded in-flight transaction. | 
+| inFlightTxPos | uint256 | the UTXO position of the in-flight exit. The outputIndex should be set to 0. | 
+| inFlightTxInclusionProof | bytes | inclusion proof for the in-flight tx. | 
+
+### challengeInFlightExitInputSpent
+
+Challenges an exit from in-flight transaction input.
+
+```js
+function challengeInFlightExitInputSpent(struct PaymentInFlightExitRouterArgs.ChallengeInputSpentArgs args) public nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| args | struct PaymentInFlightExitRouterArgs.ChallengeInputSpentArgs | argument data to challenge. See struct 'ChallengeInputSpentArgs' for detailed info. | 
+
+### challengeInFlightExitOutputSpent
+
+Challenges an exit from in-flight transaction output.
+
+```js
+function challengeInFlightExitOutputSpent(struct PaymentInFlightExitRouterArgs.ChallengeOutputSpent args) public nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| args | struct PaymentInFlightExitRouterArgs.ChallengeOutputSpent | argument data to challenge. See struct 'ChallengeOutputSpent' for detailed info. | 
+
+### processInFlightExit
+
+Process in-flight exit.
+
+```js
+function processInFlightExit(uint160 exitId, address token) internal nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| exitId | uint160 | The in-flight exit id. | 
+| token | address | The token (in erc20 address or address(0) for ETH) of the exiting output. | 
+
+### startIFEBondSize
+
+Gets the in-flight exit bond size.
+
+```js
+function startIFEBondSize() public view
+returns(uint128)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+
+### updateStartIFEBondSize
+
+Updates the in-flight exit bond size. Will take 2 days to come into effect.
+
+```js
+function updateStartIFEBondSize(uint128 newBondSize) public nonpayable onlyOperator 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| newBondSize | uint128 | The new bond size. | 
+
+### piggybackBondSize
+
+Gets the piggyback bond size.
+
+```js
+function piggybackBondSize() public view
+returns(uint128)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+
+### updatePiggybackBondSize
+
+Updates the piggyback bond size. Will take 2 days to come into effect.
+
+```js
+function updatePiggybackBondSize(uint128 newBondSize) public nonpayable onlyOperator 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| newBondSize | uint128 | The new bond size. | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/PaymentInFlightExitRouterArgs.md
+++ b/plasma_framework/docs/PaymentInFlightExitRouterArgs.md
@@ -1,0 +1,167 @@
+# PaymentInFlightExitRouterArgs.sol
+
+View Source: [contracts/src/exits/payment/routers/PaymentInFlightExitRouterArgs.sol](../contracts/src/exits/payment/routers/PaymentInFlightExitRouterArgs.sol)
+
+**PaymentInFlightExitRouterArgs**
+
+## Structs
+### StartExitArgs
+
+```js
+struct StartExitArgs {
+ bytes inFlightTx,
+ bytes[] inputTxs,
+ uint256[] inputTxTypes,
+ uint256[] inputUtxosPos,
+ bytes[] outputGuardPreimagesForInputs,
+ bytes[] inputTxsInclusionProofs,
+ bytes[] inputTxsConfirmSigs,
+ bytes[] inFlightTxWitnesses,
+ bytes[] inputSpendingConditionOptionalArgs
+}
+```
+
+### PiggybackInFlightExitOnInputArgs
+
+```js
+struct PiggybackInFlightExitOnInputArgs {
+ bytes inFlightTx,
+ uint16 inputIndex
+}
+```
+
+### PiggybackInFlightExitOnOutputArgs
+
+```js
+struct PiggybackInFlightExitOnOutputArgs {
+ bytes inFlightTx,
+ uint16 outputIndex,
+ bytes outputGuardPreimage
+}
+```
+
+### ChallengeCanonicityArgs
+
+```js
+struct ChallengeCanonicityArgs {
+ bytes inputTx,
+ uint256 inputUtxoPos,
+ bytes inFlightTx,
+ uint16 inFlightTxInputIndex,
+ bytes competingTx,
+ uint16 competingTxInputIndex,
+ bytes outputGuardPreimage,
+ uint256 competingTxPos,
+ bytes competingTxInclusionProof,
+ bytes competingTxWitness,
+ bytes competingTxConfirmSig,
+ bytes competingTxSpendingConditionOptionalArgs
+}
+```
+
+### ChallengeInputSpentArgs
+
+```js
+struct ChallengeInputSpentArgs {
+ bytes inFlightTx,
+ uint16 inFlightTxInputIndex,
+ bytes challengingTx,
+ uint16 challengingTxInputIndex,
+ bytes challengingTxWitness,
+ bytes inputTx,
+ uint256 inputUtxoPos,
+ bytes spendingConditionOptionalArgs
+}
+```
+
+### ChallengeOutputSpent
+
+```js
+struct ChallengeOutputSpent {
+ bytes inFlightTx,
+ bytes inFlightTxInclusionProof,
+ uint256 outputUtxoPos,
+ bytes challengingTx,
+ uint16 challengingTxInputIndex,
+ bytes challengingTxWitness,
+ bytes spendingConditionOptionalArgs
+}
+```
+
+## Functions
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/PaymentOutputGuardHandler.md
+++ b/plasma_framework/docs/PaymentOutputGuardHandler.md
@@ -1,0 +1,134 @@
+# PaymentOutputGuardHandler.sol
+
+View Source: [contracts/src/exits/payment/outputGuardHandlers/PaymentOutputGuardHandler.sol](../contracts/src/exits/payment/outputGuardHandlers/PaymentOutputGuardHandler.sol)
+
+**↗ Extends: [IOutputGuardHandler](IOutputGuardHandler.md)**
+
+**PaymentOutputGuardHandler**
+
+## Functions
+
+- [isValid(struct OutputGuardModel.Data data)](#isvalid)
+- [getExitTarget(struct OutputGuardModel.Data data)](#getexittarget)
+- [getConfirmSigAddress(struct OutputGuardModel.Data )](#getconfirmsigaddress)
+
+### isValid
+
+⤾ overrides [IOutputGuardHandler.isValid](IOutputGuardHandler.md#isvalid)
+
+```js
+function isValid(struct OutputGuardModel.Data data) public view
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| data | struct OutputGuardModel.Data |  | 
+
+### getExitTarget
+
+⤾ overrides [IOutputGuardHandler.getExitTarget](IOutputGuardHandler.md#getexittarget)
+
+```js
+function getExitTarget(struct OutputGuardModel.Data data) external view
+returns(address payable)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| data | struct OutputGuardModel.Data |  | 
+
+### getConfirmSigAddress
+
+⤾ overrides [IOutputGuardHandler.getConfirmSigAddress](IOutputGuardHandler.md#getconfirmsigaddress)
+
+```js
+function getConfirmSigAddress(struct OutputGuardModel.Data ) external view
+returns(address)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+|  | struct OutputGuardModel.Data |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/PaymentOutputModel.md
+++ b/plasma_framework/docs/PaymentOutputModel.md
@@ -1,0 +1,129 @@
+# PaymentOutputModel.sol
+
+View Source: [contracts/src/transactions/outputs/PaymentOutputModel.sol](../contracts/src/transactions/outputs/PaymentOutputModel.sol)
+
+**PaymentOutputModel**
+
+Data structure and its decode function for Payment output
+
+## Structs
+### Output
+
+```js
+struct Output {
+ uint256 outputType,
+ bytes20 outputGuard,
+ address token,
+ uint256 amount
+}
+```
+
+## Functions
+
+- [owner(struct PaymentOutputModel.Output _output)](#owner)
+- [decode(struct RLP.RLPItem encoded)](#decode)
+
+### owner
+
+Get the 'owner' from the output with the assumption of
+        'outputGuard' field directly holding owner's address.
+
+```js
+function owner(struct PaymentOutputModel.Output _output) internal pure
+returns(address payable)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _output | struct PaymentOutputModel.Output |  | 
+
+### decode
+
+```js
+function decode(struct RLP.RLPItem encoded) internal pure
+returns(struct PaymentOutputModel.Output)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| encoded | struct RLP.RLPItem |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/PaymentOutputToPaymentTxCondition.md
+++ b/plasma_framework/docs/PaymentOutputToPaymentTxCondition.md
@@ -1,0 +1,138 @@
+# PaymentOutputToPaymentTxCondition.sol
+
+View Source: [contracts/src/exits/payment/spendingConditions/PaymentOutputToPaymentTxCondition.sol](../contracts/src/exits/payment/spendingConditions/PaymentOutputToPaymentTxCondition.sol)
+
+**↗ Extends: [ISpendingCondition](ISpendingCondition.md)**
+
+**PaymentOutputToPaymentTxCondition**
+
+## Contract Members
+**Constants & Variables**
+
+```js
+uint256 internal supportInputTxType;
+uint256 internal supportSpendingTxType;
+struct PaymentEip712Lib.Constants internal eip712;
+
+```
+
+## Functions
+
+- [(address framework, uint256 inputTxType, uint256 spendingTxType)](#)
+- [verify(bytes inputTxBytes, uint16 outputIndex, uint256 inputTxPos, bytes spendingTxBytes, uint16 inputIndex, bytes signature, bytes )](#verify)
+
+### 
+
+This is designed to be re-useable for all versions of Payment transaction.
+     As a result, inputTxType and spendingTxType of the Payment output is injected instead.
+
+```js
+function (address framework, uint256 inputTxType, uint256 spendingTxType) public nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| framework | address |  | 
+| inputTxType | uint256 |  | 
+| spendingTxType | uint256 |  | 
+
+### verify
+
+⤾ overrides [ISpendingCondition.verify](ISpendingCondition.md#verify)
+
+Verifies the spending condition
+
+```js
+function verify(bytes inputTxBytes, uint16 outputIndex, uint256 inputTxPos, bytes spendingTxBytes, uint16 inputIndex, bytes signature, bytes ) external view
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| inputTxBytes | bytes | encoded input transaction in bytes | 
+| outputIndex | uint16 | the output index of the input transaction | 
+| inputTxPos | uint256 | the tx position of the input tx. (0 if in-flight) | 
+| spendingTxBytes | bytes | spending transaction in bytes | 
+| inputIndex | uint16 | the input index of the spending tx that points to the output | 
+| signature | bytes | signature of the output owner | 
+|  | bytes | inputTxBytes encoded input transaction in bytes | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/PaymentPiggybackInFlightExit.md
+++ b/plasma_framework/docs/PaymentPiggybackInFlightExit.md
@@ -1,0 +1,203 @@
+# PaymentPiggybackInFlightExit.sol
+
+View Source: [contracts/src/exits/payment/controllers/PaymentPiggybackInFlightExit.sol](../contracts/src/exits/payment/controllers/PaymentPiggybackInFlightExit.sol)
+
+**PaymentPiggybackInFlightExit**
+
+## Structs
+### Controller
+
+```js
+struct Controller {
+ contract PlasmaFramework framework,
+ struct IsDeposit.Predicate isDeposit,
+ struct ExitableTimestamp.Calculator exitableTimestampCalculator,
+ contract IExitProcessor exitProcessor,
+ contract OutputGuardHandlerRegistry outputGuardHandlerRegistry,
+ uint256 minExitPeriod
+}
+```
+
+## Contract Members
+**Constants & Variables**
+
+```js
+uint8 public constant MAX_INPUT_NUM;
+uint8 public constant MAX_OUTPUT_NUM;
+
+```
+
+**Events**
+
+```js
+event InFlightExitInputPiggybacked(address indexed exitTarget, bytes32  txHash, uint16  inputIndex);
+event InFlightExitOutputPiggybacked(address indexed exitTarget, bytes32  txHash, uint16  outputIndex);
+```
+
+## Functions
+
+- [buildController(PlasmaFramework framework, IExitProcessor exitProcessor, OutputGuardHandlerRegistry outputGuardHandlerRegistry)](#buildcontroller)
+- [piggybackInput(struct PaymentPiggybackInFlightExit.Controller self, struct PaymentExitDataModel.InFlightExitMap inFlightExitMap, struct PaymentInFlightExitRouterArgs.PiggybackInFlightExitOnInputArgs args)](#piggybackinput)
+- [piggybackOutput(struct PaymentPiggybackInFlightExit.Controller self, struct PaymentExitDataModel.InFlightExitMap inFlightExitMap, struct PaymentInFlightExitRouterArgs.PiggybackInFlightExitOnOutputArgs args)](#piggybackoutput)
+- [enqueue(struct PaymentPiggybackInFlightExit.Controller controller, address token, struct UtxoPosLib.UtxoPos utxoPos, uint160 exitId)](#enqueue)
+- [getExitTargetOfOutput(struct PaymentPiggybackInFlightExit.Controller controller, bytes20 outputGuard, uint256 outputType, bytes outputGuardPreimage)](#getexittargetofoutput)
+
+### buildController
+
+Function that builds the controller struct
+
+```js
+function buildController(PlasmaFramework framework, IExitProcessor exitProcessor, OutputGuardHandlerRegistry outputGuardHandlerRegistry) public view
+returns(struct PaymentPiggybackInFlightExit.Controller)
+```
+
+**Returns**
+
+Controller struct of PaymentPiggybackInFlightExit
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| framework | PlasmaFramework |  | 
+| exitProcessor | IExitProcessor |  | 
+| outputGuardHandlerRegistry | OutputGuardHandlerRegistry |  | 
+
+### piggybackInput
+
+The main controller logic for 'piggybackInFlightExitOnInput'
+
+```js
+function piggybackInput(struct PaymentPiggybackInFlightExit.Controller self, struct PaymentExitDataModel.InFlightExitMap inFlightExitMap, struct PaymentInFlightExitRouterArgs.PiggybackInFlightExitOnInputArgs args) public nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct PaymentPiggybackInFlightExit.Controller | the controller struct | 
+| inFlightExitMap | struct PaymentExitDataModel.InFlightExitMap | the storage of all in-flight exit data | 
+| args | struct PaymentInFlightExitRouterArgs.PiggybackInFlightExitOnInputArgs | arguments of 'piggybackInFlightExitOnInput' function from client. | 
+
+### piggybackOutput
+
+The main controller logic for 'piggybackInFlightExitOnOutput'
+
+```js
+function piggybackOutput(struct PaymentPiggybackInFlightExit.Controller self, struct PaymentExitDataModel.InFlightExitMap inFlightExitMap, struct PaymentInFlightExitRouterArgs.PiggybackInFlightExitOnOutputArgs args) public nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct PaymentPiggybackInFlightExit.Controller | the controller struct | 
+| inFlightExitMap | struct PaymentExitDataModel.InFlightExitMap | the storage of all in-flight exit data | 
+| args | struct PaymentInFlightExitRouterArgs.PiggybackInFlightExitOnOutputArgs | arguments of 'piggybackInFlightExitOnOutput' function from client. | 
+
+### enqueue
+
+```js
+function enqueue(struct PaymentPiggybackInFlightExit.Controller controller, address token, struct UtxoPosLib.UtxoPos utxoPos, uint160 exitId) private nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| controller | struct PaymentPiggybackInFlightExit.Controller |  | 
+| token | address |  | 
+| utxoPos | struct UtxoPosLib.UtxoPos |  | 
+| exitId | uint160 |  | 
+
+### getExitTargetOfOutput
+
+```js
+function getExitTargetOfOutput(struct PaymentPiggybackInFlightExit.Controller controller, bytes20 outputGuard, uint256 outputType, bytes outputGuardPreimage) private view
+returns(address payable)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| controller | struct PaymentPiggybackInFlightExit.Controller |  | 
+| outputGuard | bytes20 |  | 
+| outputType | uint256 |  | 
+| outputGuardPreimage | bytes |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/PaymentProcessInFlightExit.md
+++ b/plasma_framework/docs/PaymentProcessInFlightExit.md
@@ -1,0 +1,252 @@
+# PaymentProcessInFlightExit.sol
+
+View Source: [contracts/src/exits/payment/controllers/PaymentProcessInFlightExit.sol](../contracts/src/exits/payment/controllers/PaymentProcessInFlightExit.sol)
+
+**PaymentProcessInFlightExit**
+
+## Structs
+### Controller
+
+```js
+struct Controller {
+ contract PlasmaFramework framework,
+ contract EthVault ethVault,
+ contract Erc20Vault erc20Vault
+}
+```
+
+## Contract Members
+**Constants & Variables**
+
+```js
+uint8 public constant MAX_INPUT_NUM;
+uint8 public constant MAX_OUTPUT_NUM;
+
+```
+
+**Events**
+
+```js
+event InFlightExitOmitted(uint160 indexed exitId, address  token);
+event InFlightExitOutputWithdrawn(uint160 indexed exitId, uint16  outputIndex);
+event InFlightExitInputWithdrawn(uint160 indexed exitId, uint16  inputIndex);
+```
+
+## Functions
+
+- [run(struct PaymentProcessInFlightExit.Controller self, struct PaymentExitDataModel.InFlightExitMap exitMap, uint160 exitId, address token)](#run)
+- [isAnyInputSpent(PlasmaFramework framework, struct PaymentExitDataModel.InFlightExit exit, address token)](#isanyinputspent)
+- [shouldWithdrawInput(struct PaymentExitDataModel.InFlightExit exit, struct PaymentExitDataModel.WithdrawData withdrawal, address token, uint16 index)](#shouldwithdrawinput)
+- [shouldWithdrawOutput(struct PaymentProcessInFlightExit.Controller controller, struct PaymentExitDataModel.InFlightExit exit, struct PaymentExitDataModel.WithdrawData withdrawal, address token, uint16 index)](#shouldwithdrawoutput)
+- [withdrawFromVault(struct PaymentProcessInFlightExit.Controller self, struct PaymentExitDataModel.WithdrawData withdrawal)](#withdrawfromvault)
+- [flagInputsAndOutputsSpent(PlasmaFramework framework, struct PaymentExitDataModel.InFlightExit exit, address token)](#flaginputsandoutputsspent)
+- [clearPiggybackInputFlag(struct PaymentExitDataModel.InFlightExit exit, address token)](#clearpiggybackinputflag)
+- [clearPiggybackOutputFlag(struct PaymentExitDataModel.InFlightExit exit, address token)](#clearpiggybackoutputflag)
+- [allPiggybacksCleared(struct PaymentExitDataModel.InFlightExit exit)](#allpiggybackscleared)
+
+### run
+
+Main logic function to process in-flight exit
+
+```js
+function run(struct PaymentProcessInFlightExit.Controller self, struct PaymentExitDataModel.InFlightExitMap exitMap, uint160 exitId, address token) public nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct PaymentProcessInFlightExit.Controller | the controller struct | 
+| exitMap | struct PaymentExitDataModel.InFlightExitMap | the storage of all in-flight exit data | 
+| exitId | uint160 | the exitId of the in-flight exit | 
+| token | address | the ERC20 token address of the exit. Uses address(0) to represent ETH. | 
+
+### isAnyInputSpent
+
+```js
+function isAnyInputSpent(PlasmaFramework framework, struct PaymentExitDataModel.InFlightExit exit, address token) private view
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| framework | PlasmaFramework |  | 
+| exit | struct PaymentExitDataModel.InFlightExit |  | 
+| token | address |  | 
+
+### shouldWithdrawInput
+
+```js
+function shouldWithdrawInput(struct PaymentExitDataModel.InFlightExit exit, struct PaymentExitDataModel.WithdrawData withdrawal, address token, uint16 index) private pure
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| exit | struct PaymentExitDataModel.InFlightExit |  | 
+| withdrawal | struct PaymentExitDataModel.WithdrawData |  | 
+| token | address |  | 
+| index | uint16 |  | 
+
+### shouldWithdrawOutput
+
+```js
+function shouldWithdrawOutput(struct PaymentProcessInFlightExit.Controller controller, struct PaymentExitDataModel.InFlightExit exit, struct PaymentExitDataModel.WithdrawData withdrawal, address token, uint16 index) private view
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| controller | struct PaymentProcessInFlightExit.Controller |  | 
+| exit | struct PaymentExitDataModel.InFlightExit |  | 
+| withdrawal | struct PaymentExitDataModel.WithdrawData |  | 
+| token | address |  | 
+| index | uint16 |  | 
+
+### withdrawFromVault
+
+```js
+function withdrawFromVault(struct PaymentProcessInFlightExit.Controller self, struct PaymentExitDataModel.WithdrawData withdrawal) private nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct PaymentProcessInFlightExit.Controller |  | 
+| withdrawal | struct PaymentExitDataModel.WithdrawData |  | 
+
+### flagInputsAndOutputsSpent
+
+```js
+function flagInputsAndOutputsSpent(PlasmaFramework framework, struct PaymentExitDataModel.InFlightExit exit, address token) private nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| framework | PlasmaFramework |  | 
+| exit | struct PaymentExitDataModel.InFlightExit |  | 
+| token | address |  | 
+
+### clearPiggybackInputFlag
+
+```js
+function clearPiggybackInputFlag(struct PaymentExitDataModel.InFlightExit exit, address token) private nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| exit | struct PaymentExitDataModel.InFlightExit |  | 
+| token | address |  | 
+
+### clearPiggybackOutputFlag
+
+```js
+function clearPiggybackOutputFlag(struct PaymentExitDataModel.InFlightExit exit, address token) private nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| exit | struct PaymentExitDataModel.InFlightExit |  | 
+| token | address |  | 
+
+### allPiggybacksCleared
+
+```js
+function allPiggybacksCleared(struct PaymentExitDataModel.InFlightExit exit) private pure
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| exit | struct PaymentExitDataModel.InFlightExit |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/PaymentProcessStandardExit.md
+++ b/plasma_framework/docs/PaymentProcessStandardExit.md
@@ -1,0 +1,120 @@
+# PaymentProcessStandardExit.sol
+
+View Source: [contracts/src/exits/payment/controllers/PaymentProcessStandardExit.sol](../contracts/src/exits/payment/controllers/PaymentProcessStandardExit.sol)
+
+**PaymentProcessStandardExit**
+
+## Structs
+### Controller
+
+```js
+struct Controller {
+ contract PlasmaFramework framework,
+ contract EthVault ethVault,
+ contract Erc20Vault erc20Vault
+}
+```
+
+**Events**
+
+```js
+event ExitOmitted(uint160 indexed exitId);
+event ExitFinalized(uint160 indexed exitId);
+```
+
+## Functions
+
+- [run(struct PaymentProcessStandardExit.Controller self, struct PaymentExitDataModel.StandardExitMap exitMap, uint160 exitId, address token)](#run)
+
+### run
+
+Main logic function to process standard exit
+
+```js
+function run(struct PaymentProcessStandardExit.Controller self, struct PaymentExitDataModel.StandardExitMap exitMap, uint160 exitId, address token) public nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct PaymentProcessStandardExit.Controller | the controller struct | 
+| exitMap | struct PaymentExitDataModel.StandardExitMap | the storage of all standard exit data | 
+| exitId | uint160 | the exitId of the standard exit | 
+| token | address | the ERC20 token address of the exit. Uses address(0) to represent ETH. | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/PaymentStandardExitRouter.md
+++ b/plasma_framework/docs/PaymentStandardExitRouter.md
@@ -1,0 +1,221 @@
+# PaymentStandardExitRouter.sol
+
+View Source: [contracts/src/exits/payment/routers/PaymentStandardExitRouter.sol](../contracts/src/exits/payment/routers/PaymentStandardExitRouter.sol)
+
+**↗ Extends: [IExitProcessor](IExitProcessor.md), [Operated](Operated.md), [OnlyWithValue](OnlyWithValue.md)**
+**↘ Derived Contracts: [PaymentExitGame](PaymentExitGame.md)**
+
+**PaymentStandardExitRouter**
+
+## Contract Members
+**Constants & Variables**
+
+```js
+//public members
+uint128 public constant INITIAL_BOND_SIZE;
+uint16 public constant BOND_LOWER_BOUND_DIVISOR;
+uint16 public constant BOND_UPPER_BOUND_MULTIPLIER;
+
+//internal members
+struct PaymentExitDataModel.StandardExitMap internal standardExitMap;
+struct PaymentStartStandardExit.Controller internal startStandardExitController;
+struct PaymentProcessStandardExit.Controller internal processStandardExitController;
+struct PaymentChallengeStandardExit.Controller internal challengeStandardExitController;
+struct BondSize.Params internal startStandardExitBond;
+
+```
+
+**Events**
+
+```js
+event StandardExitBondUpdated(uint128  bondSize);
+```
+
+## Functions
+
+- [(PlasmaFramework framework, EthVault ethVault, Erc20Vault erc20Vault, OutputGuardHandlerRegistry outputGuardHandlerRegistry, SpendingConditionRegistry spendingConditionRegistry, ITxFinalizationVerifier txFinalizationVerifier)](#)
+- [standardExits(uint160 exitId)](#standardexits)
+- [startStandardExitBondSize()](#startstandardexitbondsize)
+- [updateStartStandardExitBondSize(uint128 newBondSize)](#updatestartstandardexitbondsize)
+- [startStandardExit(struct PaymentStandardExitRouterArgs.StartStandardExitArgs args)](#startstandardexit)
+- [challengeStandardExit(struct PaymentStandardExitRouterArgs.ChallengeStandardExitArgs args)](#challengestandardexit)
+- [processStandardExit(uint160 exitId, address token)](#processstandardexit)
+
+### 
+
+```js
+function (PlasmaFramework framework, EthVault ethVault, Erc20Vault erc20Vault, OutputGuardHandlerRegistry outputGuardHandlerRegistry, SpendingConditionRegistry spendingConditionRegistry, ITxFinalizationVerifier txFinalizationVerifier) public nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| framework | PlasmaFramework |  | 
+| ethVault | EthVault |  | 
+| erc20Vault | Erc20Vault |  | 
+| outputGuardHandlerRegistry | OutputGuardHandlerRegistry |  | 
+| spendingConditionRegistry | SpendingConditionRegistry |  | 
+| txFinalizationVerifier | ITxFinalizationVerifier |  | 
+
+### standardExits
+
+Getter functions to retrieve standard exit data of the PaymentExitGame.
+
+```js
+function standardExits(uint160 exitId) public view
+returns(struct PaymentExitDataModel.StandardExit)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| exitId | uint160 | the exit id of such standard exit. | 
+
+### startStandardExitBondSize
+
+Gets the standard exit bond size.
+
+```js
+function startStandardExitBondSize() public view
+returns(uint128)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+
+### updateStartStandardExitBondSize
+
+Updates the standard exit bond size. Will take 2 days to come into effect.
+
+```js
+function updateStartStandardExitBondSize(uint128 newBondSize) public nonpayable onlyOperator 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| newBondSize | uint128 | The new bond size. | 
+
+### startStandardExit
+
+Starts a standard exit of a given output. Uses output-age priority.
+
+```js
+function startStandardExit(struct PaymentStandardExitRouterArgs.StartStandardExitArgs args) public payable onlyWithValue 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| args | struct PaymentStandardExitRouterArgs.StartStandardExitArgs |  | 
+
+### challengeStandardExit
+
+Challenge a standard exit by showing the exiting output was spent.
+
+```js
+function challengeStandardExit(struct PaymentStandardExitRouterArgs.ChallengeStandardExitArgs args) public payable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| args | struct PaymentStandardExitRouterArgs.ChallengeStandardExitArgs |  | 
+
+### processStandardExit
+
+Process standard exit.
+
+```js
+function processStandardExit(uint160 exitId, address token) internal nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| exitId | uint160 | The standard exit id. | 
+| token | address | The token (in erc20 address or address(0) for ETH) of the exiting output. | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/PaymentStandardExitRouterArgs.md
+++ b/plasma_framework/docs/PaymentStandardExitRouterArgs.md
@@ -1,0 +1,112 @@
+# PaymentStandardExitRouterArgs.sol
+
+View Source: [contracts/src/exits/payment/routers/PaymentStandardExitRouterArgs.sol](../contracts/src/exits/payment/routers/PaymentStandardExitRouterArgs.sol)
+
+**PaymentStandardExitRouterArgs**
+
+## Structs
+### StartStandardExitArgs
+
+```js
+struct StartStandardExitArgs {
+ uint192 utxoPos,
+ bytes rlpOutputTx,
+ bytes outputGuardPreimage,
+ bytes outputTxInclusionProof
+}
+```
+
+### ChallengeStandardExitArgs
+
+```js
+struct ChallengeStandardExitArgs {
+ uint160 exitId,
+ bytes exitingTx,
+ bytes challengeTx,
+ uint16 inputIndex,
+ bytes witness,
+ bytes spendingConditionOptionalArgs,
+ bytes outputGuardPreimage,
+ uint256 challengeTxPos,
+ bytes challengeTxInclusionProof,
+ bytes challengeTxConfirmSig
+}
+```
+
+## Functions
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/PaymentStartInFlightExit.md
+++ b/plasma_framework/docs/PaymentStartInFlightExit.md
@@ -1,0 +1,371 @@
+# PaymentStartInFlightExit.sol
+
+View Source: [contracts/src/exits/payment/controllers/PaymentStartInFlightExit.sol](../contracts/src/exits/payment/controllers/PaymentStartInFlightExit.sol)
+
+**PaymentStartInFlightExit**
+
+## Structs
+### Controller
+
+```js
+struct Controller {
+ contract PlasmaFramework framework,
+ struct IsDeposit.Predicate isDeposit,
+ struct ExitableTimestamp.Calculator exitTimestampCalculator,
+ contract OutputGuardHandlerRegistry outputGuardHandlerRegistry,
+ contract SpendingConditionRegistry spendingConditionRegistry,
+ contract IStateTransitionVerifier transitionVerifier,
+ contract ITxFinalizationVerifier txFinalizationVerifier,
+ uint256 supportedTxType
+}
+```
+
+### StartExitData
+
+```js
+struct StartExitData {
+ struct PaymentStartInFlightExit.Controller controller,
+ uint160 exitId,
+ bytes inFlightTxRaw,
+ struct PaymentTransactionModel.Transaction inFlightTx,
+ bytes32 inFlightTxHash,
+ bytes[] inputTxs,
+ struct UtxoPosLib.UtxoPos[] inputUtxosPos,
+ uint256[] inputTxTypes,
+ bytes[] outputGuardPreimagesForInputs,
+ bytes[] inputTxsInclusionProofs,
+ bytes[] inputTxsConfirmSigs,
+ bytes[] inFlightTxWitnesses,
+ bytes[] inputSpendingConditionOptionalArgs,
+ bytes32[] outputIds
+}
+```
+
+## Contract Members
+**Constants & Variables**
+
+```js
+uint256 public constant MAX_INPUT_NUM;
+
+```
+
+**Events**
+
+```js
+event InFlightExitStarted(address indexed initiator, bytes32  txHash);
+```
+
+## Functions
+
+- [buildController(PlasmaFramework framework, OutputGuardHandlerRegistry outputGuardHandlerRegistry, SpendingConditionRegistry spendingConditionRegistry, IStateTransitionVerifier transitionVerifier, ITxFinalizationVerifier txFinalizationVerifier, uint256 supportedTxType)](#buildcontroller)
+- [run(struct PaymentStartInFlightExit.Controller self, struct PaymentExitDataModel.InFlightExitMap inFlightExitMap, struct PaymentInFlightExitRouterArgs.StartExitArgs args)](#run)
+- [createStartExitData(struct PaymentStartInFlightExit.Controller controller, struct PaymentInFlightExitRouterArgs.StartExitArgs args)](#createstartexitdata)
+- [decodeInputTxsPositions(uint256[] inputUtxosPos)](#decodeinputtxspositions)
+- [getOutputIds(struct PaymentStartInFlightExit.Controller controller, bytes[] inputTxs, struct UtxoPosLib.UtxoPos[] utxoPos)](#getoutputids)
+- [verifyStart(struct PaymentStartInFlightExit.StartExitData exitData, struct PaymentExitDataModel.InFlightExitMap inFlightExitMap)](#verifystart)
+- [verifyExitNotStarted(uint160 exitId, struct PaymentExitDataModel.InFlightExitMap inFlightExitMap)](#verifyexitnotstarted)
+- [verifyNumberOfInputsMatchesNumberOfInFlightTransactionInputs(struct PaymentStartInFlightExit.StartExitData exitData)](#verifynumberofinputsmatchesnumberofinflighttransactioninputs)
+- [verifyNoInputSpentMoreThanOnce(struct PaymentTransactionModel.Transaction inFlightTx)](#verifynoinputspentmorethanonce)
+- [verifyInputTransactionIsStandardFinalized(struct PaymentStartInFlightExit.StartExitData exitData)](#verifyinputtransactionisstandardfinalized)
+- [verifyInputsSpent(struct PaymentStartInFlightExit.StartExitData exitData)](#verifyinputsspent)
+- [verifyStateTransition(struct PaymentStartInFlightExit.StartExitData exitData)](#verifystatetransition)
+- [startExit(struct PaymentStartInFlightExit.StartExitData startExitData, struct PaymentExitDataModel.InFlightExitMap inFlightExitMap)](#startexit)
+- [getYoungestInputUtxoPosition(struct UtxoPosLib.UtxoPos[] inputUtxosPos)](#getyoungestinpututxoposition)
+- [setInFlightExitInputs(struct PaymentExitDataModel.InFlightExit ife, struct PaymentStartInFlightExit.StartExitData exitData)](#setinflightexitinputs)
+- [setInFlightExitOutputs(struct PaymentExitDataModel.InFlightExit ife, struct PaymentStartInFlightExit.StartExitData exitData)](#setinflightexitoutputs)
+
+### buildController
+
+Function that builds the controller struct
+
+```js
+function buildController(PlasmaFramework framework, OutputGuardHandlerRegistry outputGuardHandlerRegistry, SpendingConditionRegistry spendingConditionRegistry, IStateTransitionVerifier transitionVerifier, ITxFinalizationVerifier txFinalizationVerifier, uint256 supportedTxType) public view
+returns(struct PaymentStartInFlightExit.Controller)
+```
+
+**Returns**
+
+Controller struct of PaymentStartInFlightExit
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| framework | PlasmaFramework |  | 
+| outputGuardHandlerRegistry | OutputGuardHandlerRegistry |  | 
+| spendingConditionRegistry | SpendingConditionRegistry |  | 
+| transitionVerifier | IStateTransitionVerifier |  | 
+| txFinalizationVerifier | ITxFinalizationVerifier |  | 
+| supportedTxType | uint256 |  | 
+
+### run
+
+Main logic function to start in-flight exit
+
+```js
+function run(struct PaymentStartInFlightExit.Controller self, struct PaymentExitDataModel.InFlightExitMap inFlightExitMap, struct PaymentInFlightExitRouterArgs.StartExitArgs args) public nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct PaymentStartInFlightExit.Controller | the controller struct | 
+| inFlightExitMap | struct PaymentExitDataModel.InFlightExitMap | the storage of all in-flight exit data | 
+| args | struct PaymentInFlightExitRouterArgs.StartExitArgs | arguments of start in-flight exit function from client. | 
+
+### createStartExitData
+
+```js
+function createStartExitData(struct PaymentStartInFlightExit.Controller controller, struct PaymentInFlightExitRouterArgs.StartExitArgs args) private pure
+returns(struct PaymentStartInFlightExit.StartExitData)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| controller | struct PaymentStartInFlightExit.Controller |  | 
+| args | struct PaymentInFlightExitRouterArgs.StartExitArgs |  | 
+
+### decodeInputTxsPositions
+
+```js
+function decodeInputTxsPositions(uint256[] inputUtxosPos) private pure
+returns(struct UtxoPosLib.UtxoPos[])
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| inputUtxosPos | uint256[] |  | 
+
+### getOutputIds
+
+```js
+function getOutputIds(struct PaymentStartInFlightExit.Controller controller, bytes[] inputTxs, struct UtxoPosLib.UtxoPos[] utxoPos) private pure
+returns(bytes32[])
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| controller | struct PaymentStartInFlightExit.Controller |  | 
+| inputTxs | bytes[] |  | 
+| utxoPos | struct UtxoPosLib.UtxoPos[] |  | 
+
+### verifyStart
+
+```js
+function verifyStart(struct PaymentStartInFlightExit.StartExitData exitData, struct PaymentExitDataModel.InFlightExitMap inFlightExitMap) private view
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| exitData | struct PaymentStartInFlightExit.StartExitData |  | 
+| inFlightExitMap | struct PaymentExitDataModel.InFlightExitMap |  | 
+
+### verifyExitNotStarted
+
+```js
+function verifyExitNotStarted(uint160 exitId, struct PaymentExitDataModel.InFlightExitMap inFlightExitMap) private view
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| exitId | uint160 |  | 
+| inFlightExitMap | struct PaymentExitDataModel.InFlightExitMap |  | 
+
+### verifyNumberOfInputsMatchesNumberOfInFlightTransactionInputs
+
+```js
+function verifyNumberOfInputsMatchesNumberOfInFlightTransactionInputs(struct PaymentStartInFlightExit.StartExitData exitData) private pure
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| exitData | struct PaymentStartInFlightExit.StartExitData |  | 
+
+### verifyNoInputSpentMoreThanOnce
+
+```js
+function verifyNoInputSpentMoreThanOnce(struct PaymentTransactionModel.Transaction inFlightTx) private pure
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| inFlightTx | struct PaymentTransactionModel.Transaction |  | 
+
+### verifyInputTransactionIsStandardFinalized
+
+```js
+function verifyInputTransactionIsStandardFinalized(struct PaymentStartInFlightExit.StartExitData exitData) private view
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| exitData | struct PaymentStartInFlightExit.StartExitData |  | 
+
+### verifyInputsSpent
+
+```js
+function verifyInputsSpent(struct PaymentStartInFlightExit.StartExitData exitData) private view
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| exitData | struct PaymentStartInFlightExit.StartExitData |  | 
+
+### verifyStateTransition
+
+```js
+function verifyStateTransition(struct PaymentStartInFlightExit.StartExitData exitData) private view
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| exitData | struct PaymentStartInFlightExit.StartExitData |  | 
+
+### startExit
+
+```js
+function startExit(struct PaymentStartInFlightExit.StartExitData startExitData, struct PaymentExitDataModel.InFlightExitMap inFlightExitMap) private nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| startExitData | struct PaymentStartInFlightExit.StartExitData |  | 
+| inFlightExitMap | struct PaymentExitDataModel.InFlightExitMap |  | 
+
+### getYoungestInputUtxoPosition
+
+```js
+function getYoungestInputUtxoPosition(struct UtxoPosLib.UtxoPos[] inputUtxosPos) private pure
+returns(uint256)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| inputUtxosPos | struct UtxoPosLib.UtxoPos[] |  | 
+
+### setInFlightExitInputs
+
+```js
+function setInFlightExitInputs(struct PaymentExitDataModel.InFlightExit ife, struct PaymentStartInFlightExit.StartExitData exitData) private nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| ife | struct PaymentExitDataModel.InFlightExit |  | 
+| exitData | struct PaymentStartInFlightExit.StartExitData |  | 
+
+### setInFlightExitOutputs
+
+```js
+function setInFlightExitOutputs(struct PaymentExitDataModel.InFlightExit ife, struct PaymentStartInFlightExit.StartExitData exitData) private nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| ife | struct PaymentExitDataModel.InFlightExit |  | 
+| exitData | struct PaymentStartInFlightExit.StartExitData |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/PaymentStartStandardExit.md
+++ b/plasma_framework/docs/PaymentStartStandardExit.md
@@ -1,0 +1,218 @@
+# PaymentStartStandardExit.sol
+
+View Source: [contracts/src/exits/payment/controllers/PaymentStartStandardExit.sol](../contracts/src/exits/payment/controllers/PaymentStartStandardExit.sol)
+
+**PaymentStartStandardExit**
+
+## Structs
+### Controller
+
+```js
+struct Controller {
+ contract IExitProcessor exitProcessor,
+ contract PlasmaFramework framework,
+ struct IsDeposit.Predicate isDeposit,
+ struct ExitableTimestamp.Calculator exitableTimestampCalculator,
+ contract OutputGuardHandlerRegistry outputGuardHandlerRegistry,
+ contract ITxFinalizationVerifier txFinalizationVerifier
+}
+```
+
+### StartStandardExitData
+
+```js
+struct StartStandardExitData {
+ struct PaymentStartStandardExit.Controller controller,
+ struct PaymentStandardExitRouterArgs.StartStandardExitArgs args,
+ struct UtxoPosLib.UtxoPos utxoPos,
+ struct PaymentTransactionModel.Transaction outputTx,
+ struct PaymentOutputModel.Output output,
+ contract IOutputGuardHandler outputGuardHandler,
+ struct OutputGuardModel.Data outputGuardData,
+ uint160 exitId,
+ bool isTxDeposit,
+ uint256 txBlockTimeStamp,
+ struct TxFinalizationModel.Data finalizationData
+}
+```
+
+**Events**
+
+```js
+event ExitStarted(address indexed owner, uint160  exitId);
+```
+
+## Functions
+
+- [buildController(IExitProcessor exitProcessor, PlasmaFramework framework, OutputGuardHandlerRegistry outputGuardHandlerRegistry, ITxFinalizationVerifier txFinalizationVerifier)](#buildcontroller)
+- [run(struct PaymentStartStandardExit.Controller self, struct PaymentExitDataModel.StandardExitMap exitMap, struct PaymentStandardExitRouterArgs.StartStandardExitArgs args)](#run)
+- [setupStartStandardExitData(struct PaymentStartStandardExit.Controller controller, struct PaymentStandardExitRouterArgs.StartStandardExitArgs args)](#setupstartstandardexitdata)
+- [verifyStartStandardExitData(struct PaymentStartStandardExit.StartStandardExitData data, struct PaymentExitDataModel.StandardExitMap exitMap)](#verifystartstandardexitdata)
+- [saveStandardExitData(struct PaymentStartStandardExit.StartStandardExitData data, struct PaymentExitDataModel.StandardExitMap exitMap)](#savestandardexitdata)
+- [enqueueStandardExit(struct PaymentStartStandardExit.StartStandardExitData data)](#enqueuestandardexit)
+
+### buildController
+
+Function that builds the controller struct
+
+```js
+function buildController(IExitProcessor exitProcessor, PlasmaFramework framework, OutputGuardHandlerRegistry outputGuardHandlerRegistry, ITxFinalizationVerifier txFinalizationVerifier) public view
+returns(struct PaymentStartStandardExit.Controller)
+```
+
+**Returns**
+
+Controller struct of PaymentStartStandardExit
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| exitProcessor | IExitProcessor |  | 
+| framework | PlasmaFramework |  | 
+| outputGuardHandlerRegistry | OutputGuardHandlerRegistry |  | 
+| txFinalizationVerifier | ITxFinalizationVerifier |  | 
+
+### run
+
+Main logic function to start standard exit
+
+```js
+function run(struct PaymentStartStandardExit.Controller self, struct PaymentExitDataModel.StandardExitMap exitMap, struct PaymentStandardExitRouterArgs.StartStandardExitArgs args) public nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct PaymentStartStandardExit.Controller | the controller struct | 
+| exitMap | struct PaymentExitDataModel.StandardExitMap | the storage of all standard exit data | 
+| args | struct PaymentStandardExitRouterArgs.StartStandardExitArgs | arguments of start standard exit function from client. | 
+
+### setupStartStandardExitData
+
+```js
+function setupStartStandardExitData(struct PaymentStartStandardExit.Controller controller, struct PaymentStandardExitRouterArgs.StartStandardExitArgs args) private view
+returns(struct PaymentStartStandardExit.StartStandardExitData)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| controller | struct PaymentStartStandardExit.Controller |  | 
+| args | struct PaymentStandardExitRouterArgs.StartStandardExitArgs |  | 
+
+### verifyStartStandardExitData
+
+```js
+function verifyStartStandardExitData(struct PaymentStartStandardExit.StartStandardExitData data, struct PaymentExitDataModel.StandardExitMap exitMap) private view
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| data | struct PaymentStartStandardExit.StartStandardExitData |  | 
+| exitMap | struct PaymentExitDataModel.StandardExitMap |  | 
+
+### saveStandardExitData
+
+```js
+function saveStandardExitData(struct PaymentStartStandardExit.StartStandardExitData data, struct PaymentExitDataModel.StandardExitMap exitMap) private nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| data | struct PaymentStartStandardExit.StartStandardExitData |  | 
+| exitMap | struct PaymentExitDataModel.StandardExitMap |  | 
+
+### enqueueStandardExit
+
+```js
+function enqueueStandardExit(struct PaymentStartStandardExit.StartStandardExitData data) private nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| data | struct PaymentStartStandardExit.StartStandardExitData |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/PaymentTransactionModel.md
+++ b/plasma_framework/docs/PaymentTransactionModel.md
@@ -1,0 +1,125 @@
+# PaymentTransactionModel.sol
+
+View Source: [contracts/src/transactions/PaymentTransactionModel.sol](../contracts/src/transactions/PaymentTransactionModel.sol)
+
+**PaymentTransactionModel**
+
+Data structure and its decode function for Payment transaction
+
+## Structs
+### Transaction
+
+```js
+struct Transaction {
+ uint256 txType,
+ bytes32[] inputs,
+ struct PaymentOutputModel.Output[] outputs,
+ bytes32 metaData
+}
+```
+
+## Contract Members
+**Constants & Variables**
+
+```js
+//public members
+uint8 public constant MAX_INPUT_NUM;
+uint8 public constant MAX_OUTPUT_NUM;
+
+//private members
+uint8 private constant ENCODED_LENGTH;
+
+```
+
+## Functions
+
+- [decode(bytes _tx)](#decode)
+
+### decode
+
+```js
+function decode(bytes _tx) internal pure
+returns(struct PaymentTransactionModel.Transaction)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _tx | bytes |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/PaymentTransactionStateTransitionVerifier.md
+++ b/plasma_framework/docs/PaymentTransactionStateTransitionVerifier.md
@@ -1,0 +1,163 @@
+# PaymentTransactionStateTransitionVerifier.sol
+
+View Source: [contracts/src/exits/payment/PaymentTransactionStateTransitionVerifier.sol](../contracts/src/exits/payment/PaymentTransactionStateTransitionVerifier.sol)
+
+**PaymentTransactionStateTransitionVerifier**
+
+Verifies state transitions for payment transaction
+
+## Functions
+
+- [isCorrectStateTransition(bytes txBytes, bytes[] inputTxs, uint16[] outputIndexOfInputTxs)](#iscorrectstatetransition)
+- [_isCorrectStateTransition(struct WireTransaction.Output[] inputs, struct WireTransaction.Output[] outputs)](#_iscorrectstatetransition)
+- [filterWithToken(struct WireTransaction.Output[] outputs, address token)](#filterwithtoken)
+- [isCorrectSpend(struct WireTransaction.Output[] inputs, struct WireTransaction.Output[] outputs)](#iscorrectspend)
+- [sumAmounts(struct WireTransaction.Output[] outputs)](#sumamounts)
+
+### isCorrectStateTransition
+
+For Payment transaction to be valid, the state transition should check that the sum of the inputs is larger than the sum of the outputs
+
+```js
+function isCorrectStateTransition(bytes txBytes, bytes[] inputTxs, uint16[] outputIndexOfInputTxs) external pure
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| txBytes | bytes |  | 
+| inputTxs | bytes[] |  | 
+| outputIndexOfInputTxs | uint16[] |  | 
+
+### _isCorrectStateTransition
+
+```js
+function _isCorrectStateTransition(struct WireTransaction.Output[] inputs, struct WireTransaction.Output[] outputs) private pure
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| inputs | struct WireTransaction.Output[] |  | 
+| outputs | struct WireTransaction.Output[] |  | 
+
+### filterWithToken
+
+```js
+function filterWithToken(struct WireTransaction.Output[] outputs, address token) private pure
+returns(struct WireTransaction.Output[])
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| outputs | struct WireTransaction.Output[] |  | 
+| token | address |  | 
+
+### isCorrectSpend
+
+```js
+function isCorrectSpend(struct WireTransaction.Output[] inputs, struct WireTransaction.Output[] outputs) internal pure
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| inputs | struct WireTransaction.Output[] |  | 
+| outputs | struct WireTransaction.Output[] |  | 
+
+### sumAmounts
+
+```js
+function sumAmounts(struct WireTransaction.Output[] outputs) private pure
+returns(uint256)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| outputs | struct WireTransaction.Output[] |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/PlasmaFramework.md
+++ b/plasma_framework/docs/PlasmaFramework.md
@@ -1,0 +1,110 @@
+# PlasmaFramework.sol
+
+View Source: [contracts/src/framework/PlasmaFramework.sol](../contracts/src/framework/PlasmaFramework.sol)
+
+**↗ Extends: [Operated](Operated.md), [VaultRegistry](VaultRegistry.md), [ExitGameRegistry](ExitGameRegistry.md), [ExitGameController](ExitGameController.md), [BlockController](BlockController.md)**
+
+**PlasmaFramework**
+
+## Contract Members
+**Constants & Variables**
+
+```js
+uint256 public constant CHILD_BLOCK_INTERVAL;
+uint256 public minExitPeriod;
+
+```
+
+## Functions
+
+- [(uint256 _minExitPeriod, uint256 _initialImmuneVaults, uint256 _initialImmuneExitGames)](#)
+
+### 
+
+```js
+function (uint256 _minExitPeriod, uint256 _initialImmuneVaults, uint256 _initialImmuneExitGames) public nonpayable BlockController ExitGameController 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _minExitPeriod | uint256 |  | 
+| _initialImmuneVaults | uint256 |  | 
+| _initialImmuneExitGames | uint256 |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/PriorityQueue.md
+++ b/plasma_framework/docs/PriorityQueue.md
@@ -1,0 +1,244 @@
+# PriorityQueue (PriorityQueue.sol)
+
+View Source: [contracts/src/framework/utils/PriorityQueue.sol](../contracts/src/framework/utils/PriorityQueue.sol)
+
+**↗ Extends: [Ownable](Ownable.md)**
+
+**PriorityQueue**
+
+Min-heap priority queue implementation.
+
+## Structs
+### Queue
+
+```js
+struct Queue {
+ uint256[] heapList,
+ uint256 currentSize
+}
+```
+
+## Contract Members
+**Constants & Variables**
+
+```js
+struct PriorityQueue.Queue internal queue;
+
+```
+
+## Functions
+
+- [()](#)
+- [currentSize()](#currentsize)
+- [heapList()](#heaplist)
+- [insert(uint256 _element)](#insert)
+- [delMin()](#delmin)
+- [getMin()](#getmin)
+- [percUp(struct PriorityQueue.Queue self, uint256 pointer)](#percup)
+- [percDown(struct PriorityQueue.Queue self, uint256 pointer)](#percdown)
+- [minChild(struct PriorityQueue.Queue self, uint256 i)](#minchild)
+
+### 
+
+```js
+function () public nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+
+### currentSize
+
+Gets num of elements in the queue
+
+```js
+function currentSize() external view
+returns(uint256)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+
+### heapList
+
+Gets all elements in the queue
+
+```js
+function heapList() external view
+returns(uint256[])
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+
+### insert
+
+Inserts an element into the queue by the owner.
+
+```js
+function insert(uint256 _element) external nonpayable onlyOwner 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _element | uint256 |  | 
+
+### delMin
+
+Deletes the smallest element from the queue.
+
+```js
+function delMin() external nonpayable onlyOwner 
+returns(uint256)
+```
+
+**Returns**
+
+The smallest element in the priority queue.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+
+### getMin
+
+Returns the smallest element from the queue.
+
+```js
+function getMin() external view
+returns(uint256)
+```
+
+**Returns**
+
+The smallest element in the priority queue.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+
+### percUp
+
+```js
+function percUp(struct PriorityQueue.Queue self, uint256 pointer) private nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct PriorityQueue.Queue |  | 
+| pointer | uint256 |  | 
+
+### percDown
+
+```js
+function percDown(struct PriorityQueue.Queue self, uint256 pointer) private nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct PriorityQueue.Queue |  | 
+| pointer | uint256 |  | 
+
+### minChild
+
+```js
+function minChild(struct PriorityQueue.Queue self, uint256 i) private view
+returns(uint256)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct PriorityQueue.Queue |  | 
+| i | uint256 |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/Protocol.md
+++ b/plasma_framework/docs/Protocol.md
@@ -1,0 +1,135 @@
+# Protocol.sol
+
+View Source: [contracts/src/framework/Protocol.sol](../contracts/src/framework/Protocol.sol)
+
+**Protocol**
+
+protocols for the PlasmaFramework
+
+## Contract Members
+**Constants & Variables**
+
+```js
+uint8 internal constant MVP_VALUE;
+uint8 internal constant MORE_VP_VALUE;
+
+```
+
+## Functions
+
+- [MVP()](#mvp)
+- [MORE_VP()](#more_vp)
+- [isValidProtocol(uint8 protocol)](#isvalidprotocol)
+
+### MVP
+
+```js
+function MVP() internal pure
+returns(uint8)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+
+### MORE_VP
+
+```js
+function MORE_VP() internal pure
+returns(uint8)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+
+### isValidProtocol
+
+```js
+function isValidProtocol(uint8 protocol) internal pure
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| protocol | uint8 |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/Quarantine.md
+++ b/plasma_framework/docs/Quarantine.md
@@ -1,0 +1,130 @@
+# Quarantine.sol
+
+View Source: [contracts/src/framework/utils/Quarantine.sol](../contracts/src/framework/utils/Quarantine.sol)
+
+**Quarantine**
+
+Provides a way to quarantine (disable) contracts for a period of time
+
+## Structs
+### Data
+
+```js
+struct Data {
+ mapping(address => uint256) store,
+ uint256 quarantinePeriod,
+ uint256 immunitiesRemaining
+}
+```
+
+## Functions
+
+- [isQuarantined(struct Quarantine.Data _self, address _contractAddress)](#isquarantined)
+- [quarantine(struct Quarantine.Data _self, address _contractAddress)](#quarantine)
+
+### isQuarantined
+
+Checks whether a contract is still quarantined or not.
+
+```js
+function isQuarantined(struct Quarantine.Data _self, address _contractAddress) internal view
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _self | struct Quarantine.Data |  | 
+| _contractAddress | address |  | 
+
+### quarantine
+
+Put a contract into quarantine.
+
+```js
+function quarantine(struct Quarantine.Data _self, address _contractAddress) internal nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _self | struct Quarantine.Data |  | 
+| _contractAddress | address | the address of the contract. | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/RLP.md
+++ b/plasma_framework/docs/RLP.md
@@ -1,0 +1,639 @@
+# RLP (RLP.sol)
+
+View Source: [contracts/src/utils/RLP.sol](../contracts/src/utils/RLP.sol)
+
+**RLP**
+
+Library for RLP decoding.
+Based off of https://github.com/androlo/standard-contracts/blob/master/contracts/src/codec/RLP.sol.
+
+## Structs
+### RLPItem
+
+```js
+struct RLPItem {
+ uint256 _unsafeMemPtr,
+ uint256 _unsafeLength
+}
+```
+
+### Iterator
+
+```js
+struct Iterator {
+ struct RLP.RLPItem _unsafeItem,
+ uint256 _unsafeNextPtr
+}
+```
+
+## Contract Members
+**Constants & Variables**
+
+```js
+uint256 internal constant DATA_SHORT_START;
+uint256 internal constant DATA_LONG_START;
+uint256 internal constant LIST_SHORT_START;
+uint256 internal constant LIST_LONG_START;
+uint256 internal constant DATA_LONG_OFFSET;
+uint256 internal constant LIST_LONG_OFFSET;
+
+```
+
+## Functions
+
+- [toRLPItem(bytes self)](#torlpitem)
+- [toRLPItem(bytes self, bool strict)](#torlpitem)
+- [isNull(struct RLP.RLPItem self)](#isnull)
+- [isList(struct RLP.RLPItem self)](#islist)
+- [isData(struct RLP.RLPItem self)](#isdata)
+- [isEmpty(struct RLP.RLPItem self)](#isempty)
+- [items(struct RLP.RLPItem self)](#items)
+- [iterator(struct RLP.RLPItem self)](#iterator)
+- [toData(struct RLP.RLPItem self)](#todata)
+- [toList(struct RLP.RLPItem self)](#tolist)
+- [toAscii(struct RLP.RLPItem self)](#toascii)
+- [toUint(struct RLP.RLPItem self)](#touint)
+- [toBool(struct RLP.RLPItem self)](#tobool)
+- [toByte(struct RLP.RLPItem self)](#tobyte)
+- [toInt(struct RLP.RLPItem self)](#toint)
+- [toBytes32(struct RLP.RLPItem self)](#tobytes32)
+- [toAddress(struct RLP.RLPItem self)](#toaddress)
+- [toBytes20(struct RLP.RLPItem self)](#tobytes20)
+- [_next(struct RLP.Iterator self)](#_next)
+- [_next(struct RLP.Iterator self, bool strict)](#_next)
+- [_hasNext(struct RLP.Iterator self)](#_hasnext)
+- [_payloadOffset(struct RLP.RLPItem self)](#_payloadoffset)
+- [_itemLength(uint256 memPtr)](#_itemlength)
+- [_decode(struct RLP.RLPItem self)](#_decode)
+- [_copyToBytes(uint256 btsPtr, bytes tgt, uint256 btsLen)](#_copytobytes)
+- [_validate(struct RLP.RLPItem self)](#_validate)
+
+### toRLPItem
+
+Creates an RLPItem from an array of RLP encoded bytes.
+
+```js
+function toRLPItem(bytes self) internal pure
+returns(struct RLP.RLPItem)
+```
+
+**Returns**
+
+An RLPItem.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | bytes | The RLP encoded bytes. | 
+
+### toRLPItem
+
+Creates an RLPItem from an array of RLP encoded bytes.
+
+```js
+function toRLPItem(bytes self, bool strict) internal pure
+returns(struct RLP.RLPItem)
+```
+
+**Returns**
+
+An RLPItem
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | bytes | The RLP encoded bytes. | 
+| strict | bool | Will throw if the data is not RLP encoded. | 
+
+### isNull
+
+Check if the RLP item is null.
+
+```js
+function isNull(struct RLP.RLPItem self) internal pure
+returns(ret bool)
+```
+
+**Returns**
+
+'true' if the item is null.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct RLP.RLPItem | The RLP item. | 
+
+### isList
+
+Check if the RLP item is a list.
+
+```js
+function isList(struct RLP.RLPItem self) internal pure
+returns(ret bool)
+```
+
+**Returns**
+
+'true' if the item is a list.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct RLP.RLPItem | The RLP item. | 
+
+### isData
+
+Check if the RLP item is data.
+
+```js
+function isData(struct RLP.RLPItem self) internal pure
+returns(ret bool)
+```
+
+**Returns**
+
+'true' if the item is data.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct RLP.RLPItem | The RLP item. | 
+
+### isEmpty
+
+Check if the RLP item is empty (string or list).
+
+```js
+function isEmpty(struct RLP.RLPItem self) internal pure
+returns(ret bool)
+```
+
+**Returns**
+
+'true' if the item is null.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct RLP.RLPItem | The RLP item. | 
+
+### items
+
+Get the number of items in an RLP encoded list.
+
+```js
+function items(struct RLP.RLPItem self) internal pure
+returns(uint256)
+```
+
+**Returns**
+
+The number of items.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct RLP.RLPItem | The RLP item. | 
+
+### iterator
+
+Create an iterator.
+
+```js
+function iterator(struct RLP.RLPItem self) internal pure
+returns(it struct RLP.Iterator)
+```
+
+**Returns**
+
+An 'Iterator' over the item.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct RLP.RLPItem | The RLP item. | 
+
+### toData
+
+Decode an RLPItem into bytes. This will not work if the RLPItem is a list.
+
+```js
+function toData(struct RLP.RLPItem self) internal pure
+returns(bts bytes)
+```
+
+**Returns**
+
+The decoded string.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct RLP.RLPItem | The RLPItem. | 
+
+### toList
+
+Get the list of sub-items from an RLP encoded list.
+Warning: This is inefficient, as it requires that the list is read twice.
+
+```js
+function toList(struct RLP.RLPItem self) internal pure
+returns(list struct RLP.RLPItem[])
+```
+
+**Returns**
+
+Array of RLPItems.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct RLP.RLPItem | The RLP item. | 
+
+### toAscii
+
+Decode an RLPItem into an ascii string. This will not work if the RLPItem is a list.
+
+```js
+function toAscii(struct RLP.RLPItem self) internal pure
+returns(str string)
+```
+
+**Returns**
+
+The decoded string.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct RLP.RLPItem | The RLPItem. | 
+
+### toUint
+
+Decode an RLPItem into a uint. This will not work if the RLPItem is a list.
+
+```js
+function toUint(struct RLP.RLPItem self) internal pure
+returns(data uint256)
+```
+
+**Returns**
+
+The decoded string.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct RLP.RLPItem | The RLPItem. | 
+
+### toBool
+
+Decode an RLPItem into a boolean. This will not work if the RLPItem is a list.
+
+```js
+function toBool(struct RLP.RLPItem self) internal pure
+returns(data bool)
+```
+
+**Returns**
+
+The decoded string.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct RLP.RLPItem | The RLPItem. | 
+
+### toByte
+
+Decode an RLPItem into a byte. This will not work if the RLPItem is a list.
+
+```js
+function toByte(struct RLP.RLPItem self) internal pure
+returns(data bytes1)
+```
+
+**Returns**
+
+The decoded string.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct RLP.RLPItem | The RLPItem. | 
+
+### toInt
+
+Decode an RLPItem into an int. This will not work if the RLPItem is a list.
+
+```js
+function toInt(struct RLP.RLPItem self) internal pure
+returns(data int256)
+```
+
+**Returns**
+
+The decoded string.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct RLP.RLPItem | The RLPItem. | 
+
+### toBytes32
+
+Decode an RLPItem into a bytes32. This will not work if the RLPItem is a list.
+
+```js
+function toBytes32(struct RLP.RLPItem self) internal pure
+returns(data bytes32)
+```
+
+**Returns**
+
+The decoded string.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct RLP.RLPItem | The RLPItem. | 
+
+### toAddress
+
+Decode an RLPItem into an address. This will not work if the RLPItem is a list.
+
+```js
+function toAddress(struct RLP.RLPItem self) internal pure
+returns(data address)
+```
+
+**Returns**
+
+The decoded string.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct RLP.RLPItem | The RLPItem. | 
+
+### toBytes20
+
+Decode an RLPItem into a bytes20. This will not work if the RLPItem is a list.
+
+```js
+function toBytes20(struct RLP.RLPItem self) internal pure
+returns(data bytes20)
+```
+
+**Returns**
+
+The decoded string.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct RLP.RLPItem | The RLPItem. | 
+
+### _next
+
+Returns the next RLP item for some iterator.
+
+```js
+function _next(struct RLP.Iterator self) private pure
+returns(subItem struct RLP.RLPItem)
+```
+
+**Returns**
+
+The next RLP item.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct RLP.Iterator | The iterator. | 
+
+### _next
+
+Returns the next RLP item for some iterator and validates it.
+
+```js
+function _next(struct RLP.Iterator self, bool strict) private pure
+returns(subItem struct RLP.RLPItem)
+```
+
+**Returns**
+
+The next RLP item.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct RLP.Iterator | The iterator. | 
+| strict | bool |  | 
+
+### _hasNext
+
+Checks if an iterator has a next RLP item.
+
+```js
+function _hasNext(struct RLP.Iterator self) private pure
+returns(bool)
+```
+
+**Returns**
+
+True if the iterator has an RLP item. False otherwise.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct RLP.Iterator | The iterator. | 
+
+### _payloadOffset
+
+Determines the payload offset of some RLP item.
+
+```js
+function _payloadOffset(struct RLP.RLPItem self) private pure
+returns(uint256)
+```
+
+**Returns**
+
+The payload offset for that item.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct RLP.RLPItem | RLP item to query. | 
+
+### _itemLength
+
+Determines the length of an RLP item.
+
+```js
+function _itemLength(uint256 memPtr) private pure
+returns(len uint256)
+```
+
+**Returns**
+
+Length of the item.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| memPtr | uint256 | Pointer to the start of the item. | 
+
+### _decode
+
+Determines the start position and length of some RLP item.
+
+```js
+function _decode(struct RLP.RLPItem self) private pure
+returns(memPtr uint256, len uint256)
+```
+
+**Returns**
+
+A pointer to the beginning of the item and the length of that item.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct RLP.RLPItem | RLP item to query. | 
+
+### _copyToBytes
+
+Copies some data to a certain target.
+
+```js
+function _copyToBytes(uint256 btsPtr, bytes tgt, uint256 btsLen) private pure
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| btsPtr | uint256 | Pointer to the data to copy. | 
+| tgt | bytes | Place to copy. | 
+| btsLen | uint256 | How many bytes to copy. | 
+
+### _validate
+
+Checks that an RLP item is valid.
+
+```js
+function _validate(struct RLP.RLPItem self) private pure
+returns(ret bool)
+```
+
+**Returns**
+
+True if the RLP item is well-formed. False otherwise.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| self | struct RLP.RLPItem | RLP item to validate. | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/SafeERC20.md
+++ b/plasma_framework/docs/SafeERC20.md
@@ -1,0 +1,184 @@
+# SafeERC20 (SafeERC20.sol)
+
+View Source: [openzeppelin-solidity/contracts/token/ERC20/SafeERC20.sol](../openzeppelin-solidity/contracts/token/ERC20/SafeERC20.sol)
+
+**SafeERC20**
+
+Wrappers around ERC20 operations that throw on failure (when the token
+contract returns false). Tokens that return no value (and instead revert or
+throw on failure) are also supported, non-reverting calls are assumed to be
+successful.
+To use this library you can add a `using SafeERC20 for ERC20;` statement to your contract,
+which allows you to call the safe operations as `token.safeTransfer(...)`, etc.
+
+## Functions
+
+- [safeTransfer(IERC20 token, address to, uint256 value)](#safetransfer)
+- [safeTransferFrom(IERC20 token, address from, address to, uint256 value)](#safetransferfrom)
+- [safeApprove(IERC20 token, address spender, uint256 value)](#safeapprove)
+- [safeIncreaseAllowance(IERC20 token, address spender, uint256 value)](#safeincreaseallowance)
+- [safeDecreaseAllowance(IERC20 token, address spender, uint256 value)](#safedecreaseallowance)
+- [callOptionalReturn(IERC20 token, bytes data)](#calloptionalreturn)
+
+### safeTransfer
+
+```js
+function safeTransfer(IERC20 token, address to, uint256 value) internal nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| token | IERC20 |  | 
+| to | address |  | 
+| value | uint256 |  | 
+
+### safeTransferFrom
+
+```js
+function safeTransferFrom(IERC20 token, address from, address to, uint256 value) internal nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| token | IERC20 |  | 
+| from | address |  | 
+| to | address |  | 
+| value | uint256 |  | 
+
+### safeApprove
+
+```js
+function safeApprove(IERC20 token, address spender, uint256 value) internal nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| token | IERC20 |  | 
+| spender | address |  | 
+| value | uint256 |  | 
+
+### safeIncreaseAllowance
+
+```js
+function safeIncreaseAllowance(IERC20 token, address spender, uint256 value) internal nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| token | IERC20 |  | 
+| spender | address |  | 
+| value | uint256 |  | 
+
+### safeDecreaseAllowance
+
+```js
+function safeDecreaseAllowance(IERC20 token, address spender, uint256 value) internal nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| token | IERC20 |  | 
+| spender | address |  | 
+| value | uint256 |  | 
+
+### callOptionalReturn
+
+Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement
+on the return value: the return value is optional (but if data is returned, it must not be false).
+
+```js
+function callOptionalReturn(IERC20 token, bytes data) private nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| token | IERC20 | The token targeted by the call. | 
+| data | bytes | The call data (encoded using abi.encode or one of its variants). | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/SafeMath.md
+++ b/plasma_framework/docs/SafeMath.md
@@ -1,0 +1,203 @@
+# SafeMath.sol
+
+View Source: [openzeppelin-solidity/contracts/math/SafeMath.sol](../openzeppelin-solidity/contracts/math/SafeMath.sol)
+
+**SafeMath**
+
+Wrappers over Solidity's arithmetic operations with added overflow
+checks.
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+in bugs, because programmers usually assume that an overflow raises an
+error, which is the standard behavior in high level programming languages.
+`SafeMath` restores this intuition by reverting the transaction when an
+operation overflows.
+ * Using this library instead of the unchecked operations eliminates an entire
+class of bugs, so it's recommended to use it always.
+
+## Functions
+
+- [add(uint256 a, uint256 b)](#add)
+- [sub(uint256 a, uint256 b)](#sub)
+- [mul(uint256 a, uint256 b)](#mul)
+- [div(uint256 a, uint256 b)](#div)
+- [mod(uint256 a, uint256 b)](#mod)
+
+### add
+
+Returns the addition of two unsigned integers, reverting on
+overflow.
+     * Counterpart to Solidity's `+` operator.
+     * Requirements:
+- Addition cannot overflow.
+
+```js
+function add(uint256 a, uint256 b) internal pure
+returns(uint256)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| a | uint256 |  | 
+| b | uint256 |  | 
+
+### sub
+
+Returns the subtraction of two unsigned integers, reverting on
+overflow (when the result is negative).
+     * Counterpart to Solidity's `-` operator.
+     * Requirements:
+- Subtraction cannot overflow.
+
+```js
+function sub(uint256 a, uint256 b) internal pure
+returns(uint256)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| a | uint256 |  | 
+| b | uint256 |  | 
+
+### mul
+
+Returns the multiplication of two unsigned integers, reverting on
+overflow.
+     * Counterpart to Solidity's `*` operator.
+     * Requirements:
+- Multiplication cannot overflow.
+
+```js
+function mul(uint256 a, uint256 b) internal pure
+returns(uint256)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| a | uint256 |  | 
+| b | uint256 |  | 
+
+### div
+
+Returns the integer division of two unsigned integers. Reverts on
+division by zero. The result is rounded towards zero.
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+`revert` opcode (which leaves remaining gas untouched) while Solidity
+uses an invalid opcode to revert (consuming all remaining gas).
+     * Requirements:
+- The divisor cannot be zero.
+
+```js
+function div(uint256 a, uint256 b) internal pure
+returns(uint256)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| a | uint256 |  | 
+| b | uint256 |  | 
+
+### mod
+
+Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+Reverts when dividing by zero.
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+opcode (which leaves remaining gas untouched) while Solidity uses an
+invalid opcode to revert (consuming all remaining gas).
+     * Requirements:
+- The divisor cannot be zero.
+
+```js
+function mod(uint256 a, uint256 b) internal pure
+returns(uint256)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| a | uint256 |  | 
+| b | uint256 |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/SpendingConditionRegistry.md
+++ b/plasma_framework/docs/SpendingConditionRegistry.md
@@ -1,0 +1,128 @@
+# SpendingConditionRegistry (SpendingConditionRegistry.sol)
+
+View Source: [contracts/src/exits/registries/SpendingConditionRegistry.sol](../contracts/src/exits/registries/SpendingConditionRegistry.sol)
+
+**↗ Extends: [Ownable](Ownable.md)**
+
+**SpendingConditionRegistry**
+
+The registry contracts of spending condition
+
+## Contract Members
+**Constants & Variables**
+
+```js
+mapping(bytes32 => contract ISpendingCondition) internal _spendingConditions;
+
+```
+
+## Functions
+
+- [spendingConditions(uint256 outputType, uint256 spendingTxType)](#spendingconditions)
+- [registerSpendingCondition(uint256 outputType, uint256 spendingTxType, ISpendingCondition condition)](#registerspendingcondition)
+
+### spendingConditions
+
+```js
+function spendingConditions(uint256 outputType, uint256 spendingTxType) public view
+returns(contract ISpendingCondition)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| outputType | uint256 |  | 
+| spendingTxType | uint256 |  | 
+
+### registerSpendingCondition
+
+Register the spending condition contract.
+
+```js
+function registerSpendingCondition(uint256 outputType, uint256 spendingTxType, ISpendingCondition condition) public nonpayable onlyOwner 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| outputType | uint256 | output type of the spending condition. | 
+| spendingTxType | uint256 | spending tx type of the spending condition. | 
+| condition | ISpendingCondition | The spending condition contract. | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/TxFinalizationModel.md
+++ b/plasma_framework/docs/TxFinalizationModel.md
@@ -1,0 +1,116 @@
+# TxFinalizationModel.sol
+
+View Source: [contracts/src/exits/models/TxFinalizationModel.sol](../contracts/src/exits/models/TxFinalizationModel.sol)
+
+**TxFinalizationModel**
+
+## Structs
+### Data
+
+```js
+struct Data {
+ contract PlasmaFramework framework,
+ uint8 protocol,
+ bytes txBytes,
+ struct TxPosLib.TxPos txPos,
+ bytes inclusionProof,
+ bytes confirmSig,
+ address confirmSigAddress
+}
+```
+
+## Functions
+
+- [moreVpData(PlasmaFramework framework, bytes txBytes, struct TxPosLib.TxPos txPos, bytes inclusionProof)](#morevpdata)
+
+### moreVpData
+
+```js
+function moreVpData(PlasmaFramework framework, bytes txBytes, struct TxPosLib.TxPos txPos, bytes inclusionProof) internal pure
+returns(struct TxFinalizationModel.Data)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| framework | PlasmaFramework |  | 
+| txBytes | bytes |  | 
+| txPos | struct TxPosLib.TxPos |  | 
+| inclusionProof | bytes |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/TxFinalizationVerifier.md
+++ b/plasma_framework/docs/TxFinalizationVerifier.md
@@ -1,0 +1,138 @@
+# TxFinalizationVerifier.sol
+
+View Source: [contracts/src/exits/utils/TxFinalizationVerifier.sol](../contracts/src/exits/utils/TxFinalizationVerifier.sol)
+
+**↗ Extends: [ITxFinalizationVerifier](ITxFinalizationVerifier.md)**
+
+**TxFinalizationVerifier**
+
+Contract that checks the tx finalization, currently only MoreVp functionality is implemented
+
+## Functions
+
+- [isStandardFinalized(struct TxFinalizationModel.Data data)](#isstandardfinalized)
+- [isProtocolFinalized(struct TxFinalizationModel.Data data)](#isprotocolfinalized)
+- [checkInclusionProof(struct TxFinalizationModel.Data data)](#checkinclusionproof)
+
+### isStandardFinalized
+
+⤾ overrides [ITxFinalizationVerifier.isStandardFinalized](ITxFinalizationVerifier.md#isstandardfinalized)
+
+Checks a transaction is "standard finalized" or not
+
+```js
+function isStandardFinalized(struct TxFinalizationModel.Data data) public view
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| data | struct TxFinalizationModel.Data |  | 
+
+### isProtocolFinalized
+
+⤾ overrides [ITxFinalizationVerifier.isProtocolFinalized](ITxFinalizationVerifier.md#isprotocolfinalized)
+
+Checks a transaction is "protocol finalized" or not
+
+```js
+function isProtocolFinalized(struct TxFinalizationModel.Data data) public view
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| data | struct TxFinalizationModel.Data |  | 
+
+### checkInclusionProof
+
+```js
+function checkInclusionProof(struct TxFinalizationModel.Data data) private view
+returns(bool)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| data | struct TxFinalizationModel.Data |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/TxPosLib.md
+++ b/plasma_framework/docs/TxPosLib.md
@@ -1,0 +1,143 @@
+# TxPosLib.sol
+
+View Source: [contracts/src/utils/TxPosLib.sol](../contracts/src/utils/TxPosLib.sol)
+
+**TxPosLib**
+
+transaction position = (blockNumber * BLOCK_OFFSET_FOR_TX_POS + txIndex).
+
+## Structs
+### TxPos
+
+```js
+struct TxPos {
+ uint256 value
+}
+```
+
+## Contract Members
+**Constants & Variables**
+
+```js
+uint256 internal constant BLOCK_OFFSET_FOR_TX_POS;
+
+```
+
+## Functions
+
+- [blockNum(struct TxPosLib.TxPos _txPos)](#blocknum)
+- [txIndex(struct TxPosLib.TxPos _txPos)](#txindex)
+
+### blockNum
+
+Given a TX position, returns the block number.
+
+```js
+function blockNum(struct TxPosLib.TxPos _txPos) internal pure
+returns(uint256)
+```
+
+**Returns**
+
+The output's block number.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _txPos | struct TxPosLib.TxPos | position of transaction. | 
+
+### txIndex
+
+Given a Tx position, returns the transaction index.
+
+```js
+function txIndex(struct TxPosLib.TxPos _txPos) internal pure
+returns(uint256)
+```
+
+**Returns**
+
+The output's transaction index.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _txPos | struct TxPosLib.TxPos | position of transaction. | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/UtxoPosLib.md
+++ b/plasma_framework/docs/UtxoPosLib.md
@@ -1,0 +1,205 @@
+# UtxoPosLib.sol
+
+View Source: [contracts/src/utils/UtxoPosLib.sol](../contracts/src/utils/UtxoPosLib.sol)
+
+**UtxoPosLib**
+
+UTXO position = (blockNumber * BLOCK_OFFSET + txIndex * TX_OFFSET + outputIndex).
+
+## Structs
+### UtxoPos
+
+```js
+struct UtxoPos {
+ uint256 value
+}
+```
+
+## Contract Members
+**Constants & Variables**
+
+```js
+uint256 internal constant BLOCK_OFFSET;
+uint256 internal constant TX_OFFSET;
+
+```
+
+## Functions
+
+- [build(struct TxPosLib.TxPos txPos, uint16 outputIndex)](#build)
+- [blockNum(struct UtxoPosLib.UtxoPos _utxoPos)](#blocknum)
+- [txIndex(struct UtxoPosLib.UtxoPos _utxoPos)](#txindex)
+- [outputIndex(struct UtxoPosLib.UtxoPos _utxoPos)](#outputindex)
+- [txPos(struct UtxoPosLib.UtxoPos _utxoPos)](#txpos)
+
+### build
+
+Given txPos and outputIndex, returns the Utxo struct.
+
+```js
+function build(struct TxPosLib.TxPos txPos, uint16 outputIndex) internal pure
+returns(struct UtxoPosLib.UtxoPos)
+```
+
+**Returns**
+
+UtxoPos of the according value
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| txPos | struct TxPosLib.TxPos | tx position | 
+| outputIndex | uint16 | the output's transaction index. | 
+
+### blockNum
+
+Given an UTXO position, returns the block number.
+
+```js
+function blockNum(struct UtxoPosLib.UtxoPos _utxoPos) internal pure
+returns(uint256)
+```
+
+**Returns**
+
+The output's block number.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _utxoPos | struct UtxoPosLib.UtxoPos | Output identifier in form of utxo position. | 
+
+### txIndex
+
+Given an UTXO position, returns the transaction index.
+
+```js
+function txIndex(struct UtxoPosLib.UtxoPos _utxoPos) internal pure
+returns(uint256)
+```
+
+**Returns**
+
+The output's transaction index.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _utxoPos | struct UtxoPosLib.UtxoPos | Output identifier in form of utxo position. | 
+
+### outputIndex
+
+Given an UTXO position, returns the output index.
+
+```js
+function outputIndex(struct UtxoPosLib.UtxoPos _utxoPos) internal pure
+returns(uint16)
+```
+
+**Returns**
+
+The output's index.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _utxoPos | struct UtxoPosLib.UtxoPos | Output identifier in form of utxo position. | 
+
+### txPos
+
+Given an UTXO position, returns transaction position.
+
+```js
+function txPos(struct UtxoPosLib.UtxoPos _utxoPos) internal pure
+returns(struct TxPosLib.TxPos)
+```
+
+**Returns**
+
+The transaction position.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _utxoPos | struct UtxoPosLib.UtxoPos | Output identifier in form of utxo position. | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/Vault.md
+++ b/plasma_framework/docs/Vault.md
@@ -1,0 +1,189 @@
+# Vault.sol
+
+View Source: [contracts/src/vaults/Vault.sol](../contracts/src/vaults/Vault.sol)
+
+**↗ Extends: [Operated](Operated.md)**
+**↘ Derived Contracts: [Erc20Vault](Erc20Vault.md), [EthVault](EthVault.md)**
+
+**Vault**
+
+Base contract for vault implementation
+
+## Contract Members
+**Constants & Variables**
+
+```js
+//internal members
+contract PlasmaFramework internal framework;
+bytes32[16] internal zeroHashes;
+
+//public members
+address[2] public depositVerifiers;
+uint256 public newDepositVerifierMaturityTimestamp;
+
+```
+
+**Events**
+
+```js
+event SetDepositVerifierCalled(address  nextDepositVerifier);
+```
+
+## Modifiers
+
+- [onlyFromNonQuarantinedExitGame](#onlyfromnonquarantinedexitgame)
+
+### onlyFromNonQuarantinedExitGame
+
+Checks it is called by a non quarantined exit game contract
+
+```js
+modifier onlyFromNonQuarantinedExitGame() internal
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+
+## Functions
+
+- [(PlasmaFramework _framework)](#)
+- [setDepositVerifier(address _verifier)](#setdepositverifier)
+- [getEffectiveDepositVerifier()](#geteffectivedepositverifier)
+- [_submitDepositBlock(bytes _depositTx)](#_submitdepositblock)
+
+### 
+
+```js
+function (PlasmaFramework _framework) public nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _framework | PlasmaFramework |  | 
+
+### setDepositVerifier
+
+Sets the deposit verifier contract. This can be only called by the operator.
+
+```js
+function setDepositVerifier(address _verifier) public nonpayable onlyOperator 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _verifier | address | address of the verifier contract. | 
+
+### getEffectiveDepositVerifier
+
+Gets currently effective deposit verifier contract address.
+
+```js
+function getEffectiveDepositVerifier() public view
+returns(address)
+```
+
+**Returns**
+
+contract address of deposit verifier.
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+
+### _submitDepositBlock
+
+Generate and submit a deposit block root to the PlasmaFramework
+
+```js
+function _submitDepositBlock(bytes _depositTx) internal nonpayable
+returns(uint256)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _depositTx | bytes |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/VaultRegistry.md
+++ b/plasma_framework/docs/VaultRegistry.md
@@ -1,0 +1,185 @@
+# VaultRegistry.sol
+
+View Source: [contracts/src/framework/registries/VaultRegistry.sol](../contracts/src/framework/registries/VaultRegistry.sol)
+
+**↗ Extends: [Operated](Operated.md)**
+**↘ Derived Contracts: [BlockController](BlockController.md), [PlasmaFramework](PlasmaFramework.md)**
+
+**VaultRegistry**
+
+## Contract Members
+**Constants & Variables**
+
+```js
+mapping(uint256 => address) private _vaults;
+mapping(address => uint256) private _vaultToId;
+struct Quarantine.Data private _vaultQuarantine;
+
+```
+
+**Events**
+
+```js
+event VaultRegistered(uint256  vaultId, address  vaultAddress);
+```
+
+## Modifiers
+
+- [onlyFromNonQuarantinedVault](#onlyfromnonquarantinedvault)
+
+### onlyFromNonQuarantinedVault
+
+modifier to check the call is from a non-quarantined vault.
+
+```js
+modifier onlyFromNonQuarantinedVault() internal
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+
+## Functions
+
+- [(uint256 _minExitPeriod, uint256 _initialImmuneVaults)](#)
+- [registerVault(uint256 _vaultId, address _vaultAddress)](#registervault)
+- [vaults(uint256 _vaultId)](#vaults)
+- [vaultToId(address _vaultAddress)](#vaulttoid)
+
+### 
+
+For each new vault contract, it should take at least 1 minExitPeriod to be able to start take effect to protect deposit transaction in mempool.
+     see: https://github.com/omisego/plasma-contracts/issues/173
+
+```js
+function (uint256 _minExitPeriod, uint256 _initialImmuneVaults) public nonpayable
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _minExitPeriod | uint256 |  | 
+| _initialImmuneVaults | uint256 |  | 
+
+### registerVault
+
+Register a vault within the PlasmaFramework. This can only be called by the maintainer.
+
+```js
+function registerVault(uint256 _vaultId, address _vaultAddress) public nonpayable onlyOperator 
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _vaultId | uint256 | the id for the vault contract to register. | 
+| _vaultAddress | address | address of the vault contract. | 
+
+### vaults
+
+public getter for getting vault address with vault id
+
+```js
+function vaults(uint256 _vaultId) public view
+returns(address)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _vaultId | uint256 |  | 
+
+### vaultToId
+
+public getter for getting vault id with vault address
+
+```js
+function vaultToId(address _vaultAddress) public view
+returns(uint256)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _vaultAddress | address |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/WireTransaction.md
+++ b/plasma_framework/docs/WireTransaction.md
@@ -1,0 +1,135 @@
+# WireTransaction (WireTransaction.sol)
+
+View Source: [contracts/src/transactions/WireTransaction.sol](../contracts/src/transactions/WireTransaction.sol)
+
+**WireTransaction**
+
+Utility functions for working with transactions in wire format. This assumes our transaction would be under certain data structure limitation.
+     Current transaction structure should be able to support Payment and DEX related transactions.
+     If the assumption breaks, we can still upgrade to a new ExitGame with either another transaction data structure or replace this with interfaces.
+
+## Structs
+### Output
+
+```js
+struct Output {
+ uint256 outputType,
+ uint256 amount,
+ bytes20 outputGuard,
+ address token
+}
+```
+
+## Functions
+
+- [getOutput(bytes transaction, uint16 outputIndex)](#getoutput)
+- [getTransactionType(bytes transaction)](#gettransactiontype)
+
+### getOutput
+
+Returns output for transaction in wire format.
+Outputs is a field on the second index and should be a list where first three elements are: amount, output guard, token.
+
+```js
+function getOutput(bytes transaction, uint16 outputIndex) internal pure
+returns(struct WireTransaction.Output)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| transaction | bytes |  | 
+| outputIndex | uint16 |  | 
+
+### getTransactionType
+
+Returns transaction type for transaction in wire format.
+Transaction type is the value of first field in rlp encoded list.
+
+```js
+function getTransactionType(bytes transaction) internal pure
+returns(uint256)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| transaction | bytes |  | 
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/docs/ZeroHashesProvider.md
+++ b/plasma_framework/docs/ZeroHashesProvider.md
@@ -1,0 +1,99 @@
+# ZeroHashesProvider.sol
+
+View Source: [contracts/src/vaults/ZeroHashesProvider.sol](../contracts/src/vaults/ZeroHashesProvider.sol)
+
+**ZeroHashesProvider**
+
+## Functions
+
+- [getZeroHashes()](#getzerohashes)
+
+### getZeroHashes
+
+Pre-computes zero hashes to be used for building merkle tree for deposit block
+
+```js
+function getZeroHashes() internal pure
+returns(bytes32[16])
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+
+## Contracts
+
+* [Address](Address.md)
+* [AddressPayable](AddressPayable.md)
+* [Bits](Bits.md)
+* [BlockController](BlockController.md)
+* [BlockModel](BlockModel.md)
+* [BondSize](BondSize.md)
+* [ECDSA](ECDSA.md)
+* [Erc20DepositVerifier](Erc20DepositVerifier.md)
+* [Erc20Vault](Erc20Vault.md)
+* [EthDepositVerifier](EthDepositVerifier.md)
+* [EthVault](EthVault.md)
+* [ExitableTimestamp](ExitableTimestamp.md)
+* [ExitGameController](ExitGameController.md)
+* [ExitGameRegistry](ExitGameRegistry.md)
+* [ExitId](ExitId.md)
+* [ExitPriority](ExitPriority.md)
+* [IERC20](IERC20.md)
+* [IErc20DepositVerifier](IErc20DepositVerifier.md)
+* [IEthDepositVerifier](IEthDepositVerifier.md)
+* [IExitProcessor](IExitProcessor.md)
+* [IOutputGuardHandler](IOutputGuardHandler.md)
+* [IsDeposit](IsDeposit.md)
+* [ISpendingCondition](ISpendingCondition.md)
+* [IStateTransitionVerifier](IStateTransitionVerifier.md)
+* [ITxFinalizationVerifier](ITxFinalizationVerifier.md)
+* [Math](Math.md)
+* [Merkle](Merkle.md)
+* [Migrations](Migrations.md)
+* [OnlyFromAddress](OnlyFromAddress.md)
+* [OnlyWithValue](OnlyWithValue.md)
+* [Operated](Operated.md)
+* [OutputGuardHandlerRegistry](OutputGuardHandlerRegistry.md)
+* [OutputGuardModel](OutputGuardModel.md)
+* [OutputId](OutputId.md)
+* [Ownable](Ownable.md)
+* [PaymentChallengeIFEInputSpent](PaymentChallengeIFEInputSpent.md)
+* [PaymentChallengeIFENotCanonical](PaymentChallengeIFENotCanonical.md)
+* [PaymentChallengeIFEOutputSpent](PaymentChallengeIFEOutputSpent.md)
+* [PaymentChallengeStandardExit](PaymentChallengeStandardExit.md)
+* [PaymentEip712Lib](PaymentEip712Lib.md)
+* [PaymentExitDataModel](PaymentExitDataModel.md)
+* [PaymentExitGame](PaymentExitGame.md)
+* [PaymentInFlightExitModelUtils](PaymentInFlightExitModelUtils.md)
+* [PaymentInFlightExitRouter](PaymentInFlightExitRouter.md)
+* [PaymentInFlightExitRouterArgs](PaymentInFlightExitRouterArgs.md)
+* [PaymentOutputGuardHandler](PaymentOutputGuardHandler.md)
+* [PaymentOutputModel](PaymentOutputModel.md)
+* [PaymentOutputToPaymentTxCondition](PaymentOutputToPaymentTxCondition.md)
+* [PaymentPiggybackInFlightExit](PaymentPiggybackInFlightExit.md)
+* [PaymentProcessInFlightExit](PaymentProcessInFlightExit.md)
+* [PaymentProcessStandardExit](PaymentProcessStandardExit.md)
+* [PaymentStandardExitRouter](PaymentStandardExitRouter.md)
+* [PaymentStandardExitRouterArgs](PaymentStandardExitRouterArgs.md)
+* [PaymentStartInFlightExit](PaymentStartInFlightExit.md)
+* [PaymentStartStandardExit](PaymentStartStandardExit.md)
+* [PaymentTransactionModel](PaymentTransactionModel.md)
+* [PaymentTransactionStateTransitionVerifier](PaymentTransactionStateTransitionVerifier.md)
+* [PlasmaFramework](PlasmaFramework.md)
+* [PriorityQueue](PriorityQueue.md)
+* [Protocol](Protocol.md)
+* [Quarantine](Quarantine.md)
+* [RLP](RLP.md)
+* [SafeERC20](SafeERC20.md)
+* [SafeMath](SafeMath.md)
+* [SpendingConditionRegistry](SpendingConditionRegistry.md)
+* [TxFinalizationModel](TxFinalizationModel.md)
+* [TxFinalizationVerifier](TxFinalizationVerifier.md)
+* [TxPosLib](TxPosLib.md)
+* [UtxoPosLib](UtxoPosLib.md)
+* [Vault](Vault.md)
+* [VaultRegistry](VaultRegistry.md)
+* [WireTransaction](WireTransaction.md)
+* [ZeroHashesProvider](ZeroHashesProvider.md)

--- a/plasma_framework/package-lock.json
+++ b/plasma_framework/package-lock.json
@@ -375,7 +375,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -422,6 +421,24 @@
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "args": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/args/-/args-5.0.1.tgz",
+      "integrity": "sha512-1kqmFCFsPffavQFGt8OxJdIcETti99kySRUPMpOhaGjL6mRJn8HFU1OxKY5bMqfZKUwTQc1mZkAjmGYaVOHFtQ==",
+      "requires": {
+        "camelcase": "5.0.0",
+        "chalk": "2.4.2",
+        "leven": "2.1.0",
+        "mri": "1.1.4"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+        }
       }
     },
     "array-flatten": {
@@ -1712,7 +1729,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1854,7 +1870,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -1862,8 +1877,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colors": {
       "version": "1.0.3",
@@ -2178,6 +2192,11 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "dateformat": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
     },
     "death": {
       "version": "1.1.0",
@@ -3676,6 +3695,11 @@
         "micromatch": "^4.0.2"
       }
     },
+    "fast-json-parse": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
+      "integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw=="
+    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -3686,6 +3710,16 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fast-redact": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-2.0.0.tgz",
+      "integrity": "sha512-zxpkULI9W9MNTK2sJ3BpPQrTEXFNESd2X6O1tXMFpK/XM0G5c5Rll2EVYZH2TqI3xRGK/VaJ+eEOt7pnENJpeA=="
+    },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
     "fastq": {
       "version": "1.6.0",
@@ -3814,6 +3848,11 @@
         "rimraf": "2.6.3",
         "write": "1.0.3"
       }
+    },
+    "flatstr": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
+      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
     },
     "flatted": {
       "version": "2.0.1",
@@ -17392,8 +17431,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbol-support-x": {
       "version": "1.4.2",
@@ -18026,6 +18064,11 @@
       "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
       "dev": true
     },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
     "js-sha3": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
@@ -18354,6 +18397,11 @@
         }
       }
     },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -18419,6 +18467,11 @@
           "dev": true
         }
       }
+    },
+    "linq": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/linq/-/linq-3.2.1.tgz",
+      "integrity": "sha512-BEhjQpbvrKPWlg5m/+PXTHsQoXzzR0UWCvgI8Hm+WtUMtTwPvw9Tay5CWfqsWSVk81wqbHNDFpFXyqBmm4/dqA=="
     },
     "load-json-file": {
       "version": "2.0.0",
@@ -18884,6 +18937,11 @@
         "rimraf": "^2.5.4",
         "run-queue": "^1.0.3"
       }
+    },
+    "mri": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+      "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w=="
     },
     "ms": {
       "version": "2.1.2",
@@ -19654,6 +19712,52 @@
         "pinkie": "^2.0.0"
       }
     },
+    "pino": {
+      "version": "5.13.4",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-5.13.4.tgz",
+      "integrity": "sha512-heeg8m8FZY8Nl3nuuD+msJUmhamqoGl7JXoTExh9YpGajzz6LYbVByUqrjbf4sCEMYFsqdcqnTJWiSY660DraQ==",
+      "requires": {
+        "fast-redact": "^2.0.0",
+        "fast-safe-stringify": "^2.0.7",
+        "flatstr": "^1.0.9",
+        "pino-std-serializers": "^2.3.0",
+        "quick-format-unescaped": "^3.0.2",
+        "sonic-boom": "^0.7.5"
+      }
+    },
+    "pino-pretty": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-2.6.1.tgz",
+      "integrity": "sha512-e/CWtKLidqkr7sinfIVVcsfcHgnFVlGvuEfKuuPFnxBo+9dZZsmgF8a9Rj7SYJ5LMZ8YBxNY9Ca46eam4ajKtQ==",
+      "requires": {
+        "args": "^5.0.0",
+        "chalk": "^2.3.2",
+        "dateformat": "^3.0.3",
+        "fast-json-parse": "^1.0.3",
+        "fast-safe-stringify": "^2.0.6",
+        "jmespath": "^0.15.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^3.0.6",
+        "split2": "^3.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "pino-std-serializers": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.4.2.tgz",
+      "integrity": "sha512-WaL504dO8eGs+vrK+j4BuQQq6GLKeCCcHaMB2ItygzVURcL1CycwNEUHTD/lHFHs/NL5qAz2UKrjYWXKSf4aMQ=="
+    },
     "pkg-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
@@ -19849,6 +19953,11 @@
         "object-assign": "^4.1.0",
         "strict-uri-encode": "^1.0.0"
       }
+    },
+    "quick-format-unescaped": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
+      "integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ=="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -20135,6 +20244,11 @@
         "stealthy-require": "^1.1.1",
         "tough-cookie": "^2.3.3"
       }
+    },
+    "require-all": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/require-all/-/require-all-3.0.0.tgz",
+      "integrity": "sha1-Rz1JcEvjEBFc4ST3c4Ox69hnExI="
     },
     "require-from-string": {
       "version": "2.0.2",
@@ -20720,6 +20834,39 @@
         "npm-check-updates": "^3.1.11"
       }
     },
+    "solidoc": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/solidoc/-/solidoc-1.0.5.tgz",
+      "integrity": "sha512-6UUP66JhtnTbLBjDt/eJgIzwYLTKEwaw0ocA5073jXtpkKk49PDGjJbtVgRJQID0cHHsRLXg6b8ROdk8sOSTnw==",
+      "requires": {
+        "fs-extra": "^7.0.0",
+        "glob": "^7.1.3",
+        "linq": "^3.1.0",
+        "pino": "^5.8.0",
+        "pino-pretty": "^2.2.2",
+        "require-all": "^3.0.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        }
+      }
+    },
+    "sonic-boom": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.6.tgz",
+      "integrity": "sha512-k9E2QQ4zxuVRLDW+ZW6ISzJs3wlEorVdmM7ApDgor7wsGKSDG5YGHsGmgLY4XYh4DMlr/2ap2BWAE7yTFJtWnQ==",
+      "requires": {
+        "flatstr": "^1.0.12"
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -20773,6 +20920,26 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
+    },
+    "split2": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.1.1.tgz",
+      "integrity": "sha512-emNzr1s7ruq4N+1993yht631/JH+jaj0NYBosuKmLcq+JkGQ9MmTw1RB1fGaTCzUuseRIClrlSLHRNYGwWQ58Q==",
+      "requires": {
+        "readable-stream": "^3.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -20937,7 +21104,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }

--- a/plasma_framework/package.json
+++ b/plasma_framework/package.json
@@ -31,6 +31,7 @@
   "scripts": {
     "test": "truffle test",
     "coverage": "truffle run coverage",
+    "docgen": "[[ -z $(git status --porcelain) ]] && rm -rf contracts/mocks && solidoc ./ ./docs && git checkout -- contracts/mocks || echo 'Please make sure all files are committed and the git status is clean' ",
     "linter": "node_modules/eslint/bin/eslint.js . --fix",
     "linter-sol": "node_modules/.bin/solhint --max-warnings 0 \"contracts/**/*.sol\""
   },

--- a/plasma_framework/package.json
+++ b/plasma_framework/package.json
@@ -9,7 +9,8 @@
     "@truffle/hdwallet-provider": "^1.0.19",
     "dotenv": "^8.0.0",
     "lodash.clonedeep": "^4.5.0",
-    "openzeppelin-solidity": "2.3.0"
+    "openzeppelin-solidity": "2.3.0",
+    "solidoc": "^1.0.5"
   },
   "devDependencies": {
     "@codechecks/client": "^0.1.10",


### PR DESCRIPTION
### Note
- install `solidoc`
- add `npm run docgen` command. Please code review this commit: https://github.com/omisego/plasma-contracts/commit/8f7514dbfccf5ae78059b951a21e2e31de776ac9. I removed the `mocks` file first in the command in order to avoid generating documentation for `mocks`. Please take a looks whether that makes sense or not.
- run `npm run docgen`, and commit the auto generated doc files.

ref #272 

### Reference
- Openzepplin's `solidity-docgen` does not support import with dependency: https://github.com/OpenZeppelin/solidity-docgen/issues/24
- Found `solidoc` via this issue referenced above issue: https://github.com/PolymathNetwork/polymath-core/pull/802