### PR TITLE
feat: remove txType as input of the startIFE

### DIFF
--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentStartInFlightExit.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentStartInFlightExit.sol
@@ -53,12 +53,12 @@ library PaymentStartInFlightExit {
 
      /**
      * @dev data to be passed around start in-flight exit helper functions
+     * @param controller the Controller struct of this library
      * @param exitId ID of the exit.
      * @param inFlightTxRaw In-flight transaction as bytes.
      * @param inFlightTx Decoded in-flight transaction.
      * @param inFlightTxHash Hash of in-flight transaction.
      * @param inputTxs Input transactions as bytes.
-     * @param inputUtxosPos Postions of input utxos.
      * @param inputUtxosPos Postions of input utxos coded as integers.
      * @param outputGuardPreimagesForInputs Output guard pre-images for in-flight transaction inputs.
      * @param inputTxsInclusionProofs Merkle proofs for input transactions.
@@ -75,7 +75,6 @@ library PaymentStartInFlightExit {
         bytes32 inFlightTxHash;
         bytes[] inputTxs;
         UtxoPosLib.UtxoPos[] inputUtxosPos;
-        uint256[] inputTxTypes;
         bytes[] outputGuardPreimagesForInputs;
         bytes[] inputTxsInclusionProofs;
         bytes[] inputTxsConfirmSigs;
@@ -147,7 +146,6 @@ library PaymentStartInFlightExit {
         exitData.inFlightTx = PaymentTransactionModel.decode(args.inFlightTx);
         exitData.inFlightTxHash = keccak256(args.inFlightTx);
         exitData.inputTxs = args.inputTxs;
-        exitData.inputTxTypes = args.inputTxTypes;
         exitData.inputUtxosPos = decodeInputTxsPositions(args.inputUtxosPos);
         exitData.inputTxsInclusionProofs = args.inputTxsInclusionProofs;
         exitData.inputTxsConfirmSigs = args.inputTxsConfirmSigs;
@@ -216,10 +214,6 @@ library PaymentStartInFlightExit {
             "Number of input transactions does not match number of in-flight transaction inputs"
         );
         require(
-            exitData.inputTxTypes.length == exitData.inFlightTx.inputs.length,
-            "Number of input tx types does not match number of in-flight transaction inputs"
-        );
-        require(
             exitData.inputUtxosPos.length == exitData.inFlightTx.inputs.length,
             "Number of input transactions positions does not match number of in-flight transaction inputs"
         );
@@ -272,7 +266,7 @@ library PaymentStartInFlightExit {
             require(outputGuardHandler.isValid(outputGuardData),
                     "Output guard information is invalid for the input tx");
 
-            uint8 protocol = exitData.controller.framework.protocols(exitData.inputTxTypes[i]);
+            uint8 protocol = exitData.controller.framework.protocols(WireTransaction.getTransactionType(exitData.inputTxs[i]));
 
             TxFinalizationModel.Data memory finalizationData = TxFinalizationModel.Data({
                 framework: exitData.controller.framework,

--- a/plasma_framework/contracts/src/exits/payment/routers/PaymentInFlightExitRouterArgs.sol
+++ b/plasma_framework/contracts/src/exits/payment/routers/PaymentInFlightExitRouterArgs.sol
@@ -5,7 +5,6 @@ library PaymentInFlightExitRouterArgs {
     * @notice Wraps arguments for startInFlightExit.
     * @param inFlightTx RLP encoded in-flight transaction.
     * @param inputTxs Transactions that created the inputs to the in-flight transaction. In the same order as in-flight transaction inputs.
-    * @param inputTxTypes Transaction type of the input transactions.
     * @param inputUtxosPos Utxos that represent in-flight transaction inputs. In the same order as input transactions.
     * @param outputGuardPreimagesForInputs (Optional) Output guard pre-images for in-flight transaction inputs. Length must always match that of the inputTxs
     * @param inputTxsInclusionProofs Merkle proofs that show the input-creating transactions are valid. In the same order as input transactions.
@@ -16,7 +15,6 @@ library PaymentInFlightExitRouterArgs {
     struct StartExitArgs {
         bytes inFlightTx;
         bytes[] inputTxs;
-        uint256[] inputTxTypes;
         uint256[] inputUtxosPos;
         bytes[] outputGuardPreimagesForInputs;
         bytes[] inputTxsInclusionProofs;

--- a/plasma_framework/test/helpers/ife.js
+++ b/plasma_framework/test/helpers/ife.js
@@ -82,8 +82,6 @@ function buildIfeStartArgs([inputTx1, inputTx2], [inputOwner1, inputOwner2], inp
 
     const inputSpendingConditionOptionalArgs = [EMPTY_BYTES, EMPTY_BYTES];
 
-    const inputTxTypes = [IFE_TX_TYPE, IFE_TX_TYPE];
-
     const outputGuardPreimagesForInputs = [
         web3.utils.toHex(inputOwner1),
         web3.utils.toHex(inputOwner2),
@@ -92,7 +90,6 @@ function buildIfeStartArgs([inputTx1, inputTx2], [inputOwner1, inputOwner2], inp
     const args = {
         inFlightTx: inFlightTxRaw,
         inputTxs,
-        inputTxTypes,
         inputUtxosPos,
         outputGuardPreimagesForInputs,
         inputTxsInclusionProofs,

--- a/plasma_framework/test/src/exits/payment/PaymentStartInFlightExit.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentStartInFlightExit.test.js
@@ -520,29 +520,6 @@ contract('PaymentInFlightExitRouter', ([_, alice, richFather, carol]) => {
                 );
             });
 
-            it('should fail when number of input tx types does not match in-flight transactions number of inputs', async () => {
-                const {
-                    args,
-                    inputTxsBlockRoot1,
-                    inputTxsBlockRoot2,
-                } = buildValidIfeStartArgs(
-                    AMOUNT,
-                    [alice, bob, carol],
-                    [OUTPUT_TYPE_ONE, OUTPUT_TYPE_ONE, OUTPUT_TYPE_ONE],
-                    BLOCK_NUMBER,
-                    DEPOSIT_BLOCK_NUMBER,
-                );
-                await registerSpendingConditionTrue(this.spendingConditionRegistry);
-                await this.framework.setBlock(BLOCK_NUMBER, inputTxsBlockRoot1, 0);
-                await this.framework.setBlock(DEPOSIT_BLOCK_NUMBER, inputTxsBlockRoot2, 0);
-                args.inputTxTypes = [];
-
-                await expectRevert(
-                    this.exitGame.startInFlightExit(args, { from: alice, value: this.startIFEBondSize.toString() }),
-                    'Number of input tx types does not match number of in-flight transaction inputs',
-                );
-            });
-
             it('should fail when number of output gauard preimage of input txs does not match in-flight transactions number of inputs', async () => {
                 const {
                     args,


### PR DESCRIPTION
### Note
We have changed the code to be using WireTransaction to parse txType instead.
This is some leftover that was not cleaned up.

closes: https://github.com/omisego/plasma-contracts/issues/338
