### PR TITLE
Add Dockerfile

### DIFF
--- a/plasma_framework/Dockerfile
+++ b/plasma_framework/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:10-alpine
+
+RUN apk update && apk add make git g++ python
+
+COPY . /home/truffle
+
+WORKDIR /home/truffle
+
+RUN rm -Rf ./node_modules
+
+RUN npm install typescript && npm install


### PR DESCRIPTION
This PR adds a Dockerfile for an environment to deploy the contracts from. The intention behind this is to use a container and attempt to deploy the contracts to Rinkeby during CI/CD.