### PR TITLE
truffle-migrations outputs saves to a file

### DIFF
--- a/plasma_framework/migrations/6_output_results.js
+++ b/plasma_framework/migrations/6_output_results.js
@@ -1,8 +1,10 @@
 /* eslint-disable no-console */
 
-const PlasmaFramework = artifacts.require('PlasmaFramework');
-
+const fs = require('fs');
+const path = require('path');
 const config = require('./config.js');
+
+const PlasmaFramework = artifacts.require('PlasmaFramework');
 
 module.exports = async (
     deployer,
@@ -15,12 +17,17 @@ module.exports = async (
     const erc20Vault = await plasmaFramework.vaults(config.registerKeys.vaultId.erc20);
     const paymentExitGame = await plasmaFramework.exitGames(config.registerKeys.txTypes.payment);
 
-    console.log(JSON.stringify({
-        plasma_framework_tx_hash: `${PlasmaFramework.network.transactionHash}`.toLowerCase(),
-        plasma_framework: `${plasmaFramework.address}`.toLowerCase(),
+    const data = JSON.stringify({
+        authority_address: `${authorityAddress}`.toLowerCase(),
         eth_vault: `${ethVault}`.toLowerCase(),
         erc20_vault: `${erc20Vault}`.toLowerCase(),
         payment_exit_game: `${paymentExitGame}`.toLowerCase(),
-        authority_address: `${authorityAddress}`.toLowerCase(),
-    }));
+        plasma_framework_tx_hash: `${PlasmaFramework.network.transactionHash}`.toLowerCase(),
+        plasma_framework: `${plasmaFramework.address}`.toLowerCase(),
+    });
+
+    console.log(data);
+
+    // Save to `output.json`
+    fs.writeFileSync(path.resolve(__dirname, '../build/outputs.json'), data);
 };

--- a/plasma_framework/migrations/6_output_results.js
+++ b/plasma_framework/migrations/6_output_results.js
@@ -29,5 +29,9 @@ module.exports = async (
     console.log(data);
 
     // Save to `output.json`
-    fs.writeFileSync(path.resolve(__dirname, '../build/outputs.json'), data);
+    const buildDir = path.resolve(__dirname, '../build');
+    if (!fs.existsSync(buildDir)) {
+        fs.mkdirSync(buildDir);
+    }
+    fs.writeFileSync(path.resolve(buildDir, 'outputs.json'), data);
 };


### PR DESCRIPTION
This should make life easier for @InoMurko 

This change basically saves the truffle migration outputs into `output.json` in the `build` folder. Much easier than parsing `stdout`.