### PR TITLE
Fix python tests make instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Run truffle, passing in the network e.g.
 
 
 ### Building and running the python tests
+All the code is in the `plasma_framework/python_tests` directory, so go there first.
 
 Installing dependencies needed for compilation:
 ```

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Run truffle, passing in the network e.g.
 
 
 ### Building and running the python tests
+We suggest running the following commands with an active python virtual environment ex. `venv`.
 All the code is in the `plasma_framework/python_tests` directory, so go there first.
 
 Installing dependencies needed for compilation:


### PR DESCRIPTION
Fix running python tests `make` instructions in README file. 

Closes #485