### PR TITLE
test: add unit tests for PaymentInFlightExitModelUtils library

### DIFF
--- a/plasma_framework/contracts/mocks/exits/payment/PaymentInFlightExitModelUtilsMock.sol
+++ b/plasma_framework/contracts/mocks/exits/payment/PaymentInFlightExitModelUtilsMock.sol
@@ -1,0 +1,63 @@
+pragma solidity 0.5.11;
+pragma experimental ABIEncoderV2;
+
+import "../../../src/exits/payment/PaymentInFlightExitModelUtils.sol";
+import { PaymentExitDataModel as ExitModel } from "../../../src/exits/payment/PaymentExitDataModel.sol";
+
+contract PaymentInFlightExitModelUtilsMock {
+
+    ExitModel.InFlightExit public ife;
+
+    constructor(uint256 exitMap, uint64 exitStartTimestamp) public {
+        ife.exitMap = exitMap;
+        ife.exitStartTimestamp = exitStartTimestamp;
+    }
+
+    function isInputPiggybacked(uint16 index)
+        external
+        view
+        returns (bool)
+    {
+        return PaymentInFlightExitModelUtils.isInputPiggybacked(ife, index);
+    }
+
+    function isOutputPiggybacked(uint16 index)
+        external
+        view
+        returns (bool)
+    {
+        return PaymentInFlightExitModelUtils.isOutputPiggybacked(ife, index);
+    }
+
+    function setInputPiggybacked(uint16 index)
+        external
+    {
+        PaymentInFlightExitModelUtils.setInputPiggybacked(ife, index);
+    }
+
+    function clearInputPiggybacked(uint16 index)
+        external
+    {
+        PaymentInFlightExitModelUtils.clearInputPiggybacked(ife, index);
+    }
+
+    function setOutputPiggybacked(uint16 index)
+        external
+    {
+        PaymentInFlightExitModelUtils.setOutputPiggybacked(ife, index);
+    }
+
+    function clearOutputPiggybacked(uint16 index)
+        external
+    {
+        PaymentInFlightExitModelUtils.clearOutputPiggybacked(ife, index);
+    }
+
+    function isInFirstPhase(uint256 minExitPeriod)
+        external
+        view
+        returns (bool)
+    {
+        return PaymentInFlightExitModelUtils.isInFirstPhase(ife, minExitPeriod);
+    }
+}

--- a/plasma_framework/contracts/mocks/exits/payment/routers/PaymentInFlightExitRouterMock.sol
+++ b/plasma_framework/contracts/mocks/exits/payment/routers/PaymentInFlightExitRouterMock.sol
@@ -114,7 +114,7 @@ contract PaymentInFlightExitRouterMock is FailFastReentrancyGuard, PaymentInFlig
     /** empty function that accepts ETH to fund the contract as test setup */
     function depositFundForTest() public payable {}
 
-    function stringEquals(string memory a, string memory b) private returns (bool) {
+    function stringEquals(string memory a, string memory b) private pure returns (bool) {
         return keccak256(abi.encodePacked(a)) == keccak256(abi.encodePacked(b));
     }
 }

--- a/plasma_framework/contracts/mocks/exits/payment/routers/PaymentStandardExitRouterMock.sol
+++ b/plasma_framework/contracts/mocks/exits/payment/routers/PaymentStandardExitRouterMock.sol
@@ -60,7 +60,7 @@ contract PaymentStandardExitRouterMock is PaymentStandardExitRouter {
         }
     }
 
-    function stringEquals(string memory a, string memory b) private returns (bool) {
+    function stringEquals(string memory a, string memory b) private pure returns (bool) {
         return keccak256(abi.encodePacked(a)) == keccak256(abi.encodePacked(b));
     }
 }

--- a/plasma_framework/contracts/src/exits/payment/PaymentInFlightExitModelUtils.sol
+++ b/plasma_framework/contracts/src/exits/payment/PaymentInFlightExitModelUtils.sol
@@ -43,13 +43,6 @@ library PaymentInFlightExitModelUtils {
         ife.exitMap = ife.exitMap.clearBit(uint8(index));
     }
 
