### PR TITLE
feat: remove setAuthority function

### DIFF
--- a/plasma_framework/contracts/src/framework/BlockController.sol
+++ b/plasma_framework/contracts/src/framework/BlockController.sol
@@ -62,16 +62,6 @@ contract BlockController is OnlyFromAddress, VaultRegistry {
     }
 
     /**
-     * @notice Allows the operator to set a new authority address, enabling implementation of mechanical
-     * re-org protection mechanism described here: https://github.com/omisego/plasma-contracts/issues/118
-     * @param newAuthority Address of new authority, which cannot be blank
-     */
-    function setAuthority(address newAuthority) external onlyFrom(authority) {
-        require(newAuthority != address(0), "Authority address cannot be zero");
-        authority = newAuthority;
-    }
-
-    /**
      * @notice Allows the authority to submit the Merkle root of a Plasma block
      * @dev emit BlockSubmitted event
      * @dev Block number jumps 'childBlockInterval' per submission

--- a/plasma_framework/test/src/framework/BlockController.test.js
+++ b/plasma_framework/test/src/framework/BlockController.test.js
@@ -2,7 +2,7 @@ const BlockController = artifacts.require('BlockControllerMock');
 const DummyVault = artifacts.require('DummyVault');
 
 const {
-    BN, constants, expectRevert, expectEvent,
+    BN, expectRevert, expectEvent,
 } = require('openzeppelin-test-helpers');
 const { expect } = require('chai');
 
@@ -48,20 +48,6 @@ contract('BlockController', ([maintainer, authority, other]) => {
             expect(await this.blockController.childBlockInterval())
                 .to.be.bignumber.equal(new BN(this.childBlockInterval));
         });
-
-        it('setAuthority rejects zero-address as new authority', async () => {
-            await expectRevert(
-                this.blockController.setAuthority(constants.ZERO_ADDRESS, { from: authority }),
-                'Authority address cannot be zero',
-            );
-        });
-
-        it('setAuthority can be called only by the authority', async () => {
-            await expectRevert(
-                this.blockController.setAuthority(other, { from: other }),
-                'Caller address is unauthorized',
-            );
-        });
     });
 
     describe('activateChildChain', () => {
@@ -95,7 +81,7 @@ contract('BlockController', ([maintainer, authority, other]) => {
                 );
             });
 
-            it('should not be ablt to be activated by non authority', async () => {
+            it('should not be able to be activated by non authority', async () => {
                 await expectRevert(
                     this.blockController.activateChildChain({ from: maintainer }),
                     'Caller address is unauthorized',
@@ -166,17 +152,6 @@ contract('BlockController', ([maintainer, authority, other]) => {
                 this.blockController.submitBlock(this.dummyBlockHash, { from: other }),
                 'Caller address is unauthorized',
             );
-        });
-
-        it('allows authority address to be changed', async () => {
-            await expectRevert(
-                this.blockController.submitBlock(this.dummyBlockHash, { from: other }),
-                'Caller address is unauthorized',
-            );
-
-            await this.blockController.setAuthority(other, { from: authority });
-
-            await this.blockController.submitBlock(this.dummyBlockHash, { from: other });
         });
     });
 


### PR DESCRIPTION
That function was introduced to add the flexibility to move toward mechanism reorg protection
in the future. However, after discuss with the blockchain service team (elixir-omg) that feature
is not really on the priority list of implementing.

Also, auditor has sensed some issue with current way of updating authority. As a result of combination,
should just remove the function that we might not even needed to simply things.

closes #403 