### PR TITLE
tests: add coverage on merkle contract

### DIFF
--- a/plasma_framework/test/helpers/merkle.js
+++ b/plasma_framework/test/helpers/merkle.js
@@ -11,7 +11,7 @@ class MerkleNode {
 
 class MerkleTree {
     constructor(leaves, height = 0) {
-        const minHeightForLeaves = parseInt(Math.log(leaves.length), 10) + 1;
+        const minHeightForLeaves = parseInt(Math.log2(leaves.length), 10) + 1;
 
         if (height === 0) {
             this.height = minHeightForLeaves;


### PR DESCRIPTION
### Note
1. add coverage on the case when leaf on the right sibling
2. fix bug that merkle.js uses Math.log instead of Math.log2

issue: https://github.com/omisego/plasma-contracts/issues/343