-    function clearOutputPiggyback(ExitModel.InFlightExit storage ife, uint16 index)
-        internal
-    {
-        require(index < MAX_OUTPUT_NUM, "Invalid output index");
-        ife.exitMap = ife.exitMap.clearBit(uint8(index));
-    }
-
     function setOutputPiggybacked(ExitModel.InFlightExit storage ife, uint16 index)
         internal
     {
@@ -73,27 +66,5 @@ library PaymentInFlightExitModelUtils {
     {
         uint256 periodTime = minExitPeriod / 2;
         return ((block.timestamp - ife.exitStartTimestamp) / periodTime) < 1;
-    }
-
-    function isFirstPiggybackOfTheToken(ExitModel.InFlightExit memory ife, address token)
-        internal
-        pure
-        returns (bool)
-    {
-        bool isPiggybackInput = true;
-        for (uint i = 0; i < MAX_INPUT_NUM; i++) {
-            if (isInputPiggybacked(ife, uint16(i)) && ife.inputs[i].token == token) {
-                return false;
-            }
-        }
-
-        isPiggybackInput = false;
-        for (uint i = 0; i < MAX_OUTPUT_NUM; i++) {
-            if (isOutputPiggybacked(ife, uint16(i)) && ife.outputs[i].token == token) {
-                return false;
-            }
-        }
-
-        return true;
     }
 }

--- a/plasma_framework/test/src/exits/payment/PaymentInFlightExitModelUtils.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentInFlightExitModelUtils.test.js
@@ -1,0 +1,204 @@
+/* eslint no-bitwise: ["error", { "allow": ["|"] }] */
+/* eslint-disable no-await-in-loop */
+
+const PaymentInFlightExitModelUtils = artifacts.require('PaymentInFlightExitModelUtilsMock');
+
+const { expectRevert, time } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
+
+contract('PaymentInFlightExitModelUtils', () => {
+    const MAX_INPUTS = 4;
+    const MAX_OUTPUTS = 4;
+    const MIN_EXIT_PERIOD = 1000;
+    const ALL_INPUTS_PIGGYBACKED = 2 ** 0 | 2 ** 1 | 2 ** 2 | 2 ** 3;
+    const ALL_OUTPUTS_PIGGYBACKED = 2 ** MAX_INPUTS | 2 ** (MAX_INPUTS + 1)
+    | 2 ** (MAX_INPUTS + 2) | 2 ** 2 ** (MAX_INPUTS + 2);
+
+    describe('isInputPiggybacked', () => {
+        it('returns true for piggybacked input', async () => {
+            this.modelUtils = await PaymentInFlightExitModelUtils.new(ALL_INPUTS_PIGGYBACKED, 0);
+
+            for (let i = 0; i++; i < MAX_INPUTS) {
+                const actual = await this.modelUtils.isInputPiggybacked(i);
+                expect(actual).to.be.true;
+            }
+        });
+
+        it('returns false for not piggybacked input', async () => {
+            this.modelUtils = await PaymentInFlightExitModelUtils.new(0, 0);
+
+            for (let i = 0; i++; i < MAX_INPUTS) {
+                const actual = await this.modelUtils.isInputPiggybacked(i);
+                expect(actual).to.be.false;
+            }
+        });
+
+        it('fails for invalid input index', async () => {
+            this.modelUtils = await PaymentInFlightExitModelUtils.new(0, 0);
+
+            await expectRevert(
+                this.modelUtils.isInputPiggybacked(MAX_INPUTS),
+                'Invalid input index',
+            );
+        });
+    });
+
+    describe('isOutputPiggybacked', () => {
+        it('returns true for piggybacked output', async () => {
+            this.modelUtils = await PaymentInFlightExitModelUtils.new(ALL_OUTPUTS_PIGGYBACKED, 0);
+
+            for (let i = 0; i++; i < MAX_OUTPUTS) {
+                const actual = await this.modelUtils.isOutputPiggybacked(i);
+                expect(actual).to.be.true;
+            }
+        });
+
+        it('returns false for not piggybacked output', async () => {
+            this.modelUtils = await PaymentInFlightExitModelUtils.new(0, 0);
+
+            for (let i = 0; i++; i < MAX_OUTPUTS) {
+                const actual = await this.modelUtils.isOutputPiggybacked(i);
+                expect(actual).to.be.false;
+            }
+        });
+
+        it('fails for invalid output index', async () => {
+            await expectRevert(
+                this.modelUtils.isOutputPiggybacked(MAX_OUTPUTS),
+                'Invalid output index',
+            );
+        });
+    });
+
+    describe('setInputPiggybacked', () => {
+        const verifyPiggybacked = async () => {
+            for (let i = 0; i++; i < MAX_INPUTS) {
+                await this.modelUtils.setInputPiggybacked(i);
+                const actual = await this.modelUtils.isInputPiggybacked(i);
+                expect(actual).to.be.true;
+            }
+        };
+
+        it('sets input as piggybacked', async () => {
+            this.modelUtils = await PaymentInFlightExitModelUtils.new(0, 0);
+            await verifyPiggybacked();
+        });
+
+        it('does not unset already piggybacked input', async () => {
+            this.modelUtils = await PaymentInFlightExitModelUtils.new(ALL_INPUTS_PIGGYBACKED, 0);
+            await verifyPiggybacked();
+        });
+
+        it('fails for invalid input index', async () => {
+            await expectRevert(
+                this.modelUtils.setInputPiggybacked(MAX_INPUTS),
+                'Invalid input index',
+            );
+        });
+    });
+
+    describe('setOutputPiggybacked', () => {
+        const verifyPiggybacked = async () => {
+            for (let i = 0; i++; i < MAX_INPUTS) {
+                await this.modelUtils.setOutputPiggybacked(i);
+                const actual = await this.modelUtils.isOutputPiggybacked(i);
+                expect(actual).to.be.true;
+            }
+        };
+
+        it('sets outputs as piggybacked', async () => {
+            this.modelUtils = await PaymentInFlightExitModelUtils.new(0, 0);
+            await verifyPiggybacked();
+        });
+
+        it('does not unset already piggybacked output', async () => {
+            this.modelUtils = await PaymentInFlightExitModelUtils.new(ALL_INPUTS_PIGGYBACKED, 0);
+            await verifyPiggybacked();
+        });
+
+        it('fails for invalid output index', async () => {
+            await expectRevert(
+                this.modelUtils.setOutputPiggybacked(MAX_OUTPUTS),
+                'Invalid output index',
+            );
+        });
+    });
+
+    describe('clearInputPiggybacked', () => {
+        const verifyPiggybacked = async () => {
+            for (let i = 0; i++; i < MAX_INPUTS) {
+                await this.modelUtils.clearInputPiggybacked(i);
+                const actual = await this.modelUtils.isInputPiggybacked(i);
+                expect(actual).to.be.false;
+            }
+        };
+
+        it('clears piggybacked input', async () => {
+            this.modelUtils = await PaymentInFlightExitModelUtils.new(ALL_INPUTS_PIGGYBACKED, 0);
+            await verifyPiggybacked();
+        });
+
+        it('does not change not piggybacked input', async () => {
+            this.modelUtils = await PaymentInFlightExitModelUtils.new(0, 0);
+            await verifyPiggybacked();
+        });
+
+        it('fails for invalid input index', async () => {
+            await expectRevert(
+                this.modelUtils.clearInputPiggybacked(MAX_INPUTS),
+                'Invalid input index',
+            );
+        });
+    });
+
+    describe('clearOutputPiggybacked', () => {
+        const verifyPiggybacked = async () => {
+            for (let i = 0; i++; i < MAX_INPUTS) {
+                await this.modelUtils.clearOutputPiggybacked(i);
+                const actual = await this.modelUtils.isOutputPiggybacked(i);
+                expect(actual).to.be.false;
+            }
+        };
+
+        it('clears piggybacked output', async () => {
+            this.modelUtils = await PaymentInFlightExitModelUtils.new(ALL_OUTPUTS_PIGGYBACKED, 0);
+            await verifyPiggybacked();
+        });
+
+        it('does not change not piggybacked output', async () => {
+            this.modelUtils = await PaymentInFlightExitModelUtils.new(0, 0);
+            await verifyPiggybacked();
+        });
+
+        it('fails for invalid output index', async () => {
+            await expectRevert(
+                this.modelUtils.clearOutputPiggybacked(MAX_OUTPUTS),
+                'Invalid output index',
+            );
+        });
+    });
+
+    describe('isInFirstPhase', () => {
+        beforeEach(async () => {
+            const exitStartTimestamp = (await time.latest()).toNumber();
+            this.modelUtils = await PaymentInFlightExitModelUtils.new(0, exitStartTimestamp);
+        });
+
+        it('returns true when ife is in the first phase', async () => {
+            const actual = await this.modelUtils.isInFirstPhase(MIN_EXIT_PERIOD);
+            expect(actual).to.be.true;
+        });
+
+        it('returns false when ife is not in the first phase', async () => {
+            await time.increase(MIN_EXIT_PERIOD * 2);
+            const actual = await this.modelUtils.isInFirstPhase(MIN_EXIT_PERIOD);
+            expect(actual).to.be.false;
+        });
+
+        it('returns false when ife is not in the first phase - edge case', async () => {
+            await time.increase(MIN_EXIT_PERIOD / 2);
+            const actual = await this.modelUtils.isInFirstPhase(MIN_EXIT_PERIOD);
+            expect(actual).to.be.false;
+        });
+    });
+});

--- a/plasma_framework/test/src/exits/payment/PaymentInFlightExitModelUtils.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentInFlightExitModelUtils.test.js
@@ -24,7 +24,7 @@ contract('PaymentInFlightExitModelUtils', () => {
             }
         });
 
