### PR TITLE
216 ife with invalid priority

### DIFF
--- a/plasma_framework/contracts/mocks/exits/utils/ExitableTimestampWrapper.sol
+++ b/plasma_framework/contracts/mocks/exits/utils/ExitableTimestampWrapper.sol
@@ -13,8 +13,8 @@ contract ExitableTimestampWrapper {
     function calculateDepositTxOutputExitableTimestamp(
         uint256 _now
     )
-        public 
-        view 
+        public
+        view
         returns (uint64)
     {
         return calculator.calculateDepositTxOutputExitableTimestamp(_now);
@@ -24,7 +24,7 @@ contract ExitableTimestampWrapper {
         uint256 _now,
         uint256 _blockTimestamp
     )
-        public 
+        public
         view
         returns (uint64)
     {

--- a/plasma_framework/contracts/mocks/exits/utils/ExitableTimestampWrapper.sol
+++ b/plasma_framework/contracts/mocks/exits/utils/ExitableTimestampWrapper.sol
@@ -10,11 +10,24 @@ contract ExitableTimestampWrapper {
         calculator = ExitableTimestamp.Calculator(_minExitPeriod);
     }
 
-    function calculate(uint256 _now, uint256 _blockTimestamp, bool _isDeposit)
-        public
-        view
-        returns (uint256)
+    function calculateDepositTxOutputExitableTimestamp(
+        uint256 _now
+    )
+        public 
+        view 
+        returns (uint64)
     {
-        return calculator.calculate(_now, _blockTimestamp, _isDeposit);
+        return calculator.calculateDepositTxOutputExitableTimestamp(_now);
+    }
+
+    function calculateTxExitableTimestamp(
+        uint256 _now,
+        uint256 _blockTimestamp
+    )
+        public 
+        view
+        returns (uint64)
+    {
+        return calculator.calculateTxExitableTimestamp(_now, _blockTimestamp);
     }
 }

--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentPiggybackInFlightExit.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentPiggybackInFlightExit.sol
@@ -167,12 +167,8 @@ library PaymentPiggybackInFlightExit {
         private
     {
         (, uint256 blockTimestamp) = controller.framework.blocks(utxoPos.blockNum());
-
-        // TODO: change the ExitableTimestamp interface as 'isDeposit' should be used only in SE, in IFE it doesn't matter
-        // Could update the interface to be cleaner and not forcing a "false" here.
-        // https://github.com/omisego/plasma-contracts/issues/216
-        bool isPositionDeposit = false;
-        uint64 exitableAt = controller.exitableTimestampCalculator.calculate(now, blockTimestamp, isPositionDeposit);
+        
+        uint64 exitableAt = controller.exitableTimestampCalculator.calculateTxExitableTimestamp(now, blockTimestamp);
 
         uint256 vaultId;
         if (token == address(0)) {

--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentPiggybackInFlightExit.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentPiggybackInFlightExit.sol
@@ -101,7 +101,7 @@ library PaymentPiggybackInFlightExit {
 
         PaymentExitDataModel.WithdrawData storage withdrawData = exit.inputs[args.inputIndex];
 
-        // In startInFlightExit, exitTarget for inputs would be saved as those are the neccesarry data to create the transaction
+        // In startInFlightExit, exitTarget for inputs would be saved as those are the necessary data to create the transaction
         require(withdrawData.exitTarget == msg.sender, "Can be called by the exit target only");
         withdrawData.piggybackBondSize = msg.value;
 

--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentStartStandardExit.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentStartStandardExit.sol
@@ -16,6 +16,7 @@ import "../../../transactions/outputs/PaymentOutputModel.sol";
 import "../../../utils/IsDeposit.sol";
 import "../../../utils/UtxoPosLib.sol";
 import "../../../framework/PlasmaFramework.sol";
+import "../../utils/ExitableTimestamp.sol";
 
 library PaymentStartStandardExit {
     using ExitableTimestamp for ExitableTimestamp.Calculator;
@@ -193,9 +194,15 @@ library PaymentStartStandardExit {
     }
 
     function enqueueStandardExit(StartStandardExitData memory data) private {
-        uint64 exitableAt = data.controller.exitableTimestampCalculator.calculate(
-            block.timestamp, data.txBlockTimeStamp, data.isTxDeposit
-        );
+
+        uint64 exitableAt;
+        ExitableTimestamp.Calculator memory exitableTimestampCalculator = data.controller.exitableTimestampCalculator;
+
+        if (data.isTxDeposit){
+            exitableAt = exitableTimestampCalculator.calculateDepositTxOutputExitableTimestamp(block.timestamp);
+        } else {
+            exitableAt = exitableTimestampCalculator.calculateTxExitableTimestamp(block.timestamp, data.txBlockTimeStamp);
+        }
 
         uint256 vaultId;
         if (data.output.token == address(0)) {

--- a/plasma_framework/contracts/src/exits/utils/ExitableTimestamp.sol
+++ b/plasma_framework/contracts/src/exits/utils/ExitableTimestamp.sol
@@ -7,21 +7,28 @@ library ExitableTimestamp {
         uint256 minExitPeriod;
     }
 
-    function calculate(
+    function calculateDepositTxOutputExitableTimestamp(
         Calculator memory _calculator,
-        uint256 _now,
-        uint256 _blockTimestamp,
-        bool _isDeposit
+        uint256 _now
     )
         internal
         pure
         returns (uint64)
     {
-        uint256 minExitableTimestamp = _now + _calculator.minExitPeriod;
+        // Please that boosting the exitable timestamp for a deposit should be only done in case of a SE.
+        // For the explanation please refer to: https://github.com/omisego/plasma-contracts/issues/216
+        return uint64(_now + _calculator.minExitPeriod);
+    }
 
-        if (_isDeposit) {
-            return uint64(minExitableTimestamp);
-        }
-        return uint64(Math.max(_blockTimestamp + (_calculator.minExitPeriod * 2), minExitableTimestamp));
+    function calculateTxExitableTimestamp(
+        Calculator memory _calculator,
+        uint256 _now,
+        uint256 _blockTimestamp
+    )
+        internal 
+        pure
+        returns (uint64)
+    {
+        return uint64(Math.max(_blockTimestamp + (_calculator.minExitPeriod * 2), _now + _calculator.minExitPeriod));
     }
 }

--- a/plasma_framework/contracts/src/exits/utils/ExitableTimestamp.sol
+++ b/plasma_framework/contracts/src/exits/utils/ExitableTimestamp.sol
@@ -7,6 +7,31 @@ library ExitableTimestamp {
         uint256 minExitPeriod;
     }
 
+    /**
+     * @notice Calculates the exitable timestamp for a mined transaction
+     * @dev This is the main function when asking for exitable timestamp in most cases.
+     *      The only exception is to calculate the exitable timestamp for a deposit output in standard exit.
+     *      Should use the function 'calculateDepositTxOutputExitableTimestamp' for that case.
+     */
+    function calculateTxExitableTimestamp(
+        Calculator memory _calculator,
+        uint256 _now,
+        uint256 _blockTimestamp
+    )
+        internal
+        pure
+        returns (uint64)
+    {
+        return uint64(Math.max(_blockTimestamp + (_calculator.minExitPeriod * 2), _now + _calculator.minExitPeriod));
+    }
+
+    /**
+     * @notice Calculates the exitable timestamp for deposit transaction output for standard exit
+     * @dev This function should only be used in standard exit for calculating exitable timestamp of a deposit output.
+     *      For in-fight exit, the priority of a input tx which is a deposit tx should still be using the another function 'calculateTxExitableTimestamp'.
+     *      See discussion here: https://git.io/Je4N5
+     *      Reason of deposit output has different exitable timestamp: https://git.io/JecCV
+     */
     function calculateDepositTxOutputExitableTimestamp(
         Calculator memory _calculator,
         uint256 _now
@@ -15,20 +40,6 @@ library ExitableTimestamp {
         pure
         returns (uint64)
     {
-        // Please that boosting the exitable timestamp for a deposit should be only done in case of a SE.
-        // For the explanation please refer to: https://github.com/omisego/plasma-contracts/issues/216
         return uint64(_now + _calculator.minExitPeriod);
-    }
-
-    function calculateTxExitableTimestamp(
-        Calculator memory _calculator,
-        uint256 _now,
-        uint256 _blockTimestamp
-    )
-        internal 
-        pure
-        returns (uint64)
-    {
-        return uint64(Math.max(_blockTimestamp + (_calculator.minExitPeriod * 2), _now + _calculator.minExitPeriod));
     }
 }

--- a/plasma_framework/test/src/exits/payment/PaymentExitGame.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentExitGame.test.js
@@ -263,11 +263,8 @@ contract('PaymentExitGame - End to End Tests', ([_, richFather, bob, maintainer,
                     const uniquePriority = await priorityQueue.getMin();
 
                     const currentTimestamp = await time.latest();
-                    const isTxDeposit = true;
-                    const timestamp = currentTimestamp.sub(new BN(15));
-                    const exitableAt = await this.exitableHelper.calculate(
-                        currentTimestamp, timestamp, isTxDeposit,
-                    );
+                    const exitableAt = await this.exitableHelper
+                        .calculateDepositTxOutputExitableTimestamp(currentTimestamp);
 
                     const exitIdExpected = await this.exitIdHelper.getStandardExitId(
                         true, this.depositTx, this.depositUtxoPos,

--- a/plasma_framework/test/src/exits/payment/PaymentProcessInFlightExit.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentProcessInFlightExit.test.js
@@ -266,7 +266,7 @@ contract('PaymentInFlightExitRouter', ([_, ifeBondOwner, inputOwner1, inputOwner
                 expect(postBalance).to.be.bignumber.equal(expectedBalance);
             });
 
-            it('should flag all inputs with the same token as spent no matter piggybacke or not', async () => {
+            it('should flag all inputs with the same token as spent no matter piggybacked or not', async () => {
                 // piggybacked input
                 expect(await this.framework.isOutputSpent(TEST_OUTPUT_ID_FOR_INPUT_1)).to.be.true;
                 // unpiggybacked input

--- a/plasma_framework/test/src/exits/payment/PaymentStartStandardExit.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentStartStandardExit.test.js
@@ -316,10 +316,7 @@ contract('PaymentStandardExitRouter', ([_, outputOwner, nonOutputOwner]) => {
             const exitId = await this.exitIdHelper.getStandardExitId(isTxDeposit, args.rlpOutputTx, args.utxoPos);
 
             const currentTimestamp = await time.latest();
-            const dummyTimestampNoImpactOnExitableAt = currentTimestamp.sub(new BN(15));
-            const exitableAt = await this.exitableHelper.calculate(
-                currentTimestamp, dummyTimestampNoImpactOnExitableAt, isTxDeposit,
-            );
+            const exitableAt = await this.exitableHelper.calculateDepositTxOutputExitableTimestamp(currentTimestamp);
 
             await expectEvent.inTransaction(
                 receipt.transactionHash,

--- a/plasma_framework/test/src/exits/utils/ExitableTimestamp.test.js
+++ b/plasma_framework/test/src/exits/utils/ExitableTimestamp.test.js
@@ -13,21 +13,21 @@ contract('ExitableTimestamp', () => {
     describe('calculate', () => {
         it('should get the correct exit timestamp for deposit tx', async () => {
             const latestTimestamp = await time.latest();
-            expect(await this.contract.calculate(latestTimestamp, MIN_EXIT_PERIOD, true))
+            expect(await this.contract.calculateDepositTxOutputExitableTimestamp(latestTimestamp))
                 .to.be.bignumber.equal(latestTimestamp.add(new BN(MIN_EXIT_PERIOD)));
         });
 
         it('should get the correct exit timestamp for non deposit tx whose age is older than MIN_EXIT_PERIOD', async () => {
             const latestTimestamp = await time.latest();
             const oldTimestamp = 0;
-            expect(await this.contract.calculate(latestTimestamp, oldTimestamp, false))
+            expect(await this.contract.calculateTxExitableTimestamp(latestTimestamp, oldTimestamp))
                 .to.be.bignumber.equal(latestTimestamp.add(new BN(MIN_EXIT_PERIOD)));
         });
 
         it('should get the correct exit timestamp for non deposit tx whose age is younger than MIN_EXIT_PERIOD', async () => {
             const latestTimestamp = await time.latest();
             const youngTimestamp = latestTimestamp - 15;
-            expect(await this.contract.calculate(latestTimestamp, youngTimestamp, false))
+            expect(await this.contract.calculateTxExitableTimestamp(latestTimestamp, youngTimestamp))
                 .to.be.bignumber.equal(new BN(youngTimestamp + 2 * MIN_EXIT_PERIOD));
         });
     });


### PR DESCRIPTION
We made sure that the exitable timestamp is not computed based on the youngest input, but we take the furthest exitable timestamp of all inputs.

The issue still persists in the  RootChain contract.

Closes #216