### PR TITLE
feat: convert truffle config from infura to remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,14 @@ Deploying the contracts requires three accounts:
 2. `AUTHORITY` The account that used by the Child chain to submit blocks. It must not have made any transaction prior to calling the scripts i.e. its nonce must be 0.
 3. `MAINTAINER` The account that can register new vaults, exit games, etc.
 
-
-Normally you will deploy the contracts using an Ethereum client that you run yourself, such as Geth or Parity. However, you can also use a provider such as Infura. In this case you'll need to know the private keys for the `DEPLOYER`, `AUTHORITY` and `MAINTAINER` accounts. See `truffle-config.js` for an example.
+Normally you will deploy the contracts using an Ethereum client that you run yourself, such as Geth or Parity. However, you can also use a remote provider such as Infura. In this case you'll need to know the private keys for the `DEPLOYER`, `AUTHORITY` and `MAINTAINER` accounts. See `truffle-config.js` for an example.
 
 Run truffle, passing in the network e.g.
 ```bash
 ./node_modules/.bin/truffle truffle migrate --network local
 
-# or to deploy via infura
-./node_modules/.bin/truffle truffle migrate --network infura
+# or to deploy via a remote provider
+./node_modules/.bin/truffle truffle migrate --network remote
 ```
 
 

--- a/plasma_framework/truffle-config.js
+++ b/plasma_framework/truffle-config.js
@@ -29,6 +29,9 @@ module.exports = {
             from: process.env.DEPLOYER_ADDRESS,
             network_id: 5,
         },
+        // Remote means that the remote client does not possess the private keys.
+        // Transactions need to be signed locally with the given private keys
+        // before getting submitted to the remote client.
         remote: {
             skipDryRun: true,
             provider: () => {

--- a/plasma_framework/truffle-config.js
+++ b/plasma_framework/truffle-config.js
@@ -29,21 +29,16 @@ module.exports = {
             from: process.env.DEPLOYER_ADDRESS,
             network_id: 5,
         },
-        infura: {
+        remote: {
             skipDryRun: true,
             provider: () => {
-                const infuraUrl = `${process.env.INFURA_URL}/${process.env.INFURA_API_KEY}`;
-
-                // Replace double '//'
-                const cleanInfuraUrl = infuraUrl.replace(/([^:])(\/\/+)/g, '$1/');
-
                 return new HDWalletProvider(
                     [
                         process.env.DEPLOYER_PRIVATEKEY,
                         process.env.MAINTAINER_PRIVATEKEY,
                         process.env.AUTHORITY_PRIVATEKEY,
                     ],
-                    cleanInfuraUrl,
+                    process.env.REMOTE_URL,
                     0, 3,
                 );
             },

--- a/plasma_framework/truffle-config.js
+++ b/plasma_framework/truffle-config.js
@@ -34,17 +34,15 @@ module.exports = {
         // before getting submitted to the remote client.
         remote: {
             skipDryRun: true,
-            provider: () => {
-                return new HDWalletProvider(
-                    [
-                        process.env.DEPLOYER_PRIVATEKEY,
-                        process.env.MAINTAINER_PRIVATEKEY,
-                        process.env.AUTHORITY_PRIVATEKEY,
-                    ],
-                    process.env.REMOTE_URL,
-                    0, 3,
-                );
-            },
+            provider: () => new HDWalletProvider(
+                [
+                    process.env.DEPLOYER_PRIVATEKEY,
+                    process.env.MAINTAINER_PRIVATEKEY,
+                    process.env.AUTHORITY_PRIVATEKEY,
+                ],
+                process.env.REMOTE_URL,
+                0, 3,
+            ),
             network_id: '*',
         },
     },


### PR DESCRIPTION
Currently the migration code on elixir-omg uses infura flag as a workaround to deploy contracts to local geth with specific private keys:

```yaml
  plasma-deployer:
    command:
      - /bin/sh
      - -c
      - |
          apk add --update curl
          cd /home/node/plasma-contracts/plasma_framework
          npx truffle migrate --network infura
          # ...
    environment:
      - INFURA_URL=http://geth:8545
      - INFURA_API_KEY=
      # ...
```

This PR generalizes the `infura` config into a `remote` config where the private keys are expected as inputs for contract deployment.

## Usage

```shell
$ REMOTE_URL=http://remote_provider_url \
  DEPLOYER_PRIVATEKEY=0xaaaa... \
  MAINTAINER_PRIVATEKEY=0xbbb... \
  AUTHORITY_PRIVATEKEY=0xccc... \
  npx truffle migrate --network remote
```