### PR TITLE
Turn off python build cache on Circle Ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,9 +43,9 @@ commands:
             sudo apt update && sudo apt install nodejs npm
             sudo npm install -g n && sudo n stable
             sudo npm install -g ganache-cli
-      - restore_cache:
-          keys:
-            - dependencies_v1_{{ checksum "requirements.txt" }}
+      # - restore_cache:
+          # keys:
+            # - dependencies_v1_{{ checksum "requirements.txt" }}
       - run:
           name: Install dependencies
           command: |


### PR DESCRIPTION
Due to a corrupted state of the cache and the failing master branch, I am going to turn off the cache until I fix it.