### PR TITLE
389 improve test coverage in exit game controller

### DIFF
--- a/plasma_framework/contracts/src/exits/payment/routers/PaymentInFlightExitRouterArgs.sol
+++ b/plasma_framework/contracts/src/exits/payment/routers/PaymentInFlightExitRouterArgs.sol
@@ -47,6 +47,8 @@ library PaymentInFlightExitRouterArgs {
 
     /*
      * @notice Wraps arguments for challenging non-canonical in-flight exits
+     * @param inputTx Transaction that created shared input
+     * @param inputUtxoPos Position of input utxo
      * @param inFlightTx RLP-encoded in-flight transaction
      * @param inFlightTxInputIndex Index of shared input for transactions in flight
      * @param competingTx RLP-encoded competing transaction

--- a/plasma_framework/contracts/src/framework/ExitGameController.sol
+++ b/plasma_framework/contracts/src/framework/ExitGameController.sol
@@ -51,7 +51,7 @@ contract ExitGameController is ExitGameRegistry {
         require(!mutex, "Reentrant call");
         mutex = true;
         _;
-        require(mutex, "Not locked");
+        assert(mutex);
         mutex = false;
     }
 
@@ -70,7 +70,7 @@ contract ExitGameController is ExitGameRegistry {
      * @dev Accessible only from non quarantined exit games, uses a mutex
      */
     function deactivateNonReentrant() external onlyFromNonQuarantinedExitGame() {
-        require(mutex, "Not locked");
+        assert(mutex);
         mutex = false;
     }
 


### PR DESCRIPTION
- Full test coverage for `PaymentChallengeIFENotCanonical`.
- Use `assert` instead of `require` in `ExitGameController` when verifying conditions that are expected to never fail.
 
References #389 