### PR TITLE
fix: output of contracts

### DIFF
--- a/plasma_framework/migrations/6_output_results.js
+++ b/plasma_framework/migrations/6_output_results.js
@@ -1,19 +1,37 @@
 /* eslint-disable no-console */
 
-const PlasmaFramework = artifacts.require('PlasmaFramework');
-
+const fs = require('fs');
+const path = require('path');
 const config = require('./config.js');
 
-module.exports = async (_) => {
+const PlasmaFramework = artifacts.require('PlasmaFramework');
+
+module.exports = async (
+    deployer,
+    _,
+    // eslint-disable-next-line no-unused-vars
+    [deployerAddress, maintainerAddress, authorityAddress],
+) => {
     const plasmaFramework = await PlasmaFramework.deployed();
     const ethVault = await plasmaFramework.vaults(config.registerKeys.vaultId.eth);
     const erc20Vault = await plasmaFramework.vaults(config.registerKeys.vaultId.erc20);
     const paymentExitGame = await plasmaFramework.exitGames(config.registerKeys.txTypes.payment);
 
-    console.log(JSON.stringify({
-        plasma_framework: `${plasmaFramework.address}`.toLowerCase(),
+    const data = JSON.stringify({
+        authority_address: `${authorityAddress}`.toLowerCase(),
         eth_vault: `${ethVault}`.toLowerCase(),
         erc20_vault: `${erc20Vault}`.toLowerCase(),
         payment_exit_game: `${paymentExitGame}`.toLowerCase(),
-    }));
+        plasma_framework_tx_hash: `${PlasmaFramework.network.transactionHash}`.toLowerCase(),
+        plasma_framework: `${plasmaFramework.address}`.toLowerCase(),
+    });
+
+    console.log(data);
+
+    // Save to `output.json`
+    const buildDir = path.resolve(__dirname, '../build');
+    if (!fs.existsSync(buildDir)) {
+        fs.mkdirSync(buildDir);
+    }
+    fs.writeFileSync(path.resolve(buildDir, 'outputs.json'), data);
 };

--- a/plasma_framework/package.json
+++ b/plasma_framework/package.json
@@ -6,7 +6,7 @@
     "test": "test"
   },
   "dependencies": {
-    "@truffle/hdwallet-provider": "^1.0.19",
+    "@truffle/hdwallet-provider": "^1.0.21",
     "dotenv": "^8.0.0",
     "lodash.clonedeep": "^4.5.0",
     "openzeppelin-solidity": "2.3.0",

--- a/plasma_framework/truffle-config.js
+++ b/plasma_framework/truffle-config.js
@@ -38,9 +38,13 @@ module.exports = {
                 const cleanInfuraUrl = infuraUrl.replace(/([^:])(\/\/+)/g, '$1/');
 
                 return new HDWalletProvider(
-                    [process.env.DEPLOYER_PRIVATEKEY, process.env.AUTHORITY_PRIVATEKEY],
+                    [
+                        process.env.DEPLOYER_PRIVATEKEY,
+                        process.env.MAINTAINER_PRIVATEKEY,
+                        process.env.AUTHORITY_PRIVATEKEY,
+                    ],
                     cleanInfuraUrl,
-                    0, 2,
+                    0, 3,
                 );
             },
             network_id: '*',


### PR DESCRIPTION
Branched out of `7b8a2643568556c1d126749724666bc37edc8141` because that's what we use in elixir-omg now. Will delete later when we bump them.