### PR TITLE
Improve readibility of payment game impl doc and tx types doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ coverage.json
 
 # pytest-xprocess
 .xprocess/
+
+#tenderly config 
+tenderly.yaml

--- a/plasma_framework/docs/design/payment-game-implementation-v1.md
+++ b/plasma_framework/docs/design/payment-game-implementation-v1.md
@@ -26,15 +26,15 @@ struct Output {
 
 `Transaction` is the top level structure and it has the following fields:
 1. `txType` is a unique number that represents the type of transaction. Each transaction type has only one exit game contract associated with it. 
-1. The `inputs` field is an array of `bytes32` representing the `utxoPos` as the output identifier. There are a maximum four inputs allowed. An input can not be zero if it is specified. 
+1. The `inputs` field is an array of `bytes32` representing the `utxoPos` as the output identifier. There are a maximum four inputs allowed. An input can not be `0x0` if it is specified `inputs` list. 
 1. The `outputs` field is an array of `Output` struct representing payment output information. There are a maximum of four outputs allowed. 
 1. `metaData` field is a `bytes32` field that can be used to add extra data to the transaction. It should contain `0x0` if the transaction does not have extra data.
 
 Output has four elements that fulfil the current `WireTransactionOutput`:
-1. `outputType` represents the type of output. Each new valid transaction type is tied to one or more new output types. In Payment transaction V1, there is only one output type. The output type is used to decide, eg. which spending condition to use. Also, output type is bound to the input type. Currently the only output type requires the spending tx's input to be using `utxoPos`. Potentially there can be output type deciding to be pointed by `outputId` instead in the future.
+1. `outputType` represents the type of output. Each transaction type is tied to one or more output types. In Payment transaction V1, there is only one output type. The output type is used to decide, eg. which spending condition to use. Also, output type is bound to the input type. Currently the only output type that requires the spending tx's input to be using `utxoPos`. Potentially there can be output type deciding to be pointed by `outputId` instead in the future.
 1. `outputGuard` is the field that represents the authentication data of the output. Its value must always be the same as the `owner` address of the output in the first version of Payment Transaction. For instance, if the output belongs to Alice, then the value of `outputGuard` equals Alice's address.
 1. `token` is the ERC20 token contract address that represents the transferred asset. For `ETH`, it uses `address(0)`.
-1. `amount` defined how many units of the asset are being transferred.
+1. `amount` defines how many units of the asset are being transferred.
 
 A `Transaction` can be further grouped into two different sub categories. They both fit into the above specification of a `Transaction` but they are both unique in how many inputs and outputs they allow and how they are processed by the different components in the Plasma Framework system. 
 

--- a/plasma_framework/docs/design/tx-types-dependencies.md
+++ b/plasma_framework/docs/design/tx-types-dependencies.md
@@ -1,33 +1,33 @@
 # Tx Types dependencies
 
-In an ideal word, whenever we want to expend the features to the Plasma Framework, we just need to add and register a new the Exit Game contract. However, in practice, this is not as trivial since there are some dependencies across tx types and output types due to the M(ore)VP protocol design, especially for in-flight exit protocol.
+In an ideal world, whenever we want to expand the features of the Plasma Framework, we just need to add and register a new the Exit Game contract. However, in practice, this is not as trivial since there are some dependencies across tx types and output types due to the M(ore)VP protocol design, especially for the in-flight exit protocol.
 
-In the in-flight exit game, we have two kinds of challenges (challenge piggyback input already spend + challenge non canonical) that would be challenging around the input of the in-flight tx. This brings all dependency of inputs' tx types to the current tx type as well. For instance, if an input tx type 1 has multiple dependencies (tx type 2, 3, 4) that can spend it. And our current tx type 2 can only be spend by tx type 5. However, the Exit Game contract of tx type 2 would still need to know how a tx-type-1 tx can be spend in tx type 3 and 4 too.
+In the in-flight exit game, there are two kinds of challenges (challenge piggyback input already spent + challenge non canonical) that are challenging the input of an in-flight tx. This increases the dependencies of input tx types of the current tx type further. For instance, if an input tx type 1 has multiple dependencies (tx type 2, 3, 4) that can spend it. And our current tx type 2 can only be spend by tx type 5. However, the Exit Game contract of tx type 2 would still need to know how a tx-type-1 tx can be spend in tx type 3 and 4 too.
 
-In conclusion, one tx type would not only have dependencies on how the tx type can be spend, but also how the input can be spend.
+In conclusion, one tx type does not only have dependencies on how the tx type can be spent, but also how the input can be spent.
 
 ![Transaction dependencies](./images/transaction_dependencies.jpg)
 
 ## Code design to keep things flexible with the tx type dependencies
 
-We have two designs to keep us in a more flexible situation when we want to do an extension. We have the concept of `SpendingConditionRegistry` and `WireTransaction` to abstract things out.
+There are concepts that keeps the system more flexible in situation when there is a need to add an extension. The `SpendingConditionRegistry` and `WireTransaction` are ways to abstract things further.
 
 ### Spending Condition Registry
 
 Original discussion: https://github.com/omisego/plasma-contracts/issues/214
 
-This is a registry contract that we can describe the required dependencies graph of the spending condition. It is designed to use `(outputType, spendingTxType)` as key to describe how an output type can be spend in a spending transaction type. `outputType` is chosen since there can be multiple `outputType` of a `txType`. However, to keep things simple, we assumes **all new tx type would provide new output types**. So there would be no single output type being used in two tx types.
+This is a registry contract that we can describe the required dependencies graph of the spending condition. It is designed to use `(outputType, spendingTxType)` as key to describe how an output type can be spent in a spending transaction type. `outputType` is chosen since there can be multiple `outputType` of a `txType`. However, to keep things simple, it is assumed  that **all new tx types provide new output types**. So there is no single output type being used in two different tx types.
 
-Following is an example of how spending condition registry would be representing the tx types dependency graph. The example here uses the the idea of [restricted custody DEX design](https://github.com/omisego/docs/blob/master/docs/restricted_custody_mvp1_spec.md). However, it is not limited to that, just using that as an example:
+The following figure is an example of how a spending condition registry is representing the tx types dependency graph. The example here uses the the idea of [restricted custody DEX design](https://github.com/omisego/docs/blob/master/docs/restricted_custody_mvp1_spec.md). However, it is not limited to that, it merely used as an example:
 
 
 ![Spending condition registry graph](./images/spending-condition-registry-graph.jpg)
 
-As you can see, the spending condition would need to take the input tx type into consideration as well. So a spending condition registry of `Payment Tx V2` would still need to register the path for `Payment Tx V1`. Same for V3, it would need all paths related to `O2`.
+As you can see, the spending condition needs to take the input tx type into consideration as well. So a spending condition registry of `Payment Tx V2` still needs to register the path for `Payment Tx V1`. Same for V3, it requires all paths related to `O2` to be defined.
 
 ### Wire Transaction Format
 
-Aside from the dependency of the path that a tx type can be spend, there is also data structure dependency. To be able to process a tx, one would need to decode the transaction and thus need to know what are the fields of the transactions.
+Aside from the dependency of the path that a tx type can be spent, there are also data structure dependency. In order to be able to process a tx, it is necessary to decode the transaction first and thus the structure of the transaction need to be well defined.
 
 #### Transaction Format
 
@@ -38,13 +38,14 @@ Aside from the dependency of the path that a tx type can be spend, there is also
     outputs: [struct],
 }
 ```
-A Wire transaction would have the first field be as the `txType`. It is a `uint256` representing the type of the transaction.
 
-The second field would be a list of `bytes32`. It is holding the information of `inputs` that would be pointing to an `output`.
+A `WireTransaction` has as its first field a numerical `txType` identifier. It is a `uint256` representing the type of the transaction.
 
-The third field would be a list of `struct` that would be representing an `output`. Fields for output would be further described later.
+The second field `inputs` is a list of pointers that link to other outputs in previous txs that are spent in current tx.  It is `bytes32` that maps to the block, tx index and output index that is referenced. 
 
-The transaction can have more fields than the three described above. Just the first three fields should follow this format.
+The third field `outputs` is a list of `Output` structs that are further described in the below paragraph. 
+
+A transaction can have more fields than the three described above. Just the first three fields should follow this format.
 
 #### Output Format
 
@@ -62,7 +63,7 @@ The first field of the output is a `uint256` that holds the info of `outputType`
 #### Current Payment Exit Game Implementation
 Current implementation of Payment Exit Game assumes all transactions of inputs and outputs would follow the format. Under this assumption and restriction, one can add new tx types as input or output to current Payment Exit Game implementation without the need to re-write it.
 
-We actually realize that current format of `WireTransaction` has some limitation on adding feature. For example, if we want to add non fungible token support (ERC721 tokens), this data structure would be looking awkward to hold the information. Luckily, it is possible for us to change the format with new Exit Game implementation design. However, it would mean an extra round of implementation and code audit.
+We actually realize that current format of `WireTransaction` has some limitation on adding feature. For example, if we want to add non fungible token support (ERC721 tokens), this data structure would be looking awkward to hold the information. Luckily, it is possible for us to change the format with new a Exit Game implementation design. However, it would mean an extra round of implementation and code audit.
 
 Previous discussions:
 - https://github.com/omisego/plasma-contracts/issues/236#issuecomment-546798910

--- a/plasma_framework/docs/design/tx-types-dependencies.md
+++ b/plasma_framework/docs/design/tx-types-dependencies.md
@@ -2,7 +2,7 @@
 
 In an ideal world, whenever we want to expand the features of the Plasma Framework, we just need to add and register a new the Exit Game contract. However, in practice, this is not as trivial since there are some dependencies across tx types and output types due to the M(ore)VP protocol design, especially for the in-flight exit protocol.
 
-In the in-flight exit game, there are two kinds of challenges (challenge piggyback input already spent + challenge non canonical) that are challenging the input of an in-flight tx. This increases the dependencies of input tx types of the current tx type further. For instance, if an input tx type 1 has multiple dependencies (tx type 2, 3, 4) that can spend it. And our current tx type 2 can only be spend by tx type 5. However, the Exit Game contract of tx type 2 would still need to know how a tx-type-1 tx can be spend in tx type 3 and 4 too.
+In the in-flight exit game, there are two kinds of challenges (challenge piggyback input already spent + challenge non canonical) that are challenging the input of an in-flight tx. This increases the dependencies of input tx types of the current tx type further. For instance, if an input tx type 1 has multiple dependencies (tx type 2, 3, 4) that can spend it. And our current tx type 2 can only be spent by tx type 5. However, the Exit Game contract of tx type 2 would still need to know how a tx type 1 tx can be spent in tx type 3 and 4 too.
 
 In conclusion, one tx type does not only have dependencies on how the tx type can be spent, but also how the input can be spent.
 
@@ -10,7 +10,7 @@ In conclusion, one tx type does not only have dependencies on how the tx type ca
 
 ## Code design to keep things flexible with the tx type dependencies
 
-There are concepts that keeps the system more flexible in situation when there is a need to add an extension. The `SpendingConditionRegistry` and `WireTransaction` are ways to abstract things further.
+There are concepts that keep the system more flexible in situation when there is a need to add an extension. The `SpendingConditionRegistry` and `WireTransaction` are ways to abstract things further.
 
 ### Spending Condition Registry
 

--- a/plasma_framework/tenderly.yaml
+++ b/plasma_framework/tenderly.yaml
@@ -1,2 +1,0 @@
-account_id: 1171f09b-c532-452c-b473-e58742e28ce6
-project_slug: audit-1c7cd86-rinkeby

--- a/plasma_framework/tenderly.yaml
+++ b/plasma_framework/tenderly.yaml
@@ -1,0 +1,2 @@
+account_id: 1171f09b-c532-452c-b473-e58742e28ce6
+project_slug: audit-1c7cd86-rinkeby


### PR DESCRIPTION
Fix grammar and typos for the most part while reading the docs and trying to understand output and tx type:


**A question**:

Paragraph here: https://github.com/omisego/plasma-contracts/blob/cbe34d117a74772f6bf1d8798d47515c105a3e47/plasma_framework/docs/design/payment-game-implementation-v1.md#L34

* Am not sure about this statement -> `Also, output type is bound to the input type`. Could we give more information here?
* Totally don't know what that mean? `Currently the only output type that requires the spending tx's input to be using `utxoPos`. Potentially there can be output type deciding to be pointed by `outputId` instead in the future.`

**Generally**
It's hard to grasp all the scenarios of how tx types out put types are allowed to be used within the system. It be helpful to give some concrete examples with the specific flows (deposit, transact, exit) on where output and tx types are used to execute custom logic.

Also it be good to describe on what properties an output and tx type define in the system.

 CC @boolafish 

