### PR TITLE
Some minor fixes

### DIFF
--- a/plasma_framework/contracts/mocks/exits/payment/routers/PaymentInFlightExitRouterMock.sol
+++ b/plasma_framework/contracts/mocks/exits/payment/routers/PaymentInFlightExitRouterMock.sol
@@ -82,6 +82,10 @@ contract PaymentInFlightExitRouterMock is FailFastReentrancyGuard, PaymentInFlig
         inFlightExitMap.exits[exitId].setInputPiggybacked(inputIndex);
     }
 
+    function setInFlightExitOutputPiggybacked(uint160 exitId, uint16 outputIndex) public payable {
+        inFlightExitMap.exits[exitId].setOutputPiggybacked(outputIndex);
+    }
+
     function getInFlightExitOutput(uint160 exitId, uint16 outputIndex) public view returns (PaymentExitDataModel.WithdrawData memory) {
         return inFlightExitMap.exits[exitId].outputs[outputIndex];
     }

--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentChallengeIFENotCanonical.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentChallengeIFENotCanonical.sol
@@ -170,10 +170,12 @@ library PaymentChallengeIFENotCanonical {
 
         require(
             ife.oldestCompetitorPosition > inFlightTxPos,
-            "In-flight transaction must be younger than competitors to respond to non-canonical challenge");
+            "In-flight transaction must be older than competitors to respond to non-canonical challenge");
 
         UtxoPosLib.UtxoPos memory utxoPos = UtxoPosLib.UtxoPos(inFlightTxPos);
         (bytes32 root, ) = self.framework.blocks(utxoPos.blockNum());
+        require(root != bytes32(""), "Failed to get the block root hash of the UTXO position");
+
         ife.oldestCompetitorPosition = verifyAndDeterminePositionOfTransactionIncludedInBlock(
             inFlightTx, utxoPos, root, inFlightTxInclusionProof
         );

