### PR TITLE
412 extend vault quarantined period

### DIFF
--- a/plasma_framework/contracts/src/framework/registries/VaultRegistry.sol
+++ b/plasma_framework/contracts/src/framework/registries/VaultRegistry.sol
@@ -16,13 +16,16 @@ contract VaultRegistry is OnlyFromAddress {
     );
 
     /**
-     * @dev It takes at least 1 minExitPeriod for each new vault contract to start protecting deposit transaction in mempool
-     *      see: https://github.com/omisego/plasma-contracts/issues/173
+     * @dev It takes at least 2 minExitPeriod for each new vault contract to start.
+     *      This is to protect deposit transactions already in mempool,
+     *      and also make sure user only needs to SE within first week when invalid vault is registered.
+     *      see: https://github.com/omisego/plasma-contracts/issues/412
+     *           https://github.com/omisego/plasma-contracts/issues/173
      */
     constructor(uint256 _minExitPeriod, uint256 _initialImmuneVaults)
         public
     {
-        _vaultQuarantine.quarantinePeriod = _minExitPeriod;
+        _vaultQuarantine.quarantinePeriod = 2 * _minExitPeriod;
         _vaultQuarantine.immunitiesRemaining = _initialImmuneVaults;
     }
 

--- a/plasma_framework/contracts/src/vaults/Erc20Vault.sol
+++ b/plasma_framework/contracts/src/vaults/Erc20Vault.sol
@@ -33,7 +33,10 @@ contract Erc20Vault is Vault {
      * @param depositTx RLP-encoded transaction to act as the deposit
      */
     function deposit(bytes calldata depositTx) external {
-        (address depositor, address token, uint256 amount) = IErc20DepositVerifier(getEffectiveDepositVerifier())
+        address depositVerifier = super.getEffectiveDepositVerifier();
+        require(depositVerifier != address(0), "Deposit verifier has not been set");
+
+        (address depositor, address token, uint256 amount) = IErc20DepositVerifier(depositVerifier)
             .verify(depositTx, msg.sender, address(this));
 
         IERC20(token).safeTransferFrom(depositor, address(this), amount);

--- a/plasma_framework/contracts/src/vaults/EthVault.sol
+++ b/plasma_framework/contracts/src/vaults/EthVault.sol
@@ -30,7 +30,10 @@ contract EthVault is Vault {
      * @param _depositTx RLP-encoded transaction to act as the deposit
      */
     function deposit(bytes calldata _depositTx) external payable {
-        IEthDepositVerifier(getEffectiveDepositVerifier()).verify(_depositTx, msg.value, msg.sender);
+        address depositVerifier = super.getEffectiveDepositVerifier();
+        require(depositVerifier != address(0), "Deposit verifier has not been set");
+
+        IEthDepositVerifier(depositVerifier).verify(_depositTx, msg.value, msg.sender);
         uint256 blknum = super._submitDepositBlock(_depositTx);
 
         emit DepositCreated(msg.sender, blknum, address(0), msg.value);

--- a/plasma_framework/contracts/src/vaults/Vault.sol
+++ b/plasma_framework/contracts/src/vaults/Vault.sol
@@ -40,7 +40,13 @@ contract Vault is OnlyFromAddress {
     /**
      * @notice Sets the deposit verifier contract, which may be called only by the operator
      * @dev emit SetDepositVerifierCalled
-     * @dev When one contract is already set, the next one is effective after MIN_EXIT_PERIOD
+     * @dev When one contract is already set, the next one is effective after 2 * MIN_EXIT_PERIOD.
+     *      This is to protect deposit transactions already in mempool,
+     *      and also make sure user only needs to SE within first week when invalid vault is registered.
+     *
+     *      see: https://github.com/omisego/plasma-contracts/issues/412
+     *           https://github.com/omisego/plasma-contracts/issues/173
+     *
      * @param _verifier Address of the verifier contract
      */
     function setDepositVerifier(address _verifier) public onlyFrom(framework.getMaintainer()) {
@@ -49,7 +55,7 @@ contract Vault is OnlyFromAddress {
         if (depositVerifiers[0] != address(0)) {
             depositVerifiers[0] = getEffectiveDepositVerifier();
             depositVerifiers[1] = _verifier;
-            newDepositVerifierMaturityTimestamp = now + framework.minExitPeriod();
+            newDepositVerifierMaturityTimestamp = now + 2 * framework.minExitPeriod();
         } else {
             depositVerifiers[0] = _verifier;
         }

--- a/plasma_framework/test/src/framework/registries/VaultRegistry.test.js
+++ b/plasma_framework/test/src/framework/registries/VaultRegistry.test.js
@@ -27,7 +27,7 @@ contract('VaultRegistry', ([_, maintainer, other]) => {
         });
 
         it('should accept call when called by registered and non quarantined vault contract', async () => {
-            await time.increase(MIN_EXIT_PERIOD + 1);
+            await time.increase(2 * MIN_EXIT_PERIOD + 1);
             expect(await this.dummyVault.checkOnlyFromNonQuarantinedVault()).to.be.true;
         });
 

--- a/plasma_framework/test/src/vaults/EthVault.test.js
+++ b/plasma_framework/test/src/vaults/EthVault.test.js
@@ -158,28 +158,6 @@ contract('EthVault', ([_, authority, maintainer, alice]) => {
                 'Deposit must have exactly one output.',
             );
         });
-
-        // NOTE: This test would be the same for `Erc20Vault` as functionality is in base `Vault` contract
-        it('deposit verifier waits a period of time before takes effect', async () => {
-            const newDepositVerifier = await EthDepositVerifier.new(TX_TYPE.PAYMENT, OUTPUT_TYPE.PAYMENT);
-
-            expect(await this.ethVault.getEffectiveDepositVerifier()).to.equal(this.currentDepositVerifier);
-
-            const tx = await this.ethVault.setDepositVerifier(newDepositVerifier.address, { from: maintainer });
-            expect(await this.ethVault.getEffectiveDepositVerifier()).to.equal(this.currentDepositVerifier);
-            await expectEvent.inLogs(tx.logs, 'SetDepositVerifierCalled', { nextDepositVerifier: newDepositVerifier.address });
-
-            await time.increase(2 * MIN_EXIT_PERIOD);
-            expect(await this.ethVault.getEffectiveDepositVerifier()).to.equal(newDepositVerifier.address);
-        });
-
-        // NOTE: This test would be the same for `Erc20Vault` as functionality is in base `Vault` contract
-        it('should not allow for setting empty address as deposit verifier', async () => {
-            await expectRevert(
-                this.ethVault.setDepositVerifier(constants.ZERO_ADDRESS, { from: maintainer }),
-                'Cannot set an empty address as deposit verifier',
-            );
-        });
     });
 
     describe('withdraw', () => {

--- a/plasma_framework/test/src/vaults/EthVault.test.js
+++ b/plasma_framework/test/src/vaults/EthVault.test.js
@@ -169,7 +169,7 @@ contract('EthVault', ([_, authority, maintainer, alice]) => {
             expect(await this.ethVault.getEffectiveDepositVerifier()).to.equal(this.currentDepositVerifier);
             await expectEvent.inLogs(tx.logs, 'SetDepositVerifierCalled', { nextDepositVerifier: newDepositVerifier.address });
 
-            await time.increase(MIN_EXIT_PERIOD);
+            await time.increase(2 * MIN_EXIT_PERIOD);
             expect(await this.ethVault.getEffectiveDepositVerifier()).to.equal(newDepositVerifier.address);
         });
 

--- a/plasma_framework/test/src/vaults/EthVault.test.js
+++ b/plasma_framework/test/src/vaults/EthVault.test.js
@@ -19,7 +19,7 @@ contract('EthVault', ([_, authority, maintainer, alice]) => {
     const INITIAL_IMMUNE_EXIT_GAMES = 1;
     const MIN_EXIT_PERIOD = 10;
 
-    beforeEach('setup contracts', async () => {
+    const setupContractsWithoutDepositVerifier = async () => {
         this.framework = await PlasmaFramework.new(
             MIN_EXIT_PERIOD,
             INITIAL_IMMUNE_VAULTS,
@@ -29,139 +29,162 @@ contract('EthVault', ([_, authority, maintainer, alice]) => {
         );
         await this.framework.activateChildChain({ from: authority });
         this.ethVault = await EthVault.new(this.framework.address);
-        const depositVerifier = await EthDepositVerifier.new(TX_TYPE.PAYMENT, OUTPUT_TYPE.PAYMENT);
-        await this.ethVault.setDepositVerifier(depositVerifier.address, { from: maintainer });
+
         await this.framework.registerVault(1, this.ethVault.address, { from: maintainer });
-        this.currentDepositVerifier = depositVerifier.address;
 
         this.exitGame = await DummyExitGame.new();
         await this.exitGame.setEthVault(this.ethVault.address);
         await this.framework.registerExitGame(1, this.exitGame.address, PROTOCOL.MORE_VP, { from: maintainer });
-    });
+    };
+
+    const setupAllContracts = async () => {
+        await setupContractsWithoutDepositVerifier();
+        const depositVerifier = await EthDepositVerifier.new(TX_TYPE.PAYMENT, OUTPUT_TYPE.PAYMENT);
+        await this.ethVault.setDepositVerifier(depositVerifier.address, { from: maintainer });
+    };
 
     describe('deposit', () => {
-        it('should store ethereum deposit', async () => {
-            const preDepositBlockNumber = (await this.framework.nextDepositBlock()).toNumber();
+        describe('before deposit verifier has been set', () => {
+            beforeEach(setupContractsWithoutDepositVerifier);
 
-            const deposit = Testlang.deposit(OUTPUT_TYPE.PAYMENT, DEPOSIT_VALUE, alice);
-            await this.ethVault.deposit(deposit, { from: alice, value: DEPOSIT_VALUE });
-            const postDepositBlockNumber = (await this.framework.nextDepositBlock()).toNumber();
+            it('should fail with error message', async () => {
+                const deposit = Testlang.deposit(OUTPUT_TYPE.PAYMENT, DEPOSIT_VALUE, alice);
 
-            expect(postDepositBlockNumber).to.be.equal(preDepositBlockNumber + 1);
+                await expectRevert(
+                    this.ethVault.deposit(deposit, { from: alice, value: DEPOSIT_VALUE + 1 }),
+                    'Deposit verifier has not been set',
+                );
+            });
         });
 
-        it('should emit deposit event', async () => {
-            const preDepositBlockNumber = await this.framework.nextDepositBlock();
+        describe('after all related contracts set', () => {
+            beforeEach(setupAllContracts);
 
-            const deposit = Testlang.deposit(OUTPUT_TYPE.PAYMENT, DEPOSIT_VALUE, alice);
-            const { receipt } = await this.ethVault.deposit(deposit, { from: alice, value: DEPOSIT_VALUE });
-            await expectEvent.inTransaction(
-                receipt.transactionHash,
-                EthVault,
-                'DepositCreated',
-                {
-                    depositor: alice,
-                    blknum: preDepositBlockNumber,
-                    token: constants.ZERO_ADDRESS,
-                    amount: new BN(DEPOSIT_VALUE),
-                },
-            );
-        });
+            it('should store ethereum deposit', async () => {
+                const preDepositBlockNumber = (await this.framework.nextDepositBlock()).toNumber();
 
-        it('should charge eth from depositing user', async () => {
-            const preDepositBalance = await web3.eth.getBalance(alice);
-            const deposit = Testlang.deposit(OUTPUT_TYPE.PAYMENT, DEPOSIT_VALUE, alice);
-            const tx = await this.ethVault.deposit(deposit, { from: alice, value: DEPOSIT_VALUE });
+                const deposit = Testlang.deposit(OUTPUT_TYPE.PAYMENT, DEPOSIT_VALUE, alice);
+                await this.ethVault.deposit(deposit, { from: alice, value: DEPOSIT_VALUE });
+                const postDepositBlockNumber = (await this.framework.nextDepositBlock()).toNumber();
 
-            const actualPostDepositBalance = new BN(await web3.eth.getBalance(alice));
-            const expectedPostDepositBalance = (new BN(preDepositBalance))
-                .sub(new BN(DEPOSIT_VALUE)).sub(await spentOnGas(tx.receipt));
+                expect(postDepositBlockNumber).to.be.equal(preDepositBlockNumber + 1);
+            });
 
-            expect(actualPostDepositBalance).to.be.bignumber.equal(expectedPostDepositBalance);
-        });
+            it('should emit deposit event', async () => {
+                const preDepositBlockNumber = await this.framework.nextDepositBlock();
 
-        it('should not store deposit when output value mismatches sent wei', async () => {
-            const deposit = Testlang.deposit(OUTPUT_TYPE.PAYMENT, DEPOSIT_VALUE, alice);
+                const deposit = Testlang.deposit(OUTPUT_TYPE.PAYMENT, DEPOSIT_VALUE, alice);
+                const { receipt } = await this.ethVault.deposit(deposit, { from: alice, value: DEPOSIT_VALUE });
+                await expectEvent.inTransaction(
+                    receipt.transactionHash,
+                    EthVault,
+                    'DepositCreated',
+                    {
+                        depositor: alice,
+                        blknum: preDepositBlockNumber,
+                        token: constants.ZERO_ADDRESS,
+                        amount: new BN(DEPOSIT_VALUE),
+                    },
+                );
+            });
 
-            await expectRevert(
-                this.ethVault.deposit(deposit, { from: alice, value: DEPOSIT_VALUE + 1 }),
-                'Deposited value must match sent amount.',
-            );
+            it('should charge eth from depositing user', async () => {
+                const preDepositBalance = await web3.eth.getBalance(alice);
+                const deposit = Testlang.deposit(OUTPUT_TYPE.PAYMENT, DEPOSIT_VALUE, alice);
+                const tx = await this.ethVault.deposit(deposit, { from: alice, value: DEPOSIT_VALUE });
 
-            await expectRevert(
-                this.ethVault.deposit(deposit, { from: alice, value: DEPOSIT_VALUE - 1 }),
-                'Deposited value must match sent amount.',
-            );
-        });
+                const actualPostDepositBalance = new BN(await web3.eth.getBalance(alice));
+                const expectedPostDepositBalance = (new BN(preDepositBalance))
+                    .sub(new BN(DEPOSIT_VALUE)).sub(await spentOnGas(tx.receipt));
 
-        it('should not store a deposit from user who does not match output address', async () => {
-            const deposit = Testlang.deposit(OUTPUT_TYPE.PAYMENT, DEPOSIT_VALUE, alice);
+                expect(actualPostDepositBalance).to.be.bignumber.equal(expectedPostDepositBalance);
+            });
 
-            await expectRevert(
-                this.ethVault.deposit(deposit, { value: DEPOSIT_VALUE }),
-                "Depositor's address must match sender's address",
-            );
-        });
+            it('should not store deposit when output value mismatches sent wei', async () => {
+                const deposit = Testlang.deposit(OUTPUT_TYPE.PAYMENT, DEPOSIT_VALUE, alice);
 
-        it('should not store a non-ethereum deposit', async () => {
-            const nonEth = Buffer.alloc(20, 1);
-            const deposit = Testlang.deposit(OUTPUT_TYPE.PAYMENT, DEPOSIT_VALUE, alice, nonEth);
+                await expectRevert(
+                    this.ethVault.deposit(deposit, { from: alice, value: DEPOSIT_VALUE + 1 }),
+                    'Deposited value must match sent amount.',
+                );
 
-            await expectRevert(
-                this.ethVault.deposit(deposit, { from: alice, value: DEPOSIT_VALUE }),
-                'Output requires correct currency (ETH).',
-            );
-        });
+                await expectRevert(
+                    this.ethVault.deposit(deposit, { from: alice, value: DEPOSIT_VALUE - 1 }),
+                    'Deposited value must match sent amount.',
+                );
+            });
 
-        it('should not accept a deposit with invalid output type', async () => {
-            const unsupportedOutputType = 2;
-            const deposit = Testlang.deposit(unsupportedOutputType, DEPOSIT_VALUE, alice);
+            it('should not store a deposit from user who does not match output address', async () => {
+                const deposit = Testlang.deposit(OUTPUT_TYPE.PAYMENT, DEPOSIT_VALUE, alice);
 
-            await expectRevert(
-                this.ethVault.deposit(deposit, { from: alice, value: DEPOSIT_VALUE }),
-                'Invalid output type',
-            );
-        });
+                await expectRevert(
+                    this.ethVault.deposit(deposit, { value: DEPOSIT_VALUE }),
+                    "Depositor's address must match sender's address",
+                );
+            });
 
-        it('should not accept transaction that does not match expected transaction type', async () => {
-            const output = new PaymentTransactionOutput(
-                OUTPUT_TYPE.PAYMENT, DEPOSIT_VALUE, alice, constants.ZERO_ADDRESS,
-            );
-            const deposit = new PaymentTransaction(123, [0], [output]);
+            it('should not store a non-ethereum deposit', async () => {
+                const nonEth = Buffer.alloc(20, 1);
+                const deposit = Testlang.deposit(OUTPUT_TYPE.PAYMENT, DEPOSIT_VALUE, alice, nonEth);
 
-            await expectRevert(
-                this.ethVault.deposit(deposit.rlpEncoded(), { from: alice, value: DEPOSIT_VALUE }),
-                'Invalid transaction type.',
-            );
-        });
+                await expectRevert(
+                    this.ethVault.deposit(deposit, { from: alice, value: DEPOSIT_VALUE }),
+                    'Output requires correct currency (ETH).',
+                );
+            });
 
-        it('should not accept transaction with inputs', async () => {
-            const output = new PaymentTransactionOutput(
-                OUTPUT_TYPE.PAYMENT, DEPOSIT_VALUE, alice, constants.ZERO_ADDRESS,
-            );
-            const deposit = new PaymentTransaction(1, [0], [output]);
+            it('should not accept a deposit with invalid output type', async () => {
+                const unsupportedOutputType = 2;
+                const deposit = Testlang.deposit(unsupportedOutputType, DEPOSIT_VALUE, alice);
 
-            await expectRevert(
-                this.ethVault.deposit(deposit.rlpEncoded(), { from: alice, value: DEPOSIT_VALUE }),
-                'Deposit must have no inputs.',
-            );
-        });
+                await expectRevert(
+                    this.ethVault.deposit(deposit, { from: alice, value: DEPOSIT_VALUE }),
+                    'Invalid output type',
+                );
+            });
 
-        it('should not accept transaction with more than one output', async () => {
-            const output = new PaymentTransactionOutput(
-                OUTPUT_TYPE.PAYMENT, DEPOSIT_VALUE, alice, constants.ZERO_ADDRESS,
-            );
-            const deposit = new PaymentTransaction(1, [], [output, output]);
+            it('should not accept transaction that does not match expected transaction type', async () => {
+                const output = new PaymentTransactionOutput(
+                    OUTPUT_TYPE.PAYMENT, DEPOSIT_VALUE, alice, constants.ZERO_ADDRESS,
+                );
+                const deposit = new PaymentTransaction(123, [0], [output]);
 
-            await expectRevert(
-                this.ethVault.deposit(deposit.rlpEncoded(), { from: alice, value: DEPOSIT_VALUE }),
-                'Deposit must have exactly one output.',
-            );
+                await expectRevert(
+                    this.ethVault.deposit(deposit.rlpEncoded(), { from: alice, value: DEPOSIT_VALUE }),
+                    'Invalid transaction type.',
+                );
+            });
+
+            it('should not accept transaction with inputs', async () => {
+                const output = new PaymentTransactionOutput(
+                    OUTPUT_TYPE.PAYMENT, DEPOSIT_VALUE, alice, constants.ZERO_ADDRESS,
+                );
+                const deposit = new PaymentTransaction(1, [0], [output]);
+
+                await expectRevert(
+                    this.ethVault.deposit(deposit.rlpEncoded(), { from: alice, value: DEPOSIT_VALUE }),
+                    'Deposit must have no inputs.',
+                );
+            });
+
+            it('should not accept transaction with more than one output', async () => {
+                const output = new PaymentTransactionOutput(
+                    OUTPUT_TYPE.PAYMENT, DEPOSIT_VALUE, alice, constants.ZERO_ADDRESS,
+                );
+                const deposit = new PaymentTransaction(1, [], [output, output]);
+
+                await expectRevert(
+                    this.ethVault.deposit(deposit.rlpEncoded(), { from: alice, value: DEPOSIT_VALUE }),
+                    'Deposit must have exactly one output.',
+                );
+            });
         });
     });
 
     describe('withdraw', () => {
         beforeEach(async () => {
+            await setupAllContracts();
+
             const deposit = Testlang.deposit(OUTPUT_TYPE.PAYMENT, DEPOSIT_VALUE, alice);
             await this.ethVault.deposit(deposit, { from: alice, value: DEPOSIT_VALUE });
         });

--- a/plasma_framework/test/src/vaults/Vault.test.js
+++ b/plasma_framework/test/src/vaults/Vault.test.js
@@ -9,7 +9,7 @@ const { expect } = require('chai');
 
 const { OUTPUT_TYPE, TX_TYPE } = require('../../helpers/constants.js');
 
-contract.only('Vault', ([_, authority, maintainer, alice]) => {
+contract('Vault', ([_, authority, maintainer, alice]) => {
     const MIN_EXIT_PERIOD = 10;
     const INITIAL_IMMUNE_VAULTS = 1;
     const INITIAL_IMMUNE_EXIT_GAMES = 1;

--- a/plasma_framework/test/src/vaults/Vault.test.js
+++ b/plasma_framework/test/src/vaults/Vault.test.js
@@ -1,0 +1,103 @@
+const PlasmaFramework = artifacts.require('PlasmaFramework');
+const EthVault = artifacts.require('EthVault');
+const EthDepositVerifier = artifacts.require('EthDepositVerifier');
+
+const {
+    BN, constants, expectEvent, expectRevert, time,
+} = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
+
+const { OUTPUT_TYPE, TX_TYPE } = require('../../helpers/constants.js');
+
+contract.only('Vault', ([_, authority, maintainer, alice]) => {
+    const MIN_EXIT_PERIOD = 10;
+    const INITIAL_IMMUNE_VAULTS = 1;
+    const INITIAL_IMMUNE_EXIT_GAMES = 1;
+    const TOLERANCE_SECONDS = new BN(1);
+    let vault;
+
+    beforeEach('setup contracts - use EthVault to test public functions of Vault for simplicity', async () => {
+        const framework = await PlasmaFramework.new(
+            MIN_EXIT_PERIOD,
+            INITIAL_IMMUNE_VAULTS,
+            INITIAL_IMMUNE_EXIT_GAMES,
+            authority,
+            maintainer,
+        );
+        vault = await EthVault.new(framework.address);
+    });
+
+    describe('setDepositVerifier / getEffectiveDepositVerifier', () => {
+        it('should not allow for setting empty address as deposit verifier', async () => {
+            await expectRevert(
+                vault.setDepositVerifier(constants.ZERO_ADDRESS, { from: maintainer }),
+                'Cannot set an empty address as deposit verifier',
+            );
+        });
+
+        it('should fail when not set by maintainer', async () => {
+            await expectRevert(
+                vault.setDepositVerifier(constants.ZERO_ADDRESS, { from: alice }),
+                'Caller address is unauthorized',
+            );
+        });
+
+        describe('before any deposit verifier is set', async () => {
+            it('should get empty address if nothing is set', async () => {
+                expect(await vault.getEffectiveDepositVerifier()).to.equal(constants.ZERO_ADDRESS);
+            });
+        });
+
+        describe('after the first deposit verifier is set', async () => {
+            let firstDepositVerifier;
+            let setFirstVerifierTx;
+
+            beforeEach(async () => {
+                firstDepositVerifier = await EthDepositVerifier.new(TX_TYPE.PAYMENT, OUTPUT_TYPE.PAYMENT);
+                setFirstVerifierTx = await vault.setDepositVerifier(
+                    firstDepositVerifier.address, { from: maintainer },
+                );
+            });
+
+            it('should immediately take effect', async () => {
+                expect(await vault.getEffectiveDepositVerifier()).to.equal(firstDepositVerifier.address);
+            });
+
+            it('should emit SetDepositVerifierCalled event', async () => {
+                await expectEvent.inLogs(
+                    setFirstVerifierTx.logs,
+                    'SetDepositVerifierCalled',
+                    { nextDepositVerifier: firstDepositVerifier.address },
+                );
+            });
+
+            describe('when setting the second verifier', () => {
+                let secondVerifier;
+                let setSecondVerifierTx;
+
+                beforeEach(async () => {
+                    secondVerifier = await EthDepositVerifier.new(TX_TYPE.PAYMENT, OUTPUT_TYPE.PAYMENT);
+                    setSecondVerifierTx = await vault.setDepositVerifier(secondVerifier.address, { from: maintainer });
+                });
+
+                it('should not take effect before 2 minExitPeriod has passed', async () => {
+                    await time.increase(2 * MIN_EXIT_PERIOD - 1 - TOLERANCE_SECONDS);
+                    expect(await vault.getEffectiveDepositVerifier()).to.equal(firstDepositVerifier.address);
+                });
+
+                it('should take effect after 2 minExitPeriod has passed', async () => {
+                    await time.increase(2 * MIN_EXIT_PERIOD);
+                    expect(await vault.getEffectiveDepositVerifier()).to.equal(secondVerifier.address);
+                });
+
+                it('should emit SetDepositVerifierCalled event', async () => {
+                    await expectEvent.inLogs(
+                        setSecondVerifierTx.logs,
+                        'SetDepositVerifierCalled',
+                        { nextDepositVerifier: secondVerifier.address },
+                    );
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
### Note
- Change quarantined period from 1 minExitPeriod to 2 for `Vault` and `DepositVerifier`. closes #412 
- Pull tests for set/get deposit verifier to new test file: `Vault.test.js`. It was under `EthVault.test.js` with comment saying it tests for both vaults.
- When deposit verifier is not set, ERC20 vault and Eth vault would fail with error message: `Deposit verifier has not been set`. And add test for this.

### Current Vault Tests looks like the following
```
Contract: Erc20Vault
    deposit
      before deposit verifier is set
        ✓ should fail with error message
      after all contracts are set
        ✓ should store erc20 deposit (135ms)
        ✓ should emit deposit event (140ms)
        ✓ should spend erc20 tokens from depositing user (132ms)
        ✓ should not store a deposit when the tokens have not been approved (76ms)
        ✓ should not store a deposit from user who does not match output address (81ms)
        ✓ should not store an ethereum deposit that sends funds
        ✓ should not store an ethereum deposit that does not send funds (73ms)
        ✓ should not accept a deposit with invalid output type (72ms)
        ✓ should not accept transaction that does not match expected transaction type (78ms)
        ✓ should not accept transaction with inputs (77ms)
        ✓ should not accept transaction with more than one output (89ms)
    deposit from NonCompliantERC20
      ✓ should store erc20 deposit (117ms)
    withdraw
      ✓ should fail when not called by a registered exit game contract
      ✓ should transfer ERC token to the receiver (70ms)
      ✓ should emit Erc20Withdrawn event correctly (42ms)
      given quarantined exit game
        ✓ should fail when called under quarantine (38ms)
        ✓ should succeed after quarantine period passes (65ms)
    withdraw with NonCompliantERC20
      ✓ should transfer ERC token to the receiver (66ms)

  Contract: EthVault
    deposit
      before deposit verifier has been set
        ✓ should fail with error message
      after all related contracts set
        ✓ should store ethereum deposit (84ms)
        ✓ should emit deposit event (79ms)
        ✓ should charge eth from depositing user (75ms)
        ✓ should not store deposit when output value mismatches sent wei (139ms)
        ✓ should not store a deposit from user who does not match output address (66ms)
        ✓ should not store a non-ethereum deposit (69ms)
        ✓ should not accept a deposit with invalid output type (69ms)
        ✓ should not accept transaction that does not match expected transaction type (69ms)
        ✓ should not accept transaction with inputs (71ms)
        ✓ should not accept transaction with more than one output (87ms)
    withdraw
      ✓ should fail when not called by a registered exit game contract
      ✓ should transfer ETH to the receiver (44ms)
      ✓ should emit EthWithdrawn event correctly (39ms)
      when fund transfer fails
        ✓ should emit WithdrawFailed event
        ✓ should not transfer ETH
      given quarantined exit game
        ✓ should fail when called under quarantine (40ms)
        ✓ should succeed after quarantine period passes (43ms)

  Contract: Vault
    setDepositVerifier / getEffectiveDepositVerifier
      ✓ should not allow for setting empty address as deposit verifier
      ✓ should fail when not set by maintainer
      before any deposit verifier is set
        ✓ should get empty address if nothing is set
      after the first deposit verifier is set
        ✓ should immediately take effect
        ✓ should emit SetDepositVerifierCalled event
        when setting the second verifier
          ✓ should not take effect before 2 minExitPeriod has passed
          ✓ should take effect after 2 minExitPeriod has passed
          ✓ should emit SetDepositVerifierCalled event
```
