### PR TITLE
fix: fix bug in getting spending condition for ife output and input challenge

### DIFF
--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentChallengeIFEInputSpent.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentChallengeIFEInputSpent.sol
@@ -132,7 +132,9 @@ library PaymentChallengeIFEInputSpent {
 
     function verifySpendingCondition(ChallengeIFEData memory data) private view {
         GenericTransaction.Transaction memory challengingTx = GenericTransaction.decode(data.args.challengingTx);
-        GenericTransaction.Output memory output = GenericTransaction.getOutput(challengingTx, data.args.challengingTxInputIndex);
+
+        GenericTransaction.Transaction memory inputTx = GenericTransaction.decode(data.args.inputTx);
+        GenericTransaction.Output memory output = GenericTransaction.getOutput(inputTx, data.args.challengingTxInputIndex);
 
         ISpendingCondition condition = data.controller.spendingConditionRegistry.spendingConditions(
             output.outputType, challengingTx.txType

--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentChallengeIFEOutputSpent.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentChallengeIFEOutputSpent.sol
@@ -112,10 +112,12 @@ library PaymentChallengeIFEOutputSpent {
     {
         PosLib.Position memory utxoPos = PosLib.decode(args.outputUtxoPos);
         GenericTransaction.Transaction memory challengingTx = GenericTransaction.decode(args.challengingTx);
-        GenericTransaction.Output memory output = GenericTransaction.getOutput(challengingTx, utxoPos.outputIndex);
+
+        GenericTransaction.Transaction memory ifeTx = GenericTransaction.decode(args.inFlightTx);
+        GenericTransaction.Output memory ifeTxOutput = GenericTransaction.getOutput(ifeTx, utxoPos.outputIndex);
 
         ISpendingCondition condition = controller.spendingConditionRegistry.spendingConditions(
-            output.outputType,
+            ifeTxOutput.outputType,
             challengingTx.txType
         );
         require(address(condition) != address(0), "Spending condition contract not found");

--- a/plasma_framework/test/src/exits/payment/controllers/PaymentChallengeIFEInputSpent.test.js
+++ b/plasma_framework/test/src/exits/payment/controllers/PaymentChallengeIFEInputSpent.test.js
@@ -37,6 +37,7 @@ contract('PaymentChallengeIFEInputSpent', ([_, alice, inputOwner, outputOwner, c
     const ETH = constants.ZERO_ADDRESS;
     const INPUT_TX_AMOUNT = 123456;
     const BLOCK_NUMBER = 5000;
+    const OUTPUT_TYPE_INPUT_TX = 3;
 
     before('deploy and link with controller lib', async () => {
         const startInFlightExit = await PaymentStartInFlightExit.new();
@@ -71,7 +72,8 @@ contract('PaymentChallengeIFEInputSpent', ([_, alice, inputOwner, outputOwner, c
                     buildUtxoPos(BLOCK_NUMBER - CHILD_BLOCK_INTERVAL, 4, 3),
                     buildUtxoPos(BLOCK_NUMBER - CHILD_BLOCK_INTERVAL, 10, 2),
                 ],
-                OUTPUT_TYPE.PAYMENT,
+                // different output type for an input tx to check if proper spending codition is used
+                OUTPUT_TYPE_INPUT_TX,
                 inputOwner,
                 INPUT_TX_AMOUNT,
             );
@@ -174,7 +176,7 @@ contract('PaymentChallengeIFEInputSpent', ([_, alice, inputOwner, outputOwner, c
             // lets the spending condition pass by default
             await this.spendingCondition.mockResult(true);
             await this.spendingConditionRegistry.registerSpendingCondition(
-                OUTPUT_TYPE.PAYMENT, TX_TYPE.PAYMENT, this.spendingCondition.address,
+                OUTPUT_TYPE_INPUT_TX, TX_TYPE.PAYMENT, this.spendingCondition.address,
             );
 
             const exitGameArgs = [

--- a/plasma_framework/test/src/exits/payment/controllers/PaymentChallengeIFEOutputSpent.test.js
+++ b/plasma_framework/test/src/exits/payment/controllers/PaymentChallengeIFEOutputSpent.test.js
@@ -35,6 +35,7 @@ contract('PaymentChallengeIFEOutputSpent', ([_, alice, bob]) => {
     const DUMMY_INITIAL_IMMUNE_VAULTS_NUM = 0;
     const INITIAL_IMMUNE_EXIT_GAME_NUM = 1;
     const OUTPUT_TYPE_ONE = 1;
+    const OUTPUT_TYPE_CHALLENGING_TX = 2;
     const IFE_TX_TYPE = 1;
     const OTHER_TX_TYPE = 2;
     const ETH = constants.ZERO_ADDRESS;
@@ -86,7 +87,8 @@ contract('PaymentChallengeIFEOutputSpent', ([_, alice, bob]) => {
             const inclusionProof = merkleTree.getInclusionProof(inFlightTxBytes);
 
             const outputId = computeNormalOutputId(inFlightTxBytes, 0);
-            const challengingTxOutput = new PaymentTransactionOutput(OUTPUT_TYPE_ONE, AMOUNT, alice, ETH);
+            // different output type for a challenging tx to check if proper spending codition is used
+            const challengingTxOutput = new PaymentTransactionOutput(OUTPUT_TYPE_CHALLENGING_TX, AMOUNT, alice, ETH);
             const challengingTx = new PaymentTransaction(IFE_TX_TYPE, [outputId], [challengingTxOutput]);
             const challengingTxBytes = web3.utils.bytesToHex(challengingTx.rlpEncoded());
 


### PR DESCRIPTION
Closes #522
changes:
* Use proper spending condition when challenging in-flight tx output exit
* Use proper spending condition when challenging in-flight tx input exit