### PR TITLE
fix: implement additional checks

### DIFF
--- a/plasma_framework/contracts/mocks/transactions/PaymentTransactionModelMock.sol
+++ b/plasma_framework/contracts/mocks/transactions/PaymentTransactionModelMock.sol
@@ -19,4 +19,9 @@ contract PaymentTransactionModelMock {
         });
         return PaymentTransactionModel.getOutputOwner(output);
     }
+
+    function getOutput(bytes memory transaction, uint16 outputIndex) public pure returns (FungibleTokenOutputModel.Output memory) {
+        PaymentTransactionModel.Transaction memory decodedTx = PaymentTransactionModel.decode(transaction);
+        return PaymentTransactionModel.getOutput(decodedTx, outputIndex);
+    }
 }

--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentChallengeIFENotCanonical.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentChallengeIFENotCanonical.sol
@@ -76,6 +76,7 @@ library PaymentChallengeIFENotCanonical {
     {
         uint160 exitId = ExitId.getInFlightExitId(args.inFlightTx);
         PaymentExitDataModel.InFlightExit storage ife = inFlightExitMap.exits[exitId];
+        require(args.inFlightTxInputIndex < ife.inputs.length, "Input index out of bounds");
         require(ife.exitStartTimestamp != 0, "In-flight exit does not exist");
 
         require(ife.isInFirstPhase(self.framework.minExitPeriod()),
@@ -154,6 +155,7 @@ library PaymentChallengeIFENotCanonical {
         uint160 exitId = ExitId.getInFlightExitId(inFlightTx);
         PaymentExitDataModel.InFlightExit storage ife = inFlightExitMap.exits[exitId];
         require(ife.exitStartTimestamp != 0, "In-flight exit does not exist");
+        require(inFlightTxPos > 0, "In-flight transaction position must not be 0");
 
         require(
             ife.oldestCompetitorPosition > inFlightTxPos,

--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentChallengeStandardExit.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentChallengeStandardExit.sol
@@ -18,6 +18,7 @@ import "../../../transactions/GenericTransaction.sol";
 
 library PaymentChallengeStandardExit {
     using PosLib for PosLib.Position;
+    using PaymentTransactionModel for PaymentTransactionModel.Transaction;
 
     struct Controller {
         PlasmaFramework framework;
@@ -109,7 +110,7 @@ library PaymentChallengeStandardExit {
         PosLib.Position memory utxoPos = PosLib.decode(data.exitData.utxoPos);
         FungibleTokenOutputModel.Output memory output = PaymentTransactionModel
             .decode(args.exitingTx)
-            .outputs[utxoPos.outputIndex];
+            .getOutput(utxoPos.outputIndex);
 
         ISpendingCondition condition = data.controller.spendingConditionRegistry.spendingConditions(
             output.outputType, data.challengeTxType

--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentStartInFlightExit.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentStartInFlightExit.sol
@@ -21,6 +21,7 @@ library PaymentStartInFlightExit {
     using ExitableTimestamp for ExitableTimestamp.Calculator;
     using PosLib for PosLib.Position;
     using PaymentInFlightExitModelUtils for PaymentExitDataModel.InFlightExit;
+    using PaymentTransactionModel for PaymentTransactionModel.Transaction;
 
     /**
      * @dev supportedTxType enables code reuse in different Payment Tx versions
@@ -187,6 +188,7 @@ library PaymentStartInFlightExit {
     }
 
     function verifyNumberOfInputsMatchesNumberOfInFlightTransactionInputs(StartExitData memory exitData) private pure {
+        require(exitData.inputTxs.length != 0, "In-flight transaction must have inputs");
         require(
             exitData.inputTxs.length == exitData.inFlightTx.inputs.length,
             "Number of input transactions does not match number of in-flight transaction inputs"
@@ -313,10 +315,10 @@ library PaymentStartInFlightExit {
     )
         private
     {
-        for (uint i = 0; i < exitData.inFlightTx.outputs.length; i++) {
+        for (uint16 i = 0; i < exitData.inFlightTx.outputs.length; i++) {
             // deposit transaction can't be in-flight exited
             bytes32 outputId = OutputId.computeNormalOutputId(exitData.inFlightTxRaw, i);
-            FungibleTokenOutputModel.Output memory output = exitData.inFlightTx.outputs[i];
+            FungibleTokenOutputModel.Output memory output = exitData.inFlightTx.getOutput(i);
 
             ife.outputs[i].outputId = outputId;
             ife.outputs[i].exitTarget = address(uint160(output.outputGuard));

--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentStartStandardExit.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentStartStandardExit.sol
@@ -15,6 +15,7 @@ import "../../utils/ExitableTimestamp.sol";
 library PaymentStartStandardExit {
     using ExitableTimestamp for ExitableTimestamp.Calculator;
     using PosLib for PosLib.Position;
+    using PaymentTransactionModel for PaymentTransactionModel.Transaction;
 
     struct Controller {
         IExitProcessor exitProcessor;
@@ -102,7 +103,7 @@ library PaymentStartStandardExit {
     {
         PosLib.Position memory utxoPos = PosLib.decode(args.utxoPos);
         PaymentTransactionModel.Transaction memory outputTx = PaymentTransactionModel.decode(args.rlpOutputTx);
-        FungibleTokenOutputModel.Output memory output = outputTx.outputs[utxoPos.outputIndex];
+        FungibleTokenOutputModel.Output memory output = outputTx.getOutput(utxoPos.outputIndex);
         bool isTxDeposit = controller.framework.isDeposit(utxoPos.blockNum);
         uint160 exitId = ExitId.getStandardExitId(isTxDeposit, args.rlpOutputTx, utxoPos);
         (, uint256 blockTimestamp) = controller.framework.blocks(utxoPos.blockNum);

--- a/plasma_framework/contracts/src/exits/payment/spendingConditions/PaymentOutputToPaymentTxCondition.sol
+++ b/plasma_framework/contracts/src/exits/payment/spendingConditions/PaymentOutputToPaymentTxCondition.sol
@@ -10,6 +10,7 @@ import "../../../transactions/eip712Libs/PaymentEip712Lib.sol";
 contract PaymentOutputToPaymentTxCondition is ISpendingCondition {
     using PaymentEip712Lib for PaymentEip712Lib.Constants;
     using PosLib for PosLib.Position;
+    using PaymentTransactionModel for PaymentTransactionModel.Transaction;
 
     uint256 internal supportInputTxType;
     uint256 internal supportSpendingTxType;
@@ -56,7 +57,7 @@ contract PaymentOutputToPaymentTxCondition is ISpendingCondition {
         );
 
         PosLib.Position memory decodedUtxoPos = PosLib.decode(utxoPos);
-        address owner = PaymentTransactionModel.getOutputOwner(inputTx.outputs[decodedUtxoPos.outputIndex]);
+        address owner = PaymentTransactionModel.getOutputOwner(inputTx.getOutput(decodedUtxoPos.outputIndex));
         address signer = ECDSA.recover(eip712.hashTx(spendingTx), signature);
         require(signer != address(0), "Failed to recover the signer from the signature");
         require(owner == signer, "Tx is not signed correctly");

--- a/plasma_framework/contracts/src/transactions/PaymentTransactionModel.sol
+++ b/plasma_framework/contracts/src/transactions/PaymentTransactionModel.sol
@@ -98,4 +98,13 @@ library PaymentTransactionModel {
     function getOutputOwner(FungibleTokenOutputModel.Output memory output) internal pure returns (address payable) {
         return address(uint160(output.outputGuard));
     }
+
+    /**
+     * @notice Gets output at provided index
+     *
+     */
+    function getOutput(Transaction memory transaction, uint16 outputIndex) internal pure returns (FungibleTokenOutputModel.Output memory) {
+        require(outputIndex < transaction.outputs.length, "Output index out of bounds");
+        return transaction.outputs[outputIndex];
+    }
 }

--- a/plasma_framework/docs/contracts/PaymentTransactionModel.md
+++ b/plasma_framework/docs/contracts/PaymentTransactionModel.md
@@ -36,6 +36,7 @@ uint8 private constant ENCODED_LENGTH;
 - [decode(bytes _tx)](#decode)
 - [fromGeneric(struct GenericTransaction.Transaction genericTx)](#fromgeneric)
 - [getOutputOwner(struct FungibleTokenOutputModel.Output output)](#getoutputowner)
+- [getOutput(struct PaymentTransactionModel.Transaction transaction, uint16 outputIndex)](#getoutput)
 
 ### MAX_INPUT_NUM
 
@@ -124,6 +125,22 @@ returns(address payable)
 | Name        | Type           | Description  |
 | ------------- |------------- | -----|
 | output | struct FungibleTokenOutputModel.Output |  | 
+
+### getOutput
+
+Gets output at provided index
+
+```js
+function getOutput(struct PaymentTransactionModel.Transaction transaction, uint16 outputIndex) internal pure
+returns(struct FungibleTokenOutputModel.Output)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| transaction | struct PaymentTransactionModel.Transaction |  | 
+| outputIndex | uint16 |  | 
 
 ## Contracts
 

--- a/plasma_framework/test/src/exits/payment/controllers/PaymentStartInFlightExit.test.js
+++ b/plasma_framework/test/src/exits/payment/controllers/PaymentStartInFlightExit.test.js
@@ -31,7 +31,6 @@ const {
 } = require('../../../../helpers/ife.js');
 
 contract('PaymentStartInFlightExit', ([_, alice, richFather, carol]) => {
-    const CHILD_BLOCK_INTERVAL = 1000;
     const MIN_EXIT_PERIOD = 60 * 60 * 24 * 7; // 1 week in seconds
     const DUMMY_INITIAL_IMMUNE_VAULTS_NUM = 0;
     const INITIAL_IMMUNE_EXIT_GAME_NUM = 1;
@@ -605,7 +604,7 @@ contract('PaymentStartInFlightExit', ([_, alice, richFather, carol]) => {
 
                 await expectRevert(
                     this.exitGame.startInFlightExit(args, { from: alice, value: this.startIFEBondSize.toString() }),
-                    'Number of input transactions does not match number of in-flight transaction inputs',
+                    'In-flight transaction must have inputs.',
                 );
             });
 

--- a/plasma_framework/test/src/transactions/PaymentTransactionModel.test.js
+++ b/plasma_framework/test/src/transactions/PaymentTransactionModel.test.js
@@ -19,149 +19,179 @@ contract('PaymentTransactionModel', ([alice]) => {
         this.test = await PaymentTransactionModelMock.new();
     });
 
-    it('should decode payment transaction', async () => {
-        const transaction = new PaymentTransaction(TX_TYPE.PAYMENT, [DUMMY_INPUT_1], [OUTPUT, OUTPUT], EMPTY_BYTES_32);
-        const encoded = web3.utils.bytesToHex(transaction.rlpEncoded());
+    describe('decode', () => {
+        it('should decode payment transaction', async () => {
+            const transaction = new PaymentTransaction(
+                TX_TYPE.PAYMENT, [DUMMY_INPUT_1], [OUTPUT, OUTPUT], EMPTY_BYTES_32,
+            );
+            const encoded = web3.utils.bytesToHex(transaction.rlpEncoded());
 
-        const actual = await this.test.decode(encoded);
-        const decoded = new PaymentTransaction(
-            parseInt(actual.txType, 10),
-            parseInputs(actual.inputs),
-            parseOutputs(actual.outputs),
-            actual.metaData,
-        );
+            const actual = await this.test.decode(encoded);
+            const decoded = new PaymentTransaction(
+                parseInt(actual.txType, 10),
+                parseInputs(actual.inputs),
+                parseOutputs(actual.outputs),
+                actual.metaData,
+            );
 
-        expect(JSON.stringify(decoded)).to.equal(JSON.stringify(transaction));
+            expect(JSON.stringify(decoded)).to.equal(JSON.stringify(transaction));
+        });
+
+        it('should decode payment transaction with 4 inputs and 4 outputs', async () => {
+            const transaction = new PaymentTransaction(
+                TX_TYPE.PAYMENT,
+                [DUMMY_INPUT_1, DUMMY_INPUT_1, DUMMY_INPUT_1, DUMMY_INPUT_1],
+                [OUTPUT, OUTPUT, OUTPUT, OUTPUT],
+                EMPTY_BYTES_32,
+            );
+            const encoded = web3.utils.bytesToHex(transaction.rlpEncoded());
+
+            const actual = await this.test.decode(encoded);
+            const decoded = new PaymentTransaction(
+                parseInt(actual.txType, 10),
+                parseInputs(actual.inputs),
+                parseOutputs(actual.outputs),
+                actual.metaData,
+            );
+
+            expect(JSON.stringify(decoded)).to.equal(JSON.stringify(transaction));
+        });
+
+        it('should fail when decoding transaction have more inputs than MAX_INPUT limit', async () => {
+            const inputsExceedLimit = Array(MAX_INPUT_NUM + 1).fill(DUMMY_INPUT_1);
+            const transaction = new PaymentTransaction(TX_TYPE.PAYMENT, inputsExceedLimit, [], EMPTY_BYTES_32);
+            const encoded = web3.utils.bytesToHex(transaction.rlpEncoded());
+
+            await expectRevert(
+                this.test.decode(encoded),
+                'Transaction inputs num exceeds limit',
+            );
+        });
+
+        it('should fail when decoding transaction have more outputs than MAX_OUTPUT limit', async () => {
+            const outputsExceedLimit = Array(MAX_OUTPUT_NUM + 1).fill(OUTPUT);
+            const transaction = new PaymentTransaction(
+                TX_TYPE.PAYMENT, [DUMMY_INPUT_1], outputsExceedLimit, EMPTY_BYTES_32,
+            );
+            const encoded = web3.utils.bytesToHex(transaction.rlpEncoded());
+
+            await expectRevert(
+                this.test.decode(encoded),
+                'Transaction outputs num exceeds limit',
+            );
+        });
+
+        it('should fail when transaction does not contain metadata', async () => {
+            const transaction = new PaymentTransaction(
+                TX_TYPE.PAYMENT, [DUMMY_INPUT_1], [OUTPUT, OUTPUT], EMPTY_BYTES_32,
+            );
+
+            const genericFormat = [
+                transaction.transactionType,
+                transaction.inputs,
+                PaymentTransaction.formatOutputsForRlpEncoding(transaction.outputs),
+            ];
+
+            const encoded = web3.utils.bytesToHex(rlp.encode(genericFormat));
+
+            await expectRevert(
+                this.test.decode(encoded),
+                'Invalid encoding of transaction',
+            );
+        });
+
+        it('should fail when decoding invalid transaction', async () => {
+            const encoded = web3.utils.bytesToHex(rlp.encode([0, 0]));
+
+            await expectRevert(
+                this.test.decode(encoded),
+                'Invalid encoding of transaction',
+            );
+        });
+
+        it('should fail when the transaction contains a null input', async () => {
+            const transaction = new PaymentTransaction(
+                TX_TYPE.PAYMENT, [DUMMY_INPUT_1, EMPTY_BYTES_32], [OUTPUT, OUTPUT], EMPTY_BYTES_32,
+            );
+            const encoded = web3.utils.bytesToHex(transaction.rlpEncoded());
+            await expectRevert(this.test.decode(encoded), 'Null input not allowed');
+        });
+
+        it('should fail when the transaction type is zero', async () => {
+            const transaction = new PaymentTransaction(0, [DUMMY_INPUT_1], [OUTPUT], EMPTY_BYTES_32);
+            const encoded = web3.utils.bytesToHex(transaction.rlpEncoded());
+            await expectRevert(this.test.decode(encoded), 'Transaction type must not be 0');
+        });
+
+        it('should fail when an output type is zero', async () => {
+            const zeroOutputType = new FungibleTransactionOutput(0, 100, OUTPUT_GUARD, constants.ZERO_ADDRESS);
+            const transaction = new PaymentTransaction(
+                TX_TYPE.PAYMENT, [DUMMY_INPUT_1], [OUTPUT, zeroOutputType], EMPTY_BYTES_32,
+            );
+            const encoded = web3.utils.bytesToHex(transaction.rlpEncoded());
+            await expectRevert(this.test.decode(encoded), 'Output type must not be 0');
+        });
+
+        it('should fail when an output amount is zero', async () => {
+            const zeroOutputAmount = new FungibleTransactionOutput(
+                OUTPUT_TYPE.PAYMENT, 0, OUTPUT_GUARD, constants.ZERO_ADDRESS,
+            );
+            const transaction = new PaymentTransaction(
+                TX_TYPE.PAYMENT, [DUMMY_INPUT_1], [OUTPUT, zeroOutputAmount], EMPTY_BYTES_32,
+            );
+            const encoded = web3.utils.bytesToHex(transaction.rlpEncoded());
+            await expectRevert(this.test.decode(encoded), 'Output amount must not be 0');
+        });
+
+        it('should fail when txData is not zero', async () => {
+            const output = new FungibleTransactionOutput(
+                OUTPUT_TYPE.PAYMENT, 1, OUTPUT_GUARD, constants.ZERO_ADDRESS,
+            );
+            const encoded = rlp.encode([
+                TX_TYPE.PAYMENT, [], [output.formatForRlpEncoding()], 1, EMPTY_BYTES_32,
+            ]);
+
+            await expectRevert(this.test.decode(encoded), 'txData must be 0');
+        });
+
+        it('should fail when the transaction has no outputs', async () => {
+            const transaction = new PaymentTransaction(
+                TX_TYPE.PAYMENT, [DUMMY_INPUT_1], [], EMPTY_BYTES_32,
+            );
+            const encoded = web3.utils.bytesToHex(transaction.rlpEncoded());
+            await expectRevert(this.test.decode(encoded), 'Transaction cannot have 0 outputs');
+        });
     });
 
-    it('should decode payment transaction with 4 inputs and 4 outputs', async () => {
-        const transaction = new PaymentTransaction(
-            TX_TYPE.PAYMENT,
-            [DUMMY_INPUT_1, DUMMY_INPUT_1, DUMMY_INPUT_1, DUMMY_INPUT_1],
-            [OUTPUT, OUTPUT, OUTPUT, OUTPUT],
-            EMPTY_BYTES_32,
-        );
-        const encoded = web3.utils.bytesToHex(transaction.rlpEncoded());
-
-        const actual = await this.test.decode(encoded);
-        const decoded = new PaymentTransaction(
-            parseInt(actual.txType, 10),
-            parseInputs(actual.inputs),
-            parseOutputs(actual.outputs),
-            actual.metaData,
-        );
-
-        expect(JSON.stringify(decoded)).to.equal(JSON.stringify(transaction));
-    });
-
-    it('should fail when decoding transaction have more inputs than MAX_INPUT limit', async () => {
-        const inputsExceedLimit = Array(MAX_INPUT_NUM + 1).fill(DUMMY_INPUT_1);
-        const transaction = new PaymentTransaction(TX_TYPE.PAYMENT, inputsExceedLimit, [], EMPTY_BYTES_32);
-        const encoded = web3.utils.bytesToHex(transaction.rlpEncoded());
-
-        await expectRevert(
-            this.test.decode(encoded),
-            'Transaction inputs num exceeds limit',
-        );
-    });
-
-    it('should fail when decoding transaction have more outputs than MAX_OUTPUT limit', async () => {
-        const outputsExceedLimit = Array(MAX_OUTPUT_NUM + 1).fill(OUTPUT);
-        const transaction = new PaymentTransaction(
-            TX_TYPE.PAYMENT, [DUMMY_INPUT_1], outputsExceedLimit, EMPTY_BYTES_32,
-        );
-        const encoded = web3.utils.bytesToHex(transaction.rlpEncoded());
-
-        await expectRevert(
-            this.test.decode(encoded),
-            'Transaction outputs num exceeds limit',
-        );
-    });
-
-    it('should fail when transaction does not contain metadata', async () => {
-        const transaction = new PaymentTransaction(TX_TYPE.PAYMENT, [DUMMY_INPUT_1], [OUTPUT, OUTPUT], EMPTY_BYTES_32);
-
-        const genericFormat = [
-            transaction.transactionType,
-            transaction.inputs,
-            PaymentTransaction.formatOutputsForRlpEncoding(transaction.outputs),
-        ];
-
-        const encoded = web3.utils.bytesToHex(rlp.encode(genericFormat));
-
-        await expectRevert(
-            this.test.decode(encoded),
-            'Invalid encoding of transaction',
-        );
-    });
-
-    it('should fail when decoding invalid transaction', async () => {
-        const encoded = web3.utils.bytesToHex(rlp.encode([0, 0]));
-
-        await expectRevert(
-            this.test.decode(encoded),
-            'Invalid encoding of transaction',
-        );
-    });
-
-    it('should fail when the transaction contains a null input', async () => {
-        const transaction = new PaymentTransaction(
-            TX_TYPE.PAYMENT, [DUMMY_INPUT_1, EMPTY_BYTES_32], [OUTPUT, OUTPUT], EMPTY_BYTES_32,
-        );
-        const encoded = web3.utils.bytesToHex(transaction.rlpEncoded());
-        await expectRevert(this.test.decode(encoded), 'Null input not allowed');
-    });
-
-    it('should fail when the transaction type is zero', async () => {
-        const transaction = new PaymentTransaction(0, [DUMMY_INPUT_1], [OUTPUT], EMPTY_BYTES_32);
-        const encoded = web3.utils.bytesToHex(transaction.rlpEncoded());
-        await expectRevert(this.test.decode(encoded), 'Transaction type must not be 0');
-    });
-
-    it('should fail when an output type is zero', async () => {
-        const zeroOutputType = new FungibleTransactionOutput(0, 100, OUTPUT_GUARD, constants.ZERO_ADDRESS);
-        const transaction = new PaymentTransaction(
-            TX_TYPE.PAYMENT, [DUMMY_INPUT_1], [OUTPUT, zeroOutputType], EMPTY_BYTES_32,
-        );
-        const encoded = web3.utils.bytesToHex(transaction.rlpEncoded());
-        await expectRevert(this.test.decode(encoded), 'Output type must not be 0');
-    });
-
-    it('should fail when an output amount is zero', async () => {
-        const zeroOutputAmount = new FungibleTransactionOutput(
-            OUTPUT_TYPE.PAYMENT, 0, OUTPUT_GUARD, constants.ZERO_ADDRESS,
-        );
-        const transaction = new PaymentTransaction(
-            TX_TYPE.PAYMENT, [DUMMY_INPUT_1], [OUTPUT, zeroOutputAmount], EMPTY_BYTES_32,
-        );
-        const encoded = web3.utils.bytesToHex(transaction.rlpEncoded());
-        await expectRevert(this.test.decode(encoded), 'Output amount must not be 0');
-    });
-
-    it('should fail when txData is not zero', async () => {
-        const output = new FungibleTransactionOutput(
-            OUTPUT_TYPE.PAYMENT, 1, OUTPUT_GUARD, constants.ZERO_ADDRESS,
-        );
-        const encoded = rlp.encode([
-            TX_TYPE.PAYMENT, [], [output.formatForRlpEncoding()], 1, EMPTY_BYTES_32,
-        ]);
-
-        await expectRevert(this.test.decode(encoded), 'txData must be 0');
-    });
-
-    it('should fail when the transaction has no outputs', async () => {
-        const transaction = new PaymentTransaction(
-            TX_TYPE.PAYMENT, [DUMMY_INPUT_1], [], EMPTY_BYTES_32,
-        );
-        const encoded = web3.utils.bytesToHex(transaction.rlpEncoded());
-        await expectRevert(this.test.decode(encoded), 'Transaction cannot have 0 outputs');
-    });
-
-    describe('owner', () => {
+    describe('getOutputOwner', () => {
         it('should parse the owner address from output guard when output guard holds the owner info directly', async () => {
             expect(await this.test.getOutputOwner(
                 OUTPUT_TYPE.PAYMENT, alice, constants.ZERO_ADDRESS, 100,
             )).to.equal(alice);
+        });
+    });
+
+    describe('getOutput', () => {
+        before(async () => {
+            const transaction = new PaymentTransaction(
+                TX_TYPE.PAYMENT, [DUMMY_INPUT_1], [OUTPUT, OUTPUT], EMPTY_BYTES_32,
+            );
+            this.encodedTx = web3.utils.bytesToHex(transaction.rlpEncoded());
+        });
+
+        it('should get output', async () => {
+            const output = await this.test.getOutput(this.encodedTx, 1);
+            const actual = new FungibleTransactionOutput(
+                parseInt(output.outputType, 10), parseInt(output.amount, 10), output.outputGuard, output.token,
+            );
+            expect(JSON.stringify(actual)).to.equal(JSON.stringify(OUTPUT));
+        });
+
+        it('should fail when output index is out of bounds', async () => {
+            await expectRevert(
+                this.test.getOutput(this.encodedTx, 3),
+                'Output index out of bounds',
+            );
         });
     });
 });


### PR DESCRIPTION
Closes #463
* Adds `PaymentTransactionModel.getOutput`function that gets an output for a given `outputIndex` and validates if `outputIndex` is not out of bounds
* Verifies if provided transaction position of in-flight transaction is non-zero when responding to a canonicity challenge
* Verifies if provided input index is not bigger than number of in-flight transaction inputs when challenging transaction canonicity