### PR TITLE
fix: check all registration is a contract

### DIFF
--- a/plasma_framework/contracts/src/exits/registries/OutputGuardHandlerRegistry.sol
+++ b/plasma_framework/contracts/src/exits/registries/OutputGuardHandlerRegistry.sol
@@ -1,6 +1,8 @@
 pragma solidity 0.5.11;
 
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "openzeppelin-solidity/contracts/utils/Address.sol";
+
 import "../interfaces/IOutputGuardHandler.sol";
 
 /**
@@ -25,7 +27,7 @@ contract OutputGuardHandlerRegistry is Ownable {
         onlyOwner
     {
         require(outputType != 0, "Registration not possible with output type 0");
-        require(address(handler) != address(0), "Registration not possible with an empty address");
+        require(Address.isContract(address(handler)), "Registration not possible with a non-contract address");
         require(address(outputGuardHandlers[outputType]) == address(0), "Output type already registered");
 
         outputGuardHandlers[outputType] = handler;

--- a/plasma_framework/contracts/src/exits/registries/SpendingConditionRegistry.sol
+++ b/plasma_framework/contracts/src/exits/registries/SpendingConditionRegistry.sol
@@ -1,6 +1,8 @@
 pragma solidity 0.5.11;
 
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "openzeppelin-solidity/contracts/utils/Address.sol";
+
 import "../interfaces/ISpendingCondition.sol";
 
 /**
@@ -32,7 +34,7 @@ contract SpendingConditionRegistry is Ownable {
     {
         require(outputType != 0, "Registration not possible with output type 0");
         require(spendingTxType != 0, "Registration not possible with spending tx type 0");
-        require(address(condition) != address(0), "Registration not possible with an empty address");
+        require(Address.isContract(address(condition)), "Registration not possible with a non-contract address");
 
         bytes32 key = keccak256(abi.encode(outputType, spendingTxType));
         require(address(_spendingConditions[key]) == address(0), "The (output type, spending tx type) pair is already registered");

--- a/plasma_framework/contracts/src/framework/registries/ExitGameRegistry.sol
+++ b/plasma_framework/contracts/src/framework/registries/ExitGameRegistry.sol
@@ -1,5 +1,7 @@
 pragma solidity 0.5.11;
 
+import "openzeppelin-solidity/contracts/utils/Address.sol";
+
 import "../Protocol.sol";
 import "../utils/Quarantine.sol";
 import "../../utils/OnlyFromAddress.sol";
@@ -64,7 +66,7 @@ contract ExitGameRegistry is OnlyFromAddress {
      */
     function registerExitGame(uint256 _txType, address _contract, uint8 _protocol) public onlyFrom(getMaintainer()) {
         require(_txType != 0, "Should not register with tx type 0");
-        require(_contract != address(0), "Should not register with an empty exit game address");
+        require(Address.isContract(_contract), "Should not register with a non-contract address");
         require(_exitGames[_txType] == address(0), "The tx type is already registered");
         require(_exitGameToTxType[_contract] == 0, "The exit game contract is already registered");
         require(Protocol.isValidProtocol(_protocol), "Invalid protocol value");

--- a/plasma_framework/contracts/src/framework/registries/VaultRegistry.sol
+++ b/plasma_framework/contracts/src/framework/registries/VaultRegistry.sol
@@ -1,5 +1,7 @@
 pragma solidity 0.5.11;
 
+import "openzeppelin-solidity/contracts/utils/Address.sol";
+
 import "../utils/Quarantine.sol";
 import "../../utils/OnlyFromAddress.sol";
 
@@ -52,7 +54,7 @@ contract VaultRegistry is OnlyFromAddress {
      */
     function registerVault(uint256 _vaultId, address _vaultAddress) public onlyFrom(getMaintainer()) {
         require(_vaultId != 0, "Should not register with vault ID 0");
-        require(_vaultAddress != address(0), "Should not register an empty vault address");
+        require(Address.isContract(_vaultAddress), "Should not register with a non-contract address");
         require(_vaults[_vaultId] == address(0), "The vault ID is already registered");
         require(_vaultToId[_vaultAddress] == 0, "The vault contract is already registered");
 

--- a/plasma_framework/test/src/exits/registries/OutputGuardHandlerRegistry.test.js
+++ b/plasma_framework/test/src/exits/registries/OutputGuardHandlerRegistry.test.js
@@ -49,10 +49,10 @@ contract('OutputGuardHandlerRegistry', ([_, other]) => {
             );
         });
 
-        it('should reject when trying to register with an empty address', async () => {
+        it('should reject when trying to register with a non-contract address', async () => {
             await expectRevert(
                 this.registry.registerOutputGuardHandler(1, constants.ZERO_ADDRESS),
-                'Registration not possible with an empty address',
+                'Registration not possible with a non-contract address',
             );
         });
 

--- a/plasma_framework/test/src/exits/registries/SpendingConditionRegistry.test.js
+++ b/plasma_framework/test/src/exits/registries/SpendingConditionRegistry.test.js
@@ -74,10 +74,10 @@ contract('SpendingConditionRegistry', ([_, other]) => {
             );
         });
 
-        it('should reject when trying to register with an empty address', async () => {
+        it('should reject when trying to register with a non-contract address', async () => {
             await expectRevert(
-                this.registry.registerSpendingCondition(1, 1, constants.ZERO_ADDRESS),
-                'Registration not possible with an empty address',
+                this.registry.registerSpendingCondition(1, 1, other),
+                'Registration not possible with a non-contract address',
             );
         });
 

--- a/plasma_framework/test/src/framework/registries/ExitGameRegistry.test.js
+++ b/plasma_framework/test/src/framework/registries/ExitGameRegistry.test.js
@@ -2,7 +2,7 @@ const ExitGameRegistry = artifacts.require('ExitGameRegistryMock');
 const DummyExitGame = artifacts.require('DummyExitGame');
 
 const {
-    BN, constants, expectEvent, expectRevert, time,
+    BN, expectEvent, expectRevert, time,
 } = require('openzeppelin-test-helpers');
 const { expect } = require('chai');
 const { PROTOCOL } = require('../../../helpers/constants.js');
@@ -119,10 +119,10 @@ contract('ExitGameRegistry', ([_, maintainer, other]) => {
             );
         });
 
-        it('rejects when trying to register with empty address', async () => {
+        it('rejects when trying to register with a non contract address', async () => {
             await expectRevert(
-                this.registry.registerExitGame(1, constants.ZERO_ADDRESS, PROTOCOL.MORE_VP, { from: maintainer }),
-                'Should not register with an empty exit game address',
+                this.registry.registerExitGame(1, other, PROTOCOL.MORE_VP, { from: maintainer }),
+                'Should not register with a non-contract address',
             );
         });
 

--- a/plasma_framework/test/src/framework/registries/VaultRegistry.test.js
+++ b/plasma_framework/test/src/framework/registries/VaultRegistry.test.js
@@ -108,10 +108,10 @@ contract('VaultRegistry', ([_, maintainer, other]) => {
             );
         });
 
-        it('rejects when trying to register with an empty vault address', async () => {
+        it('rejects when trying to register with a non-contract address', async () => {
             await expectRevert(
                 this.registry.registerVault(1, constants.ZERO_ADDRESS, { from: maintainer }),
-                'Should not register an empty vault address',
+                'Should not register with a non-contract address',
             );
         });
 


### PR DESCRIPTION
### Note
Add more sanity check on the contract. Previously it was possible to register an address that the contract is not yet deployed. This commit uses the openzepplin library of 'isContract' function to do the sanity check.

lib: https://docs.openzeppelin.com/contracts/2.x/api/utils#Address-isContract-address-
closes: https://github.com/omisego/plasma-contracts/issues/410

