### PR TITLE
chore: not using cache in python CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,9 +33,6 @@ commands:
           name: Change dependencies directories ownership
           command: |
             sudo chown -R circleci:circleci /usr/local/bin /usr/local/lib /usr/local/lib/python3.7/site-packages 
-      - restore_cache:
-          keys:
-            - dependencies_v2_{{ checksum "plasma_framework/python_tests/requirements.txt" }}
       - run:
           name: Prepare environment
           command: |
@@ -48,12 +45,6 @@ commands:
           command: |
             make init dev 
             python -m solcx.install v0.5.11
-      - save_cache:
-          key: dependencies_v2_{{ checksum "plasma_framework/python_tests/requirements.txt" }}
-          paths:
-            - /usr/local/bin
-            - /usr/local/lib/python3.7/site-packages
-            - /usr/local/lib/node_modules
 
 jobs:
   Truffle tests:


### PR DESCRIPTION
### Note
Somehow the CI starts to fail when installing dependency. This commit first remove the cache
usage in CI without fully digging into the root cause to unblock normal PR merging.

Example of CI failure: https://app.circleci.com/jobs/github/omisego/plasma-contracts/7045.
It is under a branch only adds document from master, so it is definitely not code change that breaks the CI. (This PR: https://github.com/omisego/plasma-contracts/pull/455)