### PR TITLE
feat: save IFE output owner when startIFE instead

### DIFF
--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentPiggybackInFlightExit.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentPiggybackInFlightExit.sol
@@ -88,7 +88,6 @@ library PaymentPiggybackInFlightExit {
 
         PaymentExitDataModel.WithdrawData storage withdrawData = exit.inputs[args.inputIndex];
 
-        // In startInFlightExit, exitTarget for inputs are saved as this data is required to create the transaction
         require(withdrawData.exitTarget == msg.sender, "Can be called only by the exit target");
         withdrawData.piggybackBondSize = msg.value;
 
@@ -126,20 +125,12 @@ library PaymentPiggybackInFlightExit {
 
         PaymentExitDataModel.WithdrawData storage withdrawData = exit.outputs[args.outputIndex];
 
-        // TODO: move this to start IFE, as we are removing the mechanism of using output guard preimage.
-        // For inputs, exit target is set during start inFlight exit.
-        // For outputs, since output preimage data is held by the output owners, these must be retrieved on piggyback.
-        PaymentOutputModel.Output memory output = PaymentTransactionModel.decode(args.inFlightTx).outputs[args.outputIndex];
-        address payable exitTarget = output.owner();
-        require(exitTarget == msg.sender, "Can be called only by the exit target");
+        require(withdrawData.exitTarget == msg.sender, "Can be called only by the exit target");
+        withdrawData.piggybackBondSize = msg.value;
 
         if (isFirstPiggybackOfTheToken(exit, withdrawData.token)) {
             enqueue(self, withdrawData.token, UtxoPosLib.UtxoPos(exit.position), exitId);
         }
-
-        // Exit target for outputs is set in piggyback instead of start in-flight exit
-        withdrawData.exitTarget = exitTarget;
-        withdrawData.piggybackBondSize = msg.value;
 
         exit.setOutputPiggybacked(args.outputIndex);
 

--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentStartInFlightExit.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentStartInFlightExit.sol
@@ -315,7 +315,7 @@ library PaymentStartInFlightExit {
             PaymentOutputModel.Output memory output = exitData.inFlightTx.outputs[i];
 
             ife.outputs[i].outputId = outputId;
-            // Exit target is not set as output guard preimage may not be available for caller
+            ife.outputs[i].exitTarget = address(uint160(output.outputGuard));
             ife.outputs[i].token = output.token;
             ife.outputs[i].amount = output.amount;
         }

--- a/plasma_framework/test/src/exits/payment/controllers/PaymentPiggybackInFlightExitOnOutput.test.js
+++ b/plasma_framework/test/src/exits/payment/controllers/PaymentPiggybackInFlightExitOnOutput.test.js
@@ -131,13 +131,13 @@ contract('PaymentPiggybackInFlightExitOnOutput', ([_, alice, inputOwner, outputO
                 }, emptyWithdrawData, emptyWithdrawData, emptyWithdrawData],
                 outputs: [{
                     outputId: web3.utils.sha3('dummy output id'),
-                    exitTarget: constants.ZERO_ADDRESS, // would not be set during start IFE
+                    exitTarget: outputOwner,
                     token: ETH,
                     amount: outputAmount1,
                     piggybackBondSize: 0,
                 }, {
                     outputId: web3.utils.sha3('dummy output id'),
-                    exitTarget: constants.ZERO_ADDRESS, // would not be set during start IFE
+                    exitTarget: outputOwner,
                     token: ETH,
                     amount: outputAmount2,
                     piggybackBondSize: 0,

--- a/plasma_framework/test/src/exits/payment/controllers/PaymentStartInFlightExit.test.js
+++ b/plasma_framework/test/src/exits/payment/controllers/PaymentStartInFlightExit.test.js
@@ -16,7 +16,7 @@ const SpyEthVault = artifacts.require('SpyEthVaultForExitGame');
 const SpyErc20Vault = artifacts.require('SpyErc20VaultForExitGame');
 
 const {
-    BN, constants, expectEvent, expectRevert, time,
+    BN, expectEvent, expectRevert, time,
 } = require('openzeppelin-test-helpers');
 const { expect } = require('chai');
 
@@ -218,7 +218,7 @@ contract('PaymentStartInFlightExit', ([_, alice, richFather, carol]) => {
                 expectWithdrawData(
                     output,
                     expectedOutputId,
-                    constants.ZERO_ADDRESS, // exit target for outputs is not stored when starting ife
+                    this.argsDecoded.inFlightTx.outputs[0].outputGuard,
                     this.argsDecoded.inFlightTx.outputs[0].amount,
                     this.argsDecoded.inFlightTx.outputs[0].token,
                 );


### PR DESCRIPTION
### Note
PaymentExitGame was implemented to be able to support our restricted custody DEX design. As a result, the output guard preimage for an in-flight exit tx output might not be availible. Without the preimage, it was not possible to know the where this output is exiting fund to.

However, we have decided to reduce the scope of Payment Exit Game and remove the DEX supporting feature such as output guard mechanism to simplify the code base for initial launch. Given this, it becomes not necessary to save output owner (exitTarget) data in piggyback. It can be done in startIFE.

### Discussion
Do you think this change makes sense? @pgebal @kevsul @pik694 

It simplifies the code base and be more consistent. However, whenever we are introducing DEX supporting PaymentExitGame we would need to remember to bring this change back.