### PR TITLE
test: add tests for priority queue

### DIFF
--- a/plasma_framework/contracts/src/framework/utils/PriorityQueue.sol
+++ b/plasma_framework/contracts/src/framework/utils/PriorityQueue.sol
@@ -43,7 +43,7 @@ contract PriorityQueue is OnlyFromAddress {
     }
 
     /**
-     * @notice Inserts an element into the queue by the owner
+     * @notice Inserts an element into the queue by the framework
      * @dev Does not perform deduplication
      */
     function insert(uint256 _element) external onlyFrom(framework) {
@@ -53,10 +53,12 @@ contract PriorityQueue is OnlyFromAddress {
     }
 
     /**
-     * @notice Deletes the smallest element from the queue
+     * @notice Deletes the smallest element from the queue by the framework
+     * @dev Fails when queue is empty
      * @return The smallest element in the priority queue
      */
     function delMin() external onlyFrom(framework) returns (uint256) {
+        require(queue.currentSize > 0, "Queue is empty");
         uint256 retVal = queue.heapList[1];
         queue.heapList[1] = queue.heapList[queue.currentSize];
         delete queue.heapList[queue.currentSize];
@@ -72,6 +74,7 @@ contract PriorityQueue is OnlyFromAddress {
      * @return The smallest element in the priority queue
      */
     function getMin() external view returns (uint256) {
+        require(queue.currentSize > 0, "Queue is empty");
         return queue.heapList[1];
     }
 

--- a/plasma_framework/test/src/framework/utils/PriorityQueue.test.js
+++ b/plasma_framework/test/src/framework/utils/PriorityQueue.test.js
@@ -41,7 +41,7 @@ contract('PriorityQueue', ([_, nonOwner]) => {
                 .to.be.bignumber.equal(new BN(1));
         });
 
-        it('can insert multiple values with order', async () => {
+        it('can insert two values with order', async () => {
             const smallerValue = 2;
             const largerValue = 5;
             await this.priorityQueue.insert(smallerValue);
@@ -52,15 +52,15 @@ contract('PriorityQueue', ([_, nonOwner]) => {
                 .to.be.bignumber.equal(new BN(2));
         });
 
-        it('can insert out of order and still get the minimal number', async () => {
-            const smallerValue = 2;
-            const largerValue = 5;
-            await this.priorityQueue.insert(largerValue);
-            await this.priorityQueue.insert(smallerValue);
+        it('can insert multiple values out of order and still get the minimal number', async () => {
+            const valuesOutOfOrder = [13, 11, 17, 5, 3, 1, 2];
+
+            await Promise.all(valuesOutOfOrder.map(async value => this.priorityQueue.insert(value)));
+
             expect(await this.priorityQueue.getMin())
-                .to.be.bignumber.equal(new BN(smallerValue));
+                .to.be.bignumber.equal(new BN(Math.min(...valuesOutOfOrder)));
             expect(await this.priorityQueue.currentSize())
-                .to.be.bignumber.equal(new BN(2));
+                .to.be.bignumber.equal(new BN(valuesOutOfOrder.length));
         });
 
         it('is not idempotent', async () => {
@@ -74,7 +74,7 @@ contract('PriorityQueue', ([_, nonOwner]) => {
                 .to.be.bignumber.equal(new BN(2));
         });
 
-        it('should fail when not inserted by the owner', async () => {
+        it('should fail when not inserted by the framework (who deploys the priority queue contract)', async () => {
             await expectRevert(
                 this.priorityQueue.insert(100, { from: nonOwner }),
                 'Caller address is unauthorized',
@@ -91,7 +91,7 @@ contract('PriorityQueue', ([_, nonOwner]) => {
                 .to.be.bignumber.equal(new BN(0));
         });
 
-        it('can delete when multiple values in queue', async () => {
+        it('can delete when two values in queue', async () => {
             await this.priorityQueue.insert(2);
             await this.priorityQueue.insert(5);
 
@@ -102,18 +102,27 @@ contract('PriorityQueue', ([_, nonOwner]) => {
                 .to.be.bignumber.equal(new BN(1));
         });
 
+        it('can delete when multiple values in queue', async () => {
+            const valuesInOrder = [2, 3, 5, 7, 11, 13, 17];
+            await Promise.all(valuesInOrder.map(async value => this.priorityQueue.insert(value)));
+
+            await this.priorityQueue.delMin();
+            expect(await this.priorityQueue.getMin())
+                .to.be.bignumber.equal(new BN(valuesInOrder[1]));
+            expect(await this.priorityQueue.currentSize())
+                .to.be.bignumber.equal(new BN(valuesInOrder.length - 1));
+        });
+
         it('can delete all', async () => {
-            await this.priorityQueue.insert(2);
-            await this.priorityQueue.insert(5);
+            const values = [2, 3, 5, 7, 11, 13, 17];
+            await Promise.all(values.map(async value => this.priorityQueue.insert(value)));
 
-            await this.priorityQueue.delMin();
-            await this.priorityQueue.delMin();
-
+            await Promise.all(values.map(async () => this.priorityQueue.delMin()));
             expect(await this.priorityQueue.currentSize())
                 .to.be.bignumber.equal(new BN(0));
         });
 
-        it('should fail when not deleted by the owner', async () => {
+        it('should fail when not deleted by the framework (who deploys the priority queue contract)', async () => {
             await expectRevert(
                 this.priorityQueue.delMin({ from: nonOwner }),
                 'Caller address is unauthorized',

--- a/plasma_framework/test/src/framework/utils/PriorityQueue.test.js
+++ b/plasma_framework/test/src/framework/utils/PriorityQueue.test.js
@@ -17,9 +17,10 @@ contract('PriorityQueue', ([_, nonOwner]) => {
         });
 
         it('fails when empty', async () => {
-            const errorMsg = 'Returned error: VM Exception while processing transaction: invalid opcode';
-            await this.priorityQueue.getMin()
-                .catch(err => expect(err.message).to.equal(errorMsg));
+            await expectRevert(
+                this.priorityQueue.getMin(),
+                'Queue is empty',
+            );
         });
     });
 
@@ -126,6 +127,13 @@ contract('PriorityQueue', ([_, nonOwner]) => {
             await expectRevert(
                 this.priorityQueue.delMin({ from: nonOwner }),
                 'Caller address is unauthorized',
+            );
+        });
+
+        it('should fail when queue is empty', async () => {
+            await expectRevert(
+                this.priorityQueue.delMin(),
+                'Queue is empty',
             );
         });
     });


### PR DESCRIPTION
### Note
1. Privious tests was not able to hit all branches inside the code.
1. For `delMin` and `getMin`, fail the function with message.

- old coverall: https://coveralls.io/builds/26522392/source?filename=contracts/src/framework/utils/PriorityQueue.sol
- ref issue: https://github.com/omisego/plasma-contracts/issues/389
- closes: #391 

### Result
- new coverall: https://coveralls.io/builds/26610418/source?filename=contracts/src/framework/utils/PriorityQueue.sol