### PR TITLE
fix: fix compilation warnings regarding function state mutability

### DIFF
--- a/plasma_framework/contracts/mocks/utils/RLPMockSecurity.sol
+++ b/plasma_framework/contracts/mocks/utils/RLPMockSecurity.sol
@@ -17,7 +17,7 @@ contract RLPMockSecurity {
         return bytes20(_data.toRlpItem().toAddress());
     }
 
-    function decodeUint(bytes memory _data) public returns (uint) {
+    function decodeUint(bytes memory _data) public pure returns (uint) {
         return _data.toRlpItem().toUint();
     }
 

--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentChallengeIFEInputSpent.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentChallengeIFEInputSpent.sol
@@ -51,7 +51,7 @@ library PaymentChallengeIFEInputSpent {
         uint256 safeGasStipend
     )
         public
-        view
+        pure
         returns (Controller memory)
     {
         return Controller({

--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentChallengeIFENotCanonical.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentChallengeIFENotCanonical.sol
@@ -50,7 +50,7 @@ library PaymentChallengeIFENotCanonical {
         uint256 supportedTxType
     )
         public
-        view
+        pure
         returns (Controller memory)
     {
         return Controller({

--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentChallengeStandardExit.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentChallengeStandardExit.sol
@@ -49,7 +49,7 @@ library PaymentChallengeStandardExit {
         uint256 safeGasStipend
     )
         public
-        view
+        pure
         returns (Controller memory)
     {
         return Controller({


### PR DESCRIPTION
Fixes
```
,/home/circleci/repo/plasma_framework/contracts/src/exits/payment/controllers/PaymentChallengeIFENotCanonical.sol:47:5: Warning: Function state mutability can be restricted to pure
    function buildController(
    ^ (Relevant source part starts here and spans across multiple lines).
,/home/circleci/repo/plasma_framework/contracts/src/exits/payment/controllers/PaymentChallengeIFEInputSpent.sol:48:5: Warning: Function state mutability can be restricted to pure
    function buildController(
    ^ (Relevant source part starts here and spans across multiple lines).
,/home/circleci/repo/plasma_framework/contracts/src/exits/payment/controllers/PaymentChallengeStandardExit.sol:47:5: Warning: Function state mutability can be restricted to pure
    function buildController(
    ^ (Relevant source part starts here and spans across multiple lines).
,/home/circleci/repo/plasma_framework/contracts/mocks/utils/RLPMockSecurity.sol:20:5: Warning: Function state mutability can be restricted to pure
    function decodeUint(bytes memory _data) public returns (uint) {
    ^ (Relevant source part starts here and spans across multiple lines).
```