-        it('returns false for not piggybacked input', async () => {
+        it('returns false for non-piggybacked input', async () => {
             this.modelUtils = await PaymentInFlightExitModelUtils.new(0, 0);
 
             for (let i = 0; i++; i < MAX_INPUTS) {
@@ -53,7 +53,7 @@ contract('PaymentInFlightExitModelUtils', () => {
             }
         });
 
-        it('returns false for not piggybacked output', async () => {
+        it('returns false for non-piggybacked output', async () => {
             this.modelUtils = await PaymentInFlightExitModelUtils.new(0, 0);
 
             for (let i = 0; i++; i < MAX_OUTPUTS) {
@@ -195,7 +195,7 @@ contract('PaymentInFlightExitModelUtils', () => {
             expect(actual).to.be.false;
         });
 
-        it('returns false when ife is not in the first phase - edge case', async () => {
+        it('returns false when ife just passes the first phase (MIN_EXIT_PERIOD/2)', async () => {
             await time.increase(MIN_EXIT_PERIOD / 2);
             const actual = await this.modelUtils.isInFirstPhase(MIN_EXIT_PERIOD);
             expect(actual).to.be.false;

--- a/plasma_framework/test/src/exits/payment/PaymentPiggybackInFlightExitOnInput.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentPiggybackInFlightExitOnInput.test.js
@@ -211,7 +211,7 @@ contract('PaymentInFlightExitRouter', ([_, alice, inputOwner, nonInputOwner, out
                 this.exitGame.piggybackInFlightExitOnInput(
                     data.argsInputOne, { from: inputOwner, value: this.piggybackBondSize.toString() },
                 ),
-                'Index exceed max size of the input',
+                'Invalid input index',
             );
         });
 

--- a/plasma_framework/test/src/exits/payment/PaymentPiggybackInFlightExitOnOutput.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentPiggybackInFlightExitOnOutput.test.js
@@ -235,7 +235,7 @@ contract('PaymentInFlightExitRouter', ([_, alice, inputOwner, outputOwner, nonOu
                 this.exitGame.piggybackInFlightExitOnOutput(
                     data.outputOneCase.args, { from: outputOwner, value: this.piggybackBondSize.toString() },
                 ),
-                'Index exceeds max size of the output',
+                'Invalid output index',
             );
         });
 


### PR DESCRIPTION
- Improves test coverage for `PaymentInFlightExitModelUtils` library to 100%.
- Moves `isFirstPiggybackOfTheToken` from `PaymentInFlightExitModelUtils` to `PaymentPiggybackInFlightExit` as it was used only there.
- Removes unused `clearOutputPiggyback` function.

References #389 