### PR TITLE
fix: copy lib events into linked contracts

### DIFF
--- a/plasma_framework/contracts/src/exits/payment/routers/PaymentInFlightExitRouter.sol
+++ b/plasma_framework/contracts/src/exits/payment/routers/PaymentInFlightExitRouter.sol
@@ -51,6 +51,62 @@ contract PaymentInFlightExitRouter is IExitProcessor, Operated, OnlyWithValue {
     event IFEBondUpdated(uint128 bondSize);
     event PiggybackBondUpdated(uint128 bondSize);
 
+    event InFlightExitStarted(
+        address indexed initiator,
+        bytes32 txHash
+    );
+
+    event InFlightExitInputPiggybacked(
+        address indexed exitTarget,
+        bytes32 txHash,
+        uint16 inputIndex
+    );
+
+    event InFlightExitOmitted(
+        uint160 indexed exitId,
+        address token
+    );
+
+    event InFlightExitOutputWithdrawn(
+        uint160 indexed exitId,
+        uint16 outputIndex
+    );
+
+    event InFlightExitInputWithdrawn(
+        uint160 indexed exitId,
+        uint16 inputIndex
+    );
+
+    event InFlightExitOutputPiggybacked(
+        address indexed exitTarget,
+        bytes32 txHash,
+        uint16 outputIndex
+    );
+
+    event InFlightExitChallenged(
+        address indexed challenger,
+        bytes32 txHash,
+        uint256 challengeTxPosition
+    );
+
+    event InFlightExitChallengeResponded(
+        address challenger,
+        bytes32 txHash,
+        uint256 challengeTxPosition
+    );
+
+    event InFlightExitInputBlocked(
+        address indexed challenger,
+        bytes32 txHash,
+        uint16 inputIndex
+    );
+
+    event InFlightExitOutputBlocked(
+        address indexed challenger,
+        bytes32 ifeTxHash,
+        uint16 outputIndex
+    );
+
     constructor(
         PlasmaFramework framework,
         uint256 ethVaultId,

--- a/plasma_framework/contracts/src/exits/payment/routers/PaymentStandardExitRouter.sol
+++ b/plasma_framework/contracts/src/exits/payment/routers/PaymentStandardExitRouter.sol
@@ -42,6 +42,23 @@ contract PaymentStandardExitRouter is
 
     event StandardExitBondUpdated(uint128 bondSize);
 
+    event ExitStarted(
+        address indexed owner,
+        uint160 exitId
+    );
+
+    event ExitChallenged(
+        uint256 indexed utxoPos
+    );
+
+    event ExitOmitted(
+        uint160 indexed exitId
+    );
+
+    event ExitFinalized(
+        uint160 indexed exitId
+    );
+
     constructor(
         PlasmaFramework framework,
         uint256 ethVaultId,

--- a/plasma_framework/test/src/exits/payment/PaymentChallengeIFEInputSpent.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentChallengeIFEInputSpent.test.js
@@ -241,16 +241,14 @@ contract('PaymentChallengeIFEInputSpent', ([_, alice, inputOwner, outputOwner, c
         describe('after successfully challenged IFE input spent', () => {
             beforeEach(async () => {
                 this.challengerPreBalance = new BN(await web3.eth.getBalance(challenger));
-                const { receipt } = await this.exitGame.challengeInFlightExitInputSpent(
+                this.challengeTx = await this.exitGame.challengeInFlightExitInputSpent(
                     this.challengeArgs, { from: challenger },
                 );
-                this.challengeTxReceipt = receipt;
             });
 
             it('should emit InFlightExitInputBlocked event', async () => {
-                await expectEvent.inTransaction(
-                    this.challengeTxReceipt.transactionHash,
-                    PaymentChallengeIFEInputSpent,
+                await expectEvent.inLogs(
+                    this.challengeTx.logs,
                     'InFlightExitInputBlocked',
                     {
                         challenger,
@@ -269,7 +267,7 @@ contract('PaymentChallengeIFEInputSpent', ([_, alice, inputOwner, outputOwner, c
                 const actualPostBalance = new BN(await web3.eth.getBalance(challenger));
                 const expectedPostBalance = this.challengerPreBalance
                     .add(new BN(PIGGYBACK_BOND))
-                    .sub(await spentOnGas(this.challengeTxReceipt));
+                    .sub(await spentOnGas(this.challengeTx.receipt));
 
                 expect(actualPostBalance).to.be.bignumber.equal(expectedPostBalance);
             });

--- a/plasma_framework/test/src/exits/payment/PaymentChallengeIFENotCanonical.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentChallengeIFENotCanonical.test.js
@@ -256,9 +256,8 @@ contract('PaymentInFlightExitRouter', ([_, ifeOwner, inputOwner, outputOwner, co
 
             it('should emit InFlightExitChallenged event', async () => {
                 const rlpInFlightTxBytes = web3.utils.bytesToHex(this.inFlightTx.rlpEncoded());
-                await expectEvent.inTransaction(
-                    this.challengeIFETx.receipt.transactionHash,
-                    PaymentChallengeIFENotCanonical,
+                await expectEvent.inLogs(
+                    this.challengeIFETx.logs,
                     'InFlightExitChallenged',
                     {
                         challenger,
@@ -407,14 +406,13 @@ contract('PaymentInFlightExitRouter', ([_, ifeOwner, inputOwner, outputOwner, co
                 // it seems to be solidity `~uint256(0)` - what is important here: it's HUGE
                 const expectedCompetitorPos = new BN(2).pow(new BN(256)).sub(new BN(1));
 
-                const { receipt } = await this.exitGame.challengeInFlightExitNotCanonical(
+                const { logs } = await this.exitGame.challengeInFlightExitNotCanonical(
                     this.challengeArgs, { from: challenger },
                 );
 
                 const rlpInFlightTxBytes = web3.utils.bytesToHex(this.inFlightTx.rlpEncoded());
-                await expectEvent.inTransaction(
-                    receipt.transactionHash,
-                    PaymentChallengeIFENotCanonical,
+                await expectEvent.inLogs(
+                    logs,
                     'InFlightExitChallenged',
                     {
                         challenger,
@@ -456,16 +454,15 @@ contract('PaymentInFlightExitRouter', ([_, ifeOwner, inputOwner, outputOwner, co
             });
 
             it('should emit InFlightExitChallengeResponded event', async () => {
-                const { receipt } = await this.exitGame.respondToNonCanonicalChallenge(
+                const { logs } = await this.exitGame.respondToNonCanonicalChallenge(
                     this.challengeArgs.inFlightTx,
                     this.inFlightTxPos,
                     this.inFlightTxInclusionProof,
                     { from: ifeOwner },
                 );
 
-                await expectEvent.inTransaction(
-                    receipt.transactionHash,
-                    PaymentChallengeIFENotCanonical,
+                await expectEvent.inLogs(
+                    logs,
                     'InFlightExitChallengeResponded',
                     {
                         challenger: ifeOwner,

--- a/plasma_framework/test/src/exits/payment/PaymentChallengeIFEOutputSpent.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentChallengeIFEOutputSpent.test.js
@@ -194,12 +194,11 @@ contract('PaymentChallengeIFEOutputSpent', ([_, alice, bob]) => {
         });
 
         it('should emit event when challenge is successful', async () => {
-            const { receipt } = await this.exitGame.challengeInFlightExitOutputSpent(
+            const { logs } = await this.exitGame.challengeInFlightExitOutputSpent(
                 this.challengeArgs, { from: bob },
             );
-            await expectEvent.inTransaction(
-                receipt.transactionHash,
-                PaymentChallengeIFEOutputSpent,
+            await expectEvent.inLogs(
+                logs,
                 'InFlightExitOutputBlocked',
                 {
                     challenger: bob,

--- a/plasma_framework/test/src/exits/payment/PaymentChallengeStandardExit.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentChallengeStandardExit.test.js
@@ -310,9 +310,8 @@ contract('PaymentStandardExitRouter', ([_, alice, bob]) => {
                 });
 
                 it('should emit ExitChallenged event when successfully challenged', async () => {
-                    await expectEvent.inTransaction(
-                        this.tx.receipt.transactionHash,
-                        PaymentChallengeStandardExit,
+                    await expectEvent.inLogs(
+                        this.tx.logs,
                         'ExitChallenged',
                         { utxoPos: new BN(this.exitData.utxoPos) },
                     );

--- a/plasma_framework/test/src/exits/payment/PaymentExitGame.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentExitGame.test.js
@@ -386,16 +386,14 @@ contract('PaymentExitGame - End to End Tests', ([_, richFather, bob]) => {
                         };
 
                         this.bobBalanceBeforeChallenge = new BN(await web3.eth.getBalance(bob));
-                        const { receipt } = await this.exitGame.challengeStandardExit(
+                        this.challengeTx = await this.exitGame.challengeStandardExit(
                             args, { from: bob },
                         );
-                        this.challengeTxReciept = receipt;
                     });
 
                     it('should challenge it successfully', async () => {
-                        await expectEvent.inTransaction(
-                            this.challengeTxReciept.transactionHash,
-                            PaymentChallengeStandardExit,
+                        await expectEvent.inLogs(
+                            this.challengeTx.logs,
                             'ExitChallenged',
                             { utxoPos: new BN(this.depositUtxoPos) },
                         );
@@ -405,7 +403,7 @@ contract('PaymentExitGame - End to End Tests', ([_, richFather, bob]) => {
                         const actualBobBalanceAfterChallenge = new BN(await web3.eth.getBalance(bob));
                         const expectedBobBalanceAfterChallenge = this.bobBalanceBeforeChallenge
                             .add(this.startStandardExitBondSize)
-                            .sub(await spentOnGas(this.challengeTxReciept));
+                            .sub(await spentOnGas(this.challengeTx.receipt));
 
                         expect(actualBobBalanceAfterChallenge).to.be.bignumber.equal(expectedBobBalanceAfterChallenge);
                     });

--- a/plasma_framework/test/src/exits/payment/PaymentPiggybackInFlightExitOnInput.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentPiggybackInFlightExitOnInput.test.js
@@ -306,9 +306,8 @@ contract('PaymentInFlightExitRouter', ([_, alice, inputOwner, nonInputOwner, out
             });
 
             it('should emit InFlightExitInputPiggybacked event', async () => {
-                await expectEvent.inTransaction(
-                    this.piggybackTx.receipt.transactionHash,
-                    PaymentPiggybackInFlightExit,
+                await expectEvent.inLogs(
+                    this.piggybackTx.logs,
                     'InFlightExitInputPiggybacked',
                     {
                         exitTarget: inputOwner,

--- a/plasma_framework/test/src/exits/payment/PaymentPiggybackInFlightExitOnOutput.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentPiggybackInFlightExitOnOutput.test.js
@@ -400,9 +400,8 @@ contract('PaymentInFlightExitRouter', ([_, alice, inputOwner, outputOwner, nonOu
             });
 
             it('should emit InFlightExitOutputPiggybacked event', async () => {
-                await expectEvent.inTransaction(
-                    this.piggybackTx.receipt.transactionHash,
-                    PaymentPiggybackInFlightExit,
+                await expectEvent.inLogs(
+                    this.piggybackTx.logs,
                     'InFlightExitOutputPiggybacked',
                     {
                         exitTarget: outputOwner,

--- a/plasma_framework/test/src/exits/payment/PaymentProcessInFlightExit.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentProcessInFlightExit.test.js
@@ -170,10 +170,9 @@ contract('PaymentInFlightExitRouter', ([_, ifeBondOwner, inputOwner1, inputOwner
         it('should omit the exit if the exit does not exist', async () => {
             const nonExistingExitId = 666;
 
-            const { receipt } = await this.exitGame.processExit(nonExistingExitId, VAULT_ID.ETH, ETH);
-            await expectEvent.inTransaction(
-                receipt.transactionHash,
-                PaymentProcessInFlightExit,
+            const { logs } = await this.exitGame.processExit(nonExistingExitId, VAULT_ID.ETH, ETH);
+            await expectEvent.inLogs(
+                logs,
                 'InFlightExitOmitted',
                 { exitId: new BN(nonExistingExitId), token: ETH },
             );
@@ -186,10 +185,9 @@ contract('PaymentInFlightExitRouter', ([_, ifeBondOwner, inputOwner1, inputOwner
 
             await this.exitGame.proxyFlagOutputSpent(TEST_OUTPUT_ID_FOR_INPUT_1);
 
-            const { receipt } = await this.exitGame.processExit(dummyExitId, VAULT_ID.ETH, ETH);
-            await expectEvent.inTransaction(
-                receipt.transactionHash,
-                PaymentProcessInFlightExit,
+            const { logs } = await this.exitGame.processExit(dummyExitId, VAULT_ID.ETH, ETH);
+            await expectEvent.inLogs(
+                logs,
                 'InFlightExitOmitted',
                 { exitId: new BN(dummyExitId), token: ETH },
             );
@@ -383,11 +381,10 @@ contract('PaymentInFlightExitRouter', ([_, ifeBondOwner, inputOwner1, inputOwner
             });
 
             it('should emit InFlightExitInputWithdrawn event', async () => {
-                const { receipt } = await this.exitGame.processExit(this.dummyExitId, VAULT_ID.ERC20, erc20);
+                const { logs } = await this.exitGame.processExit(this.dummyExitId, VAULT_ID.ERC20, erc20);
                 const inputIndexForThirdInput = 2;
-                await expectEvent.inTransaction(
-                    receipt.transactionHash,
-                    PaymentProcessInFlightExit,
+                await expectEvent.inLogs(
+                    logs,
                     'InFlightExitInputWithdrawn',
                     { exitId: new BN(this.dummyExitId), inputIndex: new BN(inputIndexForThirdInput) },
                 );
@@ -454,11 +451,10 @@ contract('PaymentInFlightExitRouter', ([_, ifeBondOwner, inputOwner1, inputOwner
             });
 
             it('should emit InFlightExitOutputWithdrawn event', async () => {
-                const { receipt } = await this.exitGame.processExit(this.dummyExitId, VAULT_ID.ERC20, erc20);
+                const { logs } = await this.exitGame.processExit(this.dummyExitId, VAULT_ID.ERC20, erc20);
                 const outputIndexForThirdOutput = 2;
-                await expectEvent.inTransaction(
-                    receipt.transactionHash,
-                    PaymentProcessInFlightExit,
+                await expectEvent.inLogs(
+                    logs,
                     'InFlightExitOutputWithdrawn',
                     { exitId: new BN(this.dummyExitId), outputIndex: new BN(outputIndexForThirdOutput) },
                 );

--- a/plasma_framework/test/src/exits/payment/PaymentProcessStandardExit.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentProcessStandardExit.test.js
@@ -82,11 +82,10 @@ contract('PaymentStandardExitRouter', ([_, alice]) => {
             const testExitData = getTestExitData(exitable, ETH);
             await this.exitGame.setExit(exitId, testExitData);
 
-            const { receipt } = await this.exitGame.processExit(exitId, VAULT_ID.ETH, ETH);
+            const { logs } = await this.exitGame.processExit(exitId, VAULT_ID.ETH, ETH);
 
-            await expectEvent.inTransaction(
-                receipt.transactionHash,
-                PaymentProcessStandardExit,
+            await expectEvent.inLogs(
+                logs,
                 'ExitOmitted',
                 { exitId: new BN(exitId) },
             );
@@ -98,11 +97,10 @@ contract('PaymentStandardExitRouter', ([_, alice]) => {
             await this.exitGame.setExit(exitId, testExitData);
             await this.exitGame.proxyFlagOutputSpent(testExitData.outputId);
 
-            const { receipt } = await this.exitGame.processExit(exitId, VAULT_ID.ETH, ETH);
+            const { logs } = await this.exitGame.processExit(exitId, VAULT_ID.ETH, ETH);
 
-            await expectEvent.inTransaction(
-                receipt.transactionHash,
-                PaymentProcessStandardExit,
+            await expectEvent.inLogs(
+                logs,
                 'ExitOmitted',
                 { exitId: new BN(exitId) },
             );
@@ -201,11 +199,10 @@ contract('PaymentStandardExitRouter', ([_, alice]) => {
             const testExitData = getTestExitData(true, ETH);
             await this.exitGame.setExit(exitId, testExitData);
 
-            const { receipt } = await this.exitGame.processExit(exitId, VAULT_ID.ETH, ETH);
+            const { logs } = await this.exitGame.processExit(exitId, VAULT_ID.ETH, ETH);
 
-            await expectEvent.inTransaction(
-                receipt.transactionHash,
-                PaymentProcessStandardExit,
+            await expectEvent.inLogs(
+                logs,
                 'ExitFinalized',
                 { exitId: new BN(exitId) },
             );

--- a/plasma_framework/test/src/exits/payment/PaymentStartInFlightExit.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentStartInFlightExit.test.js
@@ -249,16 +249,15 @@ contract('PaymentInFlightExitRouter', ([_, alice, richFather, carol]) => {
             });
 
             it('should emit InFlightExitStarted event', async () => {
-                const { receipt } = await this.exitGame.startInFlightExit(
+                const { logs } = await this.exitGame.startInFlightExit(
                     this.args,
                     { from: alice, value: this.startIFEBondSize.toString() },
                 );
 
                 const expectedIfeHash = web3.utils.sha3(this.args.inFlightTx);
 
-                await expectEvent.inTransaction(
-                    receipt.transactionHash,
-                    PaymentStartInFlightExit,
+                await expectEvent.inLogs(
+                    logs,
                     'InFlightExitStarted',
                     {
                         initiator: alice,

--- a/plasma_framework/test/src/exits/payment/PaymentStartStandardExit.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentStartStandardExit.test.js
@@ -342,13 +342,12 @@ contract('PaymentStandardExitRouter', ([_, outputOwner, nonOutputOwner]) => {
 
             const isTxDeposit = await this.isDeposit.test(this.dummyBlockNum);
             const exitId = await this.exitIdHelper.getStandardExitId(isTxDeposit, args.rlpOutputTx, args.utxoPos);
-            const { receipt } = await this.exitGame.startStandardExit(
+            const { logs } = await this.exitGame.startStandardExit(
                 args, { from: outputOwner, value: this.startStandardExitBondSize },
             );
 
-            await expectEvent.inTransaction(
-                receipt.transactionHash,
-                PaymentStartStandardExit,
+            await expectEvent.inLogs(
+                logs,
                 'ExitStarted',
                 { owner: outputOwner, exitId },
             );

--- a/plasma_framework/test/src/exits/payment/PaymentUpdateBond.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentUpdateBond.test.js
@@ -90,14 +90,12 @@ contract('PaymentStandardExitRouter', ([_, outputOwner]) => {
 
             this.startStandardExitBondSize = await this.exitGame.startStandardExitBondSize();
             this.newBondSize = this.startStandardExitBondSize.addn(20);
-            const { receipt } = await this.exitGame.updateStartStandardExitBondSize(this.newBondSize);
-            this.updateTxReceipt = receipt;
+            this.updateTx = await this.exitGame.updateStartStandardExitBondSize(this.newBondSize);
         });
 
         it('should emit an event when the standard exit bond size is updated', async () => {
-            await expectEvent.inTransaction(
-                this.updateTxReceipt.transactionHash,
-                PaymentStandardExitRouter,
+            await expectEvent.inLogs(
+                this.updateTx.logs,
                 'StandardExitBondUpdated',
                 {
                     bondSize: this.newBondSize,
@@ -127,14 +125,12 @@ contract('PaymentStandardExitRouter', ([_, outputOwner]) => {
 
             this.startIFEBondSize = await this.exitGame.startIFEBondSize();
             this.newBondSize = this.startIFEBondSize.addn(20);
-            const { receipt } = await this.exitGame.updateStartIFEBondSize(this.newBondSize);
-            this.updateIFEBondTxReceipt = receipt;
+            this.updateIFEBondTx = await this.exitGame.updateStartIFEBondSize(this.newBondSize);
         });
 
         it('should emit an event when the in-flight exit bond size is updated', async () => {
-            await expectEvent.inTransaction(
-                this.updateIFEBondTxReceipt.transactionHash,
-                PaymentInFlightExitRouter,
+            await expectEvent.inLogs(
+                this.updateIFEBondTx.logs,
                 'IFEBondUpdated',
                 {
                     bondSize: this.newBondSize,
@@ -164,14 +160,12 @@ contract('PaymentStandardExitRouter', ([_, outputOwner]) => {
 
             this.piggybackBondSize = await this.exitGame.piggybackBondSize();
             this.newBondSize = this.piggybackBondSize.addn(20);
-            const { receipt } = await this.exitGame.updatePiggybackBondSize(this.newBondSize);
-            this.updatePiggybackBondTxReceipt = receipt;
+            this.updatePiggybackBondTx = await this.exitGame.updatePiggybackBondSize(this.newBondSize);
         });
 
         it('should emit an event when the in-flight exit bond size is updated', async () => {
-            await expectEvent.inTransaction(
-                this.updatePiggybackBondTxReceipt.transactionHash,
-                PaymentInFlightExitRouter,
+            await expectEvent.inLogs(
+                this.updatePiggybackBondTx.logs,
                 'PiggybackBondUpdated',
                 {
                     bondSize: this.newBondSize,

--- a/tests/tests_utils/plasma_framework.py
+++ b/tests/tests_utils/plasma_framework.py
@@ -1,7 +1,5 @@
 import enum
 
-from web3.exceptions import MismatchedABI
-
 from plasma_core.constants import CHILD_BLOCK_INTERVAL
 from plasma_core.transaction import TxOutputTypes, TxTypes
 from plasma_core.utils.transactions import decode_utxo_id
@@ -100,18 +98,6 @@ class PlasmaFramework:
                                                ),
                                          libraries=libs_map)
 
-        # collect events emitted by libraries
-        for lib in libs:
-            lib_events = lib.get_contract_events()
-            for event in lib_events:
-                try:
-                    if hasattr(payment_exit_game.events, event.event_name):
-                        raise AttributeError(event.event_name)
-                except MismatchedABI:
-                    pass
-                finally:
-                    setattr(payment_exit_game.events, event.event_name, event)
-            payment_exit_game.events._events += lib.events._events
         return payment_exit_game
 
     @staticmethod


### PR DESCRIPTION
# Description
 - Copy library events into the linked contracts (*Routers) so that they appear in the contract's abi and so are searchable. See https://blog.aragon.org/library-driven-development-in-solidity-2bebcaf88736/

 - Changed the tests to use `expectEvent.inLogs` instead of `expectEvent.inTransaction`, this makes sure that the events are actually in the logs, and so can be found later by e.g `getPastEvents()`