### PR TITLE
chore: run gas report on e2e test only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,16 @@ jobs:
           name: Run tests
           command: truffle test 
           working_directory: ~/repo/plasma_framework
+
+  Gas Report:
+    executor: truffle_executor
+    working_directory: ~/repo
+    steps:
+      - setup_truffle_env
+      - run:
+          name: Run tests
+          command: npx truffle test test/**/**.e2e.test.js
+          working_directory: ~/repo/plasma_framework
           environment:
             CI: true
             MOCHA_REPORTER: eth-gas-reporter
@@ -144,6 +154,7 @@ workflows:
   Run truffle tests:
     jobs:
       - Truffle tests
+      - Gas Report
       - Solidity coverage
       - Javascript linter
       - Solidity linter


### PR DESCRIPTION
### What
Unit tests relies on mock heavily, which might end up giving noice when reviewing gas usage.

### Some notes
After looking at the gas report, finally realize sth that had confused me for a while. Our report is always missing some functions. Seems like to be of this issue: https://github.com/cgewecke/eth-gas-reporter/issues/186

So basically all method using struct as input (almost all PaymentExitGame functions) would not have gas report due to that.