### PR TITLE
fix: make sure events in lib states in the caller of lib too

### DIFF
--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentProcessInFlightExit.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentProcessInFlightExit.sol
@@ -44,6 +44,7 @@ library PaymentProcessInFlightExit {
     /**
      * @notice Main logic function to process in-flight exit
      * @dev emits InFlightExitOmitted event if the exit is omitted
+     * @dev emits InFlightBondReturnFailed event if failed to pay out bond. Would continue to process the exit.
      * @dev emits InFlightExitInputWithdrawn event if the input of IFE is withdrawn successfully
      * @dev emits InFlightExitOutputWithdrawn event if the output of IFE is withdrawn successfully
      * @param self The controller struct

--- a/plasma_framework/contracts/src/exits/payment/routers/PaymentInFlightExitRouter.sol
+++ b/plasma_framework/contracts/src/exits/payment/routers/PaymentInFlightExitRouter.sol
@@ -71,6 +71,11 @@ contract PaymentInFlightExitRouter is IExitProcessor, OnlyFromAddress, OnlyWithV
         address token
     );
 
+    event InFlightBondReturnFailed(
+        address indexed receiver,
+        uint256 amount
+    );
+
     event InFlightExitOutputWithdrawn(
         uint160 indexed exitId,
         uint16 outputIndex

--- a/plasma_framework/contracts/src/exits/payment/routers/PaymentStandardExitRouter.sol
+++ b/plasma_framework/contracts/src/exits/payment/routers/PaymentStandardExitRouter.sol
@@ -63,6 +63,11 @@ contract PaymentStandardExitRouter is
         uint160 indexed exitId
     );
 
+    event BondReturnFailed(
+        address indexed receiver,
+        uint256 amount
+    );
+
     constructor(
         PlasmaFramework plasmaFramework,
         uint256 ethVaultId,


### PR DESCRIPTION
### Note
While tracing through code, realize some events in library of controller is not defined in the router.

Reason of duplicating event definition, see: https://ethereum.stackexchange.com/questions/11137/watching-events-defined-in-libraries