--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentPiggybackInFlightExit.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentPiggybackInFlightExit.sol
@@ -165,7 +165,7 @@ library PaymentPiggybackInFlightExit {
         private
     {
         (, uint256 blockTimestamp) = controller.framework.blocks(utxoPos.blockNum());
-        require(blockTimestamp != 0, "There is no block for the position to enqueue");
+        require(blockTimestamp != 0, "There is no block for the exit position to enqueue");
 
         uint64 exitableAt = controller.exitableTimestampCalculator.calculateTxExitableTimestamp(now, blockTimestamp);
 

--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentPiggybackInFlightExit.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentPiggybackInFlightExit.sol
@@ -165,6 +165,7 @@ library PaymentPiggybackInFlightExit {
         private
     {
         (, uint256 blockTimestamp) = controller.framework.blocks(utxoPos.blockNum());
+        require(blockTimestamp != 0, "Failed to get the block timestamp information of the exit position to enqueue");
 
         uint64 exitableAt = controller.exitableTimestampCalculator.calculateTxExitableTimestamp(now, blockTimestamp);
 

--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentPiggybackInFlightExit.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentPiggybackInFlightExit.sol
@@ -165,7 +165,7 @@ library PaymentPiggybackInFlightExit {
         private
     {
         (, uint256 blockTimestamp) = controller.framework.blocks(utxoPos.blockNum());
-        require(blockTimestamp != 0, "Failed to get the block timestamp information of the exit position to enqueue");
+        require(blockTimestamp != 0, "There is no block for the position to enqueue");
 
         uint64 exitableAt = controller.exitableTimestampCalculator.calculateTxExitableTimestamp(now, blockTimestamp);
 
@@ -209,14 +209,12 @@ library PaymentPiggybackInFlightExit {
         pure
         returns (bool)
     {
-        bool isPiggybackInput = true;
         for (uint i = 0; i < MAX_INPUT_NUM; i++) {
             if (ife.isInputPiggybacked(uint16(i)) && ife.inputs[i].token == token) {
                 return false;
             }
         }
 
-        isPiggybackInput = false;
         for (uint i = 0; i < MAX_OUTPUT_NUM; i++) {
             if (ife.isOutputPiggybacked(uint16(i)) && ife.outputs[i].token == token) {
                 return false;

--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentStartStandardExit.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentStartStandardExit.sol
@@ -166,7 +166,7 @@ library PaymentStartStandardExit {
         view
     {
         require(data.output.amount > 0, "Should not exit with amount 0");
-        require(data.txBlockTimeStamp != 0, "Failed to get the block timestamp of the UTXO position");
+        require(data.txBlockTimeStamp != 0, "There is no block for the position");
 
         require(address(data.outputGuardHandler) != address(0), "Failed to get the output guard handler for the output type");
         require(data.outputGuardHandler.isValid(data.outputGuardData), "Some output guard information is invalid");

--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentStartStandardExit.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentStartStandardExit.sol
@@ -166,6 +166,7 @@ library PaymentStartStandardExit {
         view
     {
         require(data.output.amount > 0, "Should not exit with amount 0");
+        require(data.txBlockTimeStamp != 0, "Failed to get the block timestamp of the UTXO position");
 
         require(address(data.outputGuardHandler) != address(0), "Failed to get the output guard handler for the output type");
         require(data.outputGuardHandler.isValid(data.outputGuardData), "Some output guard information is invalid");

--- a/plasma_framework/contracts/src/exits/payment/spendingConditions/PaymentOutputToPaymentTxCondition.sol
+++ b/plasma_framework/contracts/src/exits/payment/spendingConditions/PaymentOutputToPaymentTxCondition.sol
@@ -62,8 +62,10 @@ contract PaymentOutputToPaymentTxCondition is ISpendingCondition {
             "Spending tx points to the incorrect output UTXO position"
         );
 
-        address payable owner = inputTx.outputs[outputIndex].owner();
-        require(owner == ECDSA.recover(eip712.hashTx(spendingTx), signature), "Tx in not signed correctly");
+        address owner = inputTx.outputs[outputIndex].owner();
+        address signer = ECDSA.recover(eip712.hashTx(spendingTx), signature);
+        require(signer != address(0), "Failed to recover the signer from the signature");
+        require(owner == signer, "Tx in not signed correctly");
 
         return true;
     }

--- a/plasma_framework/contracts/src/exits/utils/TxFinalizationVerifier.sol
+++ b/plasma_framework/contracts/src/exits/utils/TxFinalizationVerifier.sol
@@ -52,6 +52,8 @@ contract TxFinalizationVerifier is ITxFinalizationVerifier {
         }
 
         (bytes32 root,) = data.framework.blocks(data.txPos.blockNum());
+        require(root != bytes32(""), "Failed to get the root hash of the block num");
+
         bytes32 leafData = keccak256(data.txBytes);
         return Merkle.checkMembership(
             leafData, data.txPos.txIndex(), root, data.inclusionProof

--- a/plasma_framework/test/src/exits/payment/PaymentPiggybackInFlightExitOnInput.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentPiggybackInFlightExitOnInput.test.js
@@ -240,14 +240,14 @@ contract('PaymentInFlightExitRouter', ([_, alice, inputOwner, nonInputOwner, out
             );
         });
 
-        it('should fail when failed to get the block timestamp info of the exit position', async () => {
+        it('should fail when there is no block for the exit position to enqueue', async () => {
             const data = await buildPiggybackInputData();
             await this.exitGame.setInFlightExit(data.exitId, data.inFlightExitData);
             await expectRevert(
                 this.exitGame.piggybackInFlightExitOnInput(
                     data.argsInputOne, { from: inputOwner, value: this.piggybackBondSize.toString() },
                 ),
-                'Failed to get the block timestamp information of the exit position to enqueue',
+                'There is no block for the exit position to enqueue',
             );
         });
 

--- a/plasma_framework/test/src/exits/payment/PaymentPiggybackInFlightExitOnInput.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentPiggybackInFlightExitOnInput.test.js
@@ -218,11 +218,9 @@ contract('PaymentInFlightExitRouter', ([_, alice, inputOwner, nonInputOwner, out
         it('should fail when the same input has been piggybacked', async () => {
             const data = await buildPiggybackInputData();
             await this.exitGame.setInFlightExit(data.exitId, data.inFlightExitData);
-            await this.exitGame.piggybackInFlightExitOnInput(
-                data.argsInputOne, { from: inputOwner, value: this.piggybackBondSize.toString() },
-            );
 
-            // second attmept should fail
+            await this.exitGame.setInFlightExitInputPiggybacked(data.exitId, data.argsInputOne.inputIndex);
+
             await expectRevert(
                 this.exitGame.piggybackInFlightExitOnInput(
                     data.argsInputOne, { from: inputOwner, value: this.piggybackBondSize.toString() },
@@ -239,6 +237,17 @@ contract('PaymentInFlightExitRouter', ([_, alice, inputOwner, nonInputOwner, out
                     data.argsInputOne, { from: nonInputOwner, value: this.piggybackBondSize.toString() },
                 ),
                 'Can be called only by the exit target',
+            );
+        });
+
+        it('should fail when failed to get the block timestamp info of the exit position', async () => {
+            const data = await buildPiggybackInputData();
+            await this.exitGame.setInFlightExit(data.exitId, data.inFlightExitData);
+            await expectRevert(
+                this.exitGame.piggybackInFlightExitOnInput(
+                    data.argsInputOne, { from: inputOwner, value: this.piggybackBondSize.toString() },
+                ),
+                'Failed to get the block timestamp information of the exit position to enqueue',
             );
         });
 

--- a/plasma_framework/test/src/exits/payment/PaymentPiggybackInFlightExitOnOutput.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentPiggybackInFlightExitOnOutput.test.js
@@ -256,7 +256,7 @@ contract('PaymentInFlightExitRouter', ([_, alice, inputOwner, outputOwner, nonOu
             );
         });
 
-        it('should fail when failed to get the block timestamp information of the exit position to enqueue', async () => {
+        it('should fail when there is no block for the exit position to enqueue', async () => {
             const data = await buildPiggybackOutputData();
 
             await this.exitGame.setInFlightExit(data.exitId, data.inFlightExitData);
@@ -265,7 +265,7 @@ contract('PaymentInFlightExitRouter', ([_, alice, inputOwner, outputOwner, nonOu
                 this.exitGame.piggybackInFlightExitOnOutput(
                     data.outputOneCase.args, { from: outputOwner, value: this.piggybackBondSize.toString() },
                 ),
-                'Failed to get the block timestamp information of the exit position to enqueue',
+                'There is no block for the exit position to enqueue',
             );
         });
 

--- a/plasma_framework/test/src/exits/payment/PaymentStartStandardExit.test.js
+++ b/plasma_framework/test/src/exits/payment/PaymentStartStandardExit.test.js
@@ -155,7 +155,7 @@ contract('PaymentStandardExitRouter', ([_, outputOwner, nonOutputOwner]) => {
                 this.exitGame.startStandardExit(
                     args, { from: outputOwner, value: this.startStandardExitBondSize },
                 ),
-                'Failed to get the block timestamp of the UTXO position',
+                'There is no block for the position',
             );
         });
 

--- a/plasma_framework/test/src/exits/payment/spendingConditions/PaymentOutputToPaymentTxCondition.test.js
+++ b/plasma_framework/test/src/exits/payment/spendingConditions/PaymentOutputToPaymentTxCondition.test.js
@@ -136,6 +136,25 @@ contract('PaymentOutputToPaymentTxCondition', ([richFather, bob]) => {
             );
         });
 
+        it('should fail when failed to recover the signer from the signature', async () => {
+            const { args } = getTestData();
+
+            const wrongSignature = args.signature.substring(0, args.signature.length - 1).concat('f');
+
+            await expectRevert(
+                this.condition.verify(
+                    args.inputTxBytes,
+                    args.outputIndex,
+                    args.inputTxPos,
+                    args.spendingTxBytes,
+                    args.inputIndex,
+                    wrongSignature,
+                    args.optionalArgs,
+                ),
+                'Failed to recover the signer from the signature',
+            );
+        });
+
         it('should fail when spending tx not correctly signed by the input owner', async () => {
             const { args, spendingTx } = getTestData();
 

--- a/plasma_framework/test/src/exits/utils/TxFinalizationVerifier.test.js
+++ b/plasma_framework/test/src/exits/utils/TxFinalizationVerifier.test.js
@@ -97,6 +97,13 @@ contract('TxFinalizationVerifier', ([richFather]) => {
                 ];
             });
 
+            it('should revert if there is no block root hash data in the PlasmaFramework for the position', async () => {
+                await expectRevert(
+                    this.test.isStandardFinalized(this.data),
+                    'Failed to get the root hash of the block num',
+                );
+            });
+
             it('should return true given valid inclusion proof', async () => {
                 await this.framework.setBlock(TEST_BLOCK_NUM, this.merkle.root, 0);
 

--- a/plasma_framework/test/src/framework/ExitGameController.test.js
+++ b/plasma_framework/test/src/framework/ExitGameController.test.js
@@ -316,7 +316,7 @@ contract('ExitGameController', () => {
                 );
             });
 
-            it('should be able to process when the "top priority" is set to 0', async () => {
+            it('should be able to process when the exitId is set to 0', async () => {
                 const tx = await this.controller.processExits(VAULT_ID, this.dummyToken, 0, 1);
                 await expectEvent.inLogs(tx.logs, 'ProcessedExitsNum', {
                     processedNum: new BN(1),
@@ -324,10 +324,10 @@ contract('ExitGameController', () => {
                 });
             });
 
-            it('should be able to process when the "top priority" is set to the exact top of the queue', async () => {
-                const priority = await this.dummyExitGame.priorityFromEnqueue();
-
-                const tx = await this.controller.processExits(VAULT_ID, this.dummyToken, priority, 1);
+            it('should be able to process when the exitId is set to the exact top of the queue', async () => {
+                const tx = await this.controller.processExits(
+                    VAULT_ID, this.dummyToken, this.dummyExit.exitId, 1,
+                );
                 await expectEvent.inLogs(tx.logs, 'ProcessedExitsNum', {
                     processedNum: new BN(1),
                     token: this.dummyToken,


### PR DESCRIPTION
### Note
1. fix: use exitId instead of top priority in processExits tests 
1. fix: checks block data is empty or not when getting from framework. closes #453 
1. fix: revert when not able to recover the signer from signature. closes #454 