### PR TITLE
add stricter range check for audit feedback

### DIFF
--- a/plasma_framework/contracts/mocks/exits/SpyPlasmaFrameworkForExitGame.sol
+++ b/plasma_framework/contracts/mocks/exits/SpyPlasmaFrameworkForExitGame.sol
@@ -44,7 +44,7 @@ contract SpyPlasmaFrameworkForExitGame is PlasmaFramework {
             _vaultId,
             _token,
             _exitableAt,
-            _txPos.getTxPostionForExitPriority(),
+            _txPos.getTxPositionForExitPriority(),
             _exitId,
             address(_exitProcessor)
         );

--- a/plasma_framework/contracts/mocks/utils/PosLibWrapper.sol
+++ b/plasma_framework/contracts/mocks/utils/PosLibWrapper.sol
@@ -14,12 +14,12 @@ contract PosLibWrapper {
         return pos.toStrictTxPos();
     }
 
-    function getTxPostionForExitPriority(PosLib.Position memory pos)
+    function getTxPositionForExitPriority(PosLib.Position memory pos)
         public
         pure
         returns (uint256)
     {
-        return pos.getTxPostionForExitPriority();
+        return pos.getTxPositionForExitPriority();
     }
 
     function encode(PosLib.Position memory pos) public pure returns (uint256) {

--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentChallengeIFEInputSpent.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentChallengeIFEInputSpent.sol
@@ -141,11 +141,9 @@ library PaymentChallengeIFEInputSpent {
         );
         require(address(condition) != address(0), "Spending condition contract not found");
 
-        PosLib.Position memory inputUtxoPos = PosLib.decode(data.args.inputUtxoPos);
-
         bool isSpent = condition.verify(
             data.args.inputTx,
-            inputUtxoPos.encode(),
+            data.args.inputUtxoPos,
             data.args.challengingTx,
             data.args.challengingTxInputIndex,
             data.args.challengingTxWitness

--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentChallengeIFENotCanonical.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentChallengeIFENotCanonical.sol
@@ -185,7 +185,7 @@ library PaymentChallengeIFENotCanonical {
         private
         pure
     {
-        require(txPos.outputIndex == 0, "Should only pass in txPos with outputIndex equals to 0");
+        require(txPos.outputIndex == 0, "Output index of txPos has to be 0");
         require(
             Merkle.checkMembership(txbytes, txPos.txIndex, root, inclusionProof),
             "Transaction is not included in block of Plasma chain"

--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentChallengeIFENotCanonical.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentChallengeIFENotCanonical.sol
@@ -80,7 +80,7 @@ library PaymentChallengeIFENotCanonical {
         require(ife.exitStartTimestamp != 0, "In-flight exit does not exist");
 
         require(ife.isInFirstPhase(self.framework.minExitPeriod()),
-                "Canonicity challege phase for this exit has ended");
+                "Canonicity challenge phase for this exit has ended");
 
         require(
             keccak256(args.inFlightTx) != keccak256(args.competingTx),
@@ -110,7 +110,7 @@ library PaymentChallengeIFENotCanonical {
 
         bool isSpentByCompetingTx = condition.verify(
             args.inputTx,
-            inputUtxoPos.encode(),
+            args.inputUtxoPos,
             args.competingTx,
             args.competingTxInputIndex,
             args.competingTxWitness
@@ -118,7 +118,7 @@ library PaymentChallengeIFENotCanonical {
         require(isSpentByCompetingTx, "Competing input spending condition is not met");
 
         // Determine the position of the competing transaction
-        uint256 competitorPosition = verifyCompetingTxFinalized(self, args);
+        uint256 competitorPosition = verifyCompetingTxFinalizedInThePosition(self, args);
 
         require(
             ife.oldestCompetitorPosition == 0 || ife.oldestCompetitorPosition > competitorPosition,
@@ -161,39 +161,38 @@ library PaymentChallengeIFENotCanonical {
             ife.oldestCompetitorPosition > inFlightTxPos,
             "In-flight transaction must be older than competitors to respond to non-canonical challenge");
 
-        PosLib.Position memory utxoPos = PosLib.decode(inFlightTxPos);
-        (bytes32 root, ) = self.framework.blocks(utxoPos.blockNum);
-        require(root != bytes32(""), "Failed to get the block root hash of the UTXO position");
+        PosLib.Position memory txPos = PosLib.decode(inFlightTxPos);
+        (bytes32 root, ) = self.framework.blocks(txPos.blockNum);
+        require(root != bytes32(""), "Failed to get the block root hash of the tx position");
 
-        ife.oldestCompetitorPosition = verifyAndDeterminePositionOfTransactionIncludedInBlock(
-            inFlightTx, utxoPos, root, inFlightTxInclusionProof
+        verifyPositionOfTransactionIncludedInBlock(
+            inFlightTx, txPos, root, inFlightTxInclusionProof
         );
 
+        ife.oldestCompetitorPosition = inFlightTxPos;
         ife.isCanonical = true;
         ife.bondOwner = msg.sender;
 
         emit InFlightExitChallengeResponded(msg.sender, keccak256(inFlightTx), inFlightTxPos);
     }
 
-    function verifyAndDeterminePositionOfTransactionIncludedInBlock(
+    function verifyPositionOfTransactionIncludedInBlock(
         bytes memory txbytes,
-        PosLib.Position memory utxoPos,
+        PosLib.Position memory txPos,
         bytes32 root,
         bytes memory inclusionProof
     )
         private
         pure
-        returns (uint256)
     {
+        require(txPos.outputIndex == 0, "Should only pass in txPos with outputIndex equals to 0");
         require(
-            Merkle.checkMembership(txbytes, utxoPos.txIndex, root, inclusionProof),
+            Merkle.checkMembership(txbytes, txPos.txIndex, root, inclusionProof),
             "Transaction is not included in block of Plasma chain"
         );
-
-        return utxoPos.encode();
     }
 
-    function verifyCompetingTxFinalized(
+    function verifyCompetingTxFinalizedInThePosition(
         Controller memory self,
         PaymentInFlightExitRouterArgs.ChallengeCanonicityArgs memory args
     )
@@ -213,15 +212,17 @@ library PaymentChallengeIFENotCanonical {
             // Should fail already in early stages (eg. decode)
             assert(isProtocolFinalized);
         } else {
-            PosLib.Position memory competingTxUtxoPos = PosLib.decode(args.competingTxPos);
+            PosLib.Position memory competingTxPos = PosLib.decode(args.competingTxPos);
+            require(competingTxPos.outputIndex == 0, "OutputIndex of competingTxPos should be 0");
+
             bool isStandardFinalized = MoreVpFinalization.isStandardFinalized(
                 self.framework,
                 args.competingTx,
-                competingTxUtxoPos.toStrictTxPos(),
+                competingTxPos,
                 args.competingTxInclusionProof
             );
             require(isStandardFinalized, "Competing tx is not standard finalized with the given tx position");
-            competitorPosition = competingTxUtxoPos.encode();
+            competitorPosition = args.competingTxPos;
         }
         return competitorPosition;
     }

--- a/plasma_framework/contracts/src/exits/payment/routers/PaymentInFlightExitRouterArgs.sol
+++ b/plasma_framework/contracts/src/exits/payment/routers/PaymentInFlightExitRouterArgs.sol
@@ -45,7 +45,7 @@ library PaymentInFlightExitRouterArgs {
      * @param inFlightTxInputIndex Index of the shared input in the in-flight transaction
      * @param competingTx RLP-encoded competing transaction
      * @param competingTxInputIndex Index of shared input in competing transaction
-     * @param competingTxPos (Optional) Position of competing transaction in the chain, if included
+     * @param competingTxPos (Optional) Position of competing transaction in the chain, if included. OutputIndex of the position should be 0.
      * @param competingTxInclusionProof (Optional) Merkle proofs showing that the competing transaction was contained in chain
      * @param competingTxWitness Witness for competing transaction
      */

--- a/plasma_framework/contracts/src/exits/utils/MoreVpFinalization.sol
+++ b/plasma_framework/contracts/src/exits/utils/MoreVpFinalization.sol
@@ -36,10 +36,6 @@ library MoreVpFinalization {
         (bytes32 root,) = framework.blocks(txPos.blockNum);
         require(root != bytes32(""), "Failed to get the root hash of the block num");
 
-        if (inclusionProof.length == 0) {
-            return false;
-        }
-
         return Merkle.checkMembership(
             txBytes, txPos.txIndex, root, inclusionProof
         );

--- a/plasma_framework/contracts/src/framework/utils/ExitPriority.sol
+++ b/plasma_framework/contracts/src/framework/utils/ExitPriority.sol
@@ -15,7 +15,7 @@ library ExitPriority {
      * @return An exit priority
      *   Anatomy of returned value, most significant bits first
      *   42 bits  - timestamp in seconds (exitable_at); we can represent dates until year 141431
-     *   54 bits  - blknum * CHILD_BLOCK_INTERVAL * 10^5 + txindex; 54 bits represent all transactions for 85 years. We are assuming CHILD_BLOCK_INTERVAL = 1000.
+     *   54 bits  - blocknum * 10^5 + txindex; 54 bits represent all transactions for 85 years. Be aware that child chain block number jumps with the interval of CHILD_BLOCK_INTERVAL, which would be 1000 in production.
      *   160 bits - exit id
      */
     function computePriority(uint64 exitableAt, PosLib.Position memory txPos, uint160 exitId)

--- a/plasma_framework/contracts/src/framework/utils/ExitPriority.sol
+++ b/plasma_framework/contracts/src/framework/utils/ExitPriority.sol
@@ -23,7 +23,7 @@ library ExitPriority {
         pure
         returns (uint256)
     {
-        return (uint256(exitableAt) << 214) | (txPos.getTxPostionForExitPriority() << 160) | uint256(exitId);
+        return (uint256(exitableAt) << 214) | (txPos.getTxPositionForExitPriority() << 160) | uint256(exitId);
     }
 
     function parseExitableAt(uint256 priority) internal pure returns (uint64) {

--- a/plasma_framework/contracts/src/utils/Merkle.sol
+++ b/plasma_framework/contracts/src/utils/Merkle.sol
@@ -21,6 +21,7 @@ library Merkle {
         pure
         returns (bool)
     {
+        require(proof.length != 0, "Merkle proof must not be empty");
         require(proof.length % 32 == 0, "Length of Merkle proof must be a multiple of 32");
 
         bytes32 proofElement;

--- a/plasma_framework/contracts/src/utils/PosLib.sol
+++ b/plasma_framework/contracts/src/utils/PosLib.sol
@@ -17,7 +17,7 @@ library PosLib {
     uint256 constant internal TX_OFFSET = 10000;
     
     uint256 constant internal MAX_OUTPUT_INDEX = TX_OFFSET - 1;
-    // since we are using merkle tree of depth 16, max tx index size would be 2^16 - 1
+    // since we are using merkle tree of depth 16, max tx index size is 2^16 - 1
     uint256 constant internal MAX_TX_INDEX = 2 ** 16 - 1;
     // in ExitPriority, only 54 bits are reserved for both blockNum and txIndex
     uint256 constant internal MAX_BLOCK_NUM = ((2 ** 54 - 1) - MAX_TX_INDEX) / (BLOCK_OFFSET / TX_OFFSET);
@@ -70,8 +70,8 @@ library PosLib {
         uint256 txIndex = (pos % BLOCK_OFFSET) / TX_OFFSET;
         uint16 outputIndex = uint16(pos % TX_OFFSET);
 
-        require(blockNum <= MAX_BLOCK_NUM, "blockNum exceed max size allowed in PlasmaFramework");
-        require(txIndex <= MAX_TX_INDEX, "txIndex exceed the size of uint16");
+        require(blockNum <= MAX_BLOCK_NUM, "blockNum exceeds max size allowed in PlasmaFramework");
+        require(txIndex <= MAX_TX_INDEX, "txIndex exceeds the size of uint16");
         return Position(uint64(blockNum), uint16(txIndex), outputIndex);
     }
 }

--- a/plasma_framework/contracts/src/utils/PosLib.sol
+++ b/plasma_framework/contracts/src/utils/PosLib.sol
@@ -7,10 +7,8 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
  * TX position = (blockNumber * BLOCK_OFFSET + txIndex * TX_OFFSET)
  */
 library PosLib {
-    using SafeMath for uint256;
-
     struct Position {
-        uint256 blockNum;
+        uint64 blockNum;
         uint16 txIndex;
         uint16 outputIndex;
     }
@@ -21,7 +19,8 @@ library PosLib {
     uint256 constant internal MAX_OUTPUT_INDEX = TX_OFFSET - 1;
     // since we are using merkle tree of depth 16, max tx index size would be 2^16 - 1
     uint256 constant internal MAX_TX_INDEX = 2 ** 16 - 1;
-    uint256 constant internal MAX_BLOCK_NUM = ((2 ** 256 - 1) - MAX_TX_INDEX * TX_OFFSET - MAX_OUTPUT_INDEX) / BLOCK_OFFSET;
+    // in ExitPriority, only 54 bits are reserved for both blockNum and txIndex
+    uint256 constant internal MAX_BLOCK_NUM = ((2 ** 54 - 1) - MAX_TX_INDEX) / (BLOCK_OFFSET / TX_OFFSET);
 
     /**
      * @notice Returns transaction position which is an utxo position of zero index output
@@ -41,7 +40,7 @@ library PosLib {
      * @param pos UTXO position for the output
      * @return Identifier of the transaction
      */
-    function getTxPostionForExitPriority(Position memory pos)
+    function getTxPositionForExitPriority(Position memory pos)
         internal
         pure
         returns (uint256)
@@ -58,7 +57,7 @@ library PosLib {
         require(pos.outputIndex <= MAX_OUTPUT_INDEX, "Invalid output index");
         require(pos.blockNum <= MAX_BLOCK_NUM, "Invalid block number");
 
-        return pos.blockNum.mul(BLOCK_OFFSET).add(uint256(pos.txIndex).mul(TX_OFFSET)).add(pos.outputIndex);
+        return pos.blockNum * BLOCK_OFFSET + pos.txIndex * TX_OFFSET + pos.outputIndex;
     }
 
     /**
@@ -71,9 +70,8 @@ library PosLib {
         uint256 txIndex = (pos % BLOCK_OFFSET) / TX_OFFSET;
         uint16 outputIndex = uint16(pos % TX_OFFSET);
 
-        // (BLOCK_OFFSET / TX_OFFSET) is larger than MAX_TX_INDEX (2 ^ 16 - 1)
-        // thus the encoded position can potentially be with txIndex larger than uint16
-        require(txIndex <= MAX_TX_INDEX, "txIndex should not exceed the size of uint16");
-        return Position(blockNum, uint16(txIndex), outputIndex);
+        require(blockNum <= MAX_BLOCK_NUM, "blockNum exceed max size allowed in PlasmaFramework");
+        require(txIndex <= MAX_TX_INDEX, "txIndex exceed the size of uint16");
+        return Position(uint64(blockNum), uint16(txIndex), outputIndex);
     }
 }

--- a/plasma_framework/docs/contracts/ExitPriority.md
+++ b/plasma_framework/docs/contracts/ExitPriority.md
@@ -24,7 +24,7 @@ returns(uint256)
 An exit priority
   Anatomy of returned value, most significant bits first
   42 bits  - timestamp in seconds (exitable_at); we can represent dates until year 141431
-  54 bits  - blknum * CHILD_BLOCK_INTERVAL * 10^5 + txindex; 54 bits represent all transactions for 85 years. We are assuming CHILD_BLOCK_INTERVAL = 1000.
+  54 bits  - blocknum * 10^5 + txindex; 54 bits represent all transactions for 85 years. Be aware that child chain block number jumps with the interval of CHILD_BLOCK_INTERVAL, which would be 1000 in production.
   160 bits - exit id
 
 **Arguments**

--- a/plasma_framework/docs/contracts/PosLib.md
+++ b/plasma_framework/docs/contracts/PosLib.md
@@ -13,7 +13,7 @@ TX position = (blockNumber * BLOCK_OFFSET + txIndex * TX_OFFSET)
 ```js
 struct Position {
  uint256 blockNum,
- uint256 txIndex,
+ uint16 txIndex,
  uint16 outputIndex
 }
 ```
@@ -24,7 +24,9 @@ struct Position {
 ```js
 uint256 internal constant BLOCK_OFFSET;
 uint256 internal constant TX_OFFSET;
+uint256 internal constant MAX_OUTPUT_INDEX;
 uint256 internal constant MAX_TX_INDEX;
+uint256 internal constant MAX_BLOCK_NUM;
 
 ```
 

--- a/plasma_framework/docs/contracts/PosLib.md
+++ b/plasma_framework/docs/contracts/PosLib.md
@@ -12,7 +12,7 @@ TX position = (blockNumber * BLOCK_OFFSET + txIndex * TX_OFFSET)
 
 ```js
 struct Position {
- uint256 blockNum,
+ uint64 blockNum,
  uint16 txIndex,
  uint16 outputIndex
 }
@@ -33,7 +33,7 @@ uint256 internal constant MAX_BLOCK_NUM;
 ## Functions
 
 - [toStrictTxPos(struct PosLib.Position pos)](#tostricttxpos)
-- [getTxPostionForExitPriority(struct PosLib.Position pos)](#gettxpostionforexitpriority)
+- [getTxPositionForExitPriority(struct PosLib.Position pos)](#gettxpositionforexitpriority)
 - [encode(struct PosLib.Position pos)](#encode)
 - [decode(uint256 pos)](#decode)
 
@@ -56,12 +56,12 @@ Position of a transaction
 | ------------- |------------- | -----|
 | pos | struct PosLib.Position | UTXO position of the output | 
 
-### getTxPostionForExitPriority
+### getTxPositionForExitPriority
 
 Used for calculating exit priority
 
 ```js
-function getTxPostionForExitPriority(struct PosLib.Position pos) internal pure
+function getTxPositionForExitPriority(struct PosLib.Position pos) internal pure
 returns(uint256)
 ```
 

--- a/plasma_framework/test/src/exits/payment/controllers/PaymentChallengeIFENotCanonical.test.js
+++ b/plasma_framework/test/src/exits/payment/controllers/PaymentChallengeIFENotCanonical.test.js
@@ -697,7 +697,7 @@ contract('PaymentChallengeIFENotCanonical', ([_, ifeOwner, inputOwner, outputOwn
                         this.inFlightTxInclusionProof,
                         { from: ifeOwner },
                     ),
-                    'Should only pass in txPos with outputIndex equals to 0',
+                    'Output index of txPos has to be 0',
                 );
             });
 

--- a/plasma_framework/test/src/exits/payment/controllers/PaymentChallengeIFENotCanonical.test.js
+++ b/plasma_framework/test/src/exits/payment/controllers/PaymentChallengeIFENotCanonical.test.js
@@ -376,7 +376,16 @@ contract('PaymentChallengeIFENotCanonical', ([_, ifeOwner, inputOwner, outputOwn
 
                 await expectRevert(
                     this.exitGame.challengeInFlightExitNotCanonical(this.challengeArgs, { from: challenger }),
-                    'Canonicity challege phase for this exit has ended',
+                    'Canonicity challenge phase for this exit has ended',
+                );
+            });
+
+            it('fails when competing tx position is not with outputIndex set to 0', async () => {
+                this.challengeArgs.competingTxPos = 1;
+
+                await expectRevert(
+                    this.exitGame.challengeInFlightExitNotCanonical(this.challengeArgs, { from: challenger }),
+                    'OutputIndex of competingTxPos should be 0',
                 );
             });
 
@@ -677,6 +686,21 @@ contract('PaymentChallengeIFENotCanonical', ([_, ifeOwner, inputOwner, outputOwn
                 );
             });
 
+            it('fails when outputIndex of in-flight transaction position is not 0', async () => {
+                const wrongPosition = new Position(this.inFlightTxPos);
+                wrongPosition.outputIndex = 123;
+
+                await expectRevert(
+                    this.exitGame.respondToNonCanonicalChallenge(
+                        this.challengeArgs.inFlightTx,
+                        buildUtxoPos(wrongPosition.blockNum, wrongPosition.txIndex, wrongPosition.outputIndex),
+                        this.inFlightTxInclusionProof,
+                        { from: ifeOwner },
+                    ),
+                    'Should only pass in txPos with outputIndex equals to 0',
+                );
+            });
+
             it('fails when the block of the in-flight tx position does not exist', async () => {
                 const validIFEBlockNum = (new Position(this.inFlightTxPos)).blockNum;
                 const noBlockExistingPosition = buildUtxoPos(validIFEBlockNum - 1000, 0, 0);
@@ -687,7 +711,7 @@ contract('PaymentChallengeIFENotCanonical', ([_, ifeOwner, inputOwner, outputOwn
                         this.inFlightTxInclusionProof,
                         { from: ifeOwner },
                     ),
-                    'Failed to get the block root hash of the UTXO position',
+                    'Failed to get the block root hash of the tx position',
                 );
             });
 

--- a/plasma_framework/test/src/exits/utils/MoreVpFinalization.test.js
+++ b/plasma_framework/test/src/exits/utils/MoreVpFinalization.test.js
@@ -120,16 +120,18 @@ contract('MoreVpFinalization', () => {
                 expect(isStandardFinalized).to.be.true;
             });
 
-            it('should return false given empty inclusion proof', async () => {
+            it('should revert given empty inclusion proof', async () => {
                 await this.framework.setBlock(TEST_BLOCK_NUM, this.merkle.root, 0);
 
-                const isStandardFinalized = await this.test.isStandardFinalized(
-                    this.framework.address,
-                    this.txBytes,
-                    this.txPos,
-                    EMPTY_BYTES,
+                await expectRevert(
+                    this.test.isStandardFinalized(
+                        this.framework.address,
+                        this.txBytes,
+                        this.txPos,
+                        EMPTY_BYTES,
+                    ),
+                    'Merkle proof must not be empty',
                 );
-                expect(isStandardFinalized).to.be.false;
             });
 
             it('should return false given invalid inclusion proof', async () => {

--- a/plasma_framework/test/src/utils/Merkle.test.js
+++ b/plasma_framework/test/src/utils/Merkle.test.js
@@ -3,6 +3,7 @@ const Merkle = artifacts.require('MerkleWrapper');
 const { expectRevert } = require('openzeppelin-test-helpers');
 const { expect } = require('chai');
 
+const { EMPTY_BYTES } = require('../../helpers/constants.js');
 const { MerkleTree } = require('../../helpers/merkle.js');
 
 contract('Merkle', () => {
@@ -80,7 +81,7 @@ contract('Merkle', () => {
             expect(result).to.be.false;
         });
 
-        it('should reject call when proof data size is incorrect', async () => {
+        it('should revert when proof data size is incorrect', async () => {
             const leafIndex = 0;
             const leafData = web3.utils.sha3(leaves[leafIndex]);
             const rootHash = this.merkleTree.root;
@@ -95,6 +96,22 @@ contract('Merkle', () => {
                     wrongSizeProof,
                 ),
                 'Length of Merkle proof must be a multiple of 32',
+            );
+        });
+
+        it('should revert when proof data is empty', async () => {
+            const leafIndex = 0;
+            const leafData = web3.utils.sha3(leaves[leafIndex]);
+            const rootHash = this.merkleTree.root;
+
+            await expectRevert(
+                this.merkleContract.checkMembership(
+                    leafData,
+                    leafIndex,
+                    rootHash,
+                    EMPTY_BYTES,
+                ),
+                'Merkle proof must not be empty',
             );
         });
     });

--- a/plasma_framework/test/src/utils/PosLib.test.js
+++ b/plasma_framework/test/src/utils/PosLib.test.js
@@ -128,18 +128,15 @@ contract('PosLib', () => {
             const position = this.blockNum * BLOCK_OFFSET + txIndexTooLarge * TX_OFFSET + this.outputIndex;
             await expectRevert(
                 this.contract.decode(position),
-                'txIndex exceed the size of uint16',
+                'txIndex exceeds the size of uint16',
             );
         });
 
         it('should fail when block number exceeds max size allowed in PlasmaFramework', async () => {
-            const position = (maxBlockNum.add(new BN(1))).mul(new BN(BLOCK_OFFSET))
-                .add((new BN(0)).mul(new BN(TX_OFFSET)))
-                .add(new BN(0))
-                .toString();
+            const position = (maxBlockNum.add(new BN(1))).mul(new BN(BLOCK_OFFSET)).toString();
             await expectRevert(
                 this.contract.decode(position),
-                'blockNum exceed max size allowed in PlasmaFramework',
+                'blockNum exceeds max size allowed in PlasmaFramework',
             );
         });
     });

--- a/plasma_framework/test/src/utils/PosLib.test.js
+++ b/plasma_framework/test/src/utils/PosLib.test.js
@@ -7,27 +7,34 @@ contract('PosLib', () => {
     const BLOCK_OFFSET = 1000000000;
     const TX_OFFSET = 10000;
 
+    const maxOutputIndex = new BN(TX_OFFSET - 1);
+    const maxTxIndex = (new BN(2)).pow(new BN(16)).sub(new BN(1));
+    const maxBlockNum = (new BN(2)).pow(new BN(256)).sub(new BN(1))
+        .sub(maxTxIndex.mul(new BN(TX_OFFSET)))
+        .sub(maxOutputIndex)
+        .div(new BN(BLOCK_OFFSET));
+
     before('setup contract and utxo pos values', async () => {
         this.contract = await PosLib.new();
 
-        this.blockNumber = 314159;
+        this.blockNum = 314159;
         this.txIndex = 123;
         this.outputIndex = 2;
 
         this.position = {
-            blockNum: this.blockNumber,
+            blockNum: this.blockNum,
             txIndex: this.txIndex,
             outputIndex: this.outputIndex,
         };
 
-        this.utxoPos = this.blockNumber * BLOCK_OFFSET + this.txIndex * TX_OFFSET + this.outputIndex;
+        this.utxoPos = this.blockNum * BLOCK_OFFSET + this.txIndex * TX_OFFSET + this.outputIndex;
         this.txPos = this.utxoPos - this.outputIndex;
     });
 
     describe('toStrictTxPos', () => {
         it('should parse a correct tx position', async () => {
             const txPos = await this.contract.toStrictTxPos(this.position);
-            expect(new BN(txPos.blockNumber)).to.be.bignumber.equal(new BN(this.blockNum));
+            expect(new BN(txPos.blockNum)).to.be.bignumber.equal(new BN(this.blockNum));
             expect(new BN(txPos.txIndex)).to.be.bignumber.equal(new BN(this.txIndex));
             expect(new BN(txPos.outputIndex)).to.be.bignumber.equal(new BN(0));
         });
@@ -42,16 +49,36 @@ contract('PosLib', () => {
     });
 
     describe('encode', () => {
-        it('should correctly encode a position', async () => {
-            const result = await this.contract.encode(this.position);
-            expect(result).to.be.bignumber.equal(new BN(this.utxoPos));
+        describe('should correctly encode', () => {
+            const outputIndexes = [new BN(0), new BN(this.outputIndex), maxOutputIndex];
+            const txIndexes = [new BN(0), new BN(this.txIndex), maxTxIndex];
+            const blockNums = [new BN(0), new BN(this.blockNum), maxBlockNum];
+
+            blockNums.forEach((blockNum) => {
+                txIndexes.forEach((txIndex) => {
+                    outputIndexes.forEach((outputIndex) => {
+                        it(`with blockNum: ${blockNum}, txIndex: ${txIndex}, outputIndex: ${outputIndex}`, async () => {
+                            const position = {
+                                blockNum: blockNum.toString(),
+                                txIndex: txIndex.toString(),
+                                outputIndex: outputIndex.toString(),
+                            };
+                            const encodedPosition = blockNum.mul(new BN(BLOCK_OFFSET))
+                                .add(txIndex.mul(new BN(TX_OFFSET)))
+                                .add(outputIndex);
+                            const result = await this.contract.encode(position);
+                            expect(result).to.be.bignumber.equal(encodedPosition);
+                        });
+                    });
+                });
+            });
         });
 
         it('should fail when output index is too big', async () => {
             const position = {
-                blockNum: this.blockNumber,
+                blockNum: this.blockNum,
                 txIndex: this.txIndex,
-                outputIndex: 1000000,
+                outputIndex: TX_OFFSET,
             };
             await expectRevert(
                 this.contract.encode(position),
@@ -59,20 +86,11 @@ contract('PosLib', () => {
             );
         });
 
-        it('should fail when transaction index is too big', async () => {
-            const position = {
-                blockNum: this.blockNumber,
-                txIndex: BLOCK_OFFSET,
-                outputIndex: this.outputIndex,
-            };
-            await expectRevert(
-                this.contract.encode(position),
-                'Invalid transaction index',
-            );
-        });
-
         it('should fail when block number is too big', async () => {
-            const invalidBlockNum = '0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+            const invalidBlockNum = (new BN(2)).pow(new BN(256)).sub(new BN(1))
+                .div(new BN(BLOCK_OFFSET))
+                .add(new BN(1))
+                .toString();
             const position = {
                 blockNum: invalidBlockNum,
                 txIndex: this.txIndex,
@@ -80,17 +98,42 @@ contract('PosLib', () => {
             };
             await expectRevert(
                 this.contract.encode(position),
-                'SafeMath: ',
+                'Invalid block number',
             );
         });
     });
 
     describe('decode', () => {
-        it('should decode a position', async () => {
-            const result = await this.contract.decode(this.utxoPos);
-            expect(new BN(result.blockNumber)).to.be.bignumber.equal(new BN(this.blockNum));
-            expect(new BN(result.txIndex)).to.be.bignumber.equal(new BN(this.txIndex));
-            expect(new BN(result.outputIndex)).to.be.bignumber.equal(new BN(this.outputIndex));
+        describe('should decode a position', () => {
+            const outputIndexes = [new BN(0), new BN(this.outputIndex), maxOutputIndex];
+            const txIndexes = [new BN(0), new BN(this.txIndex), maxTxIndex];
+            const blockNums = [new BN(0), new BN(this.blockNum), maxBlockNum];
+
+            blockNums.forEach((blockNum) => {
+                txIndexes.forEach((txIndex) => {
+                    outputIndexes.forEach((outputIndex) => {
+                        it(`with blockNum: ${blockNum}, txIndex: ${txIndex}, outputIndex: ${outputIndex}`, async () => {
+                            const position = blockNum.mul(new BN(BLOCK_OFFSET))
+                                .add(txIndex.mul(new BN(TX_OFFSET)))
+                                .add(outputIndex)
+                                .toString();
+                            const result = await this.contract.decode(position);
+                            expect(new BN(result.blockNum)).to.be.bignumber.equal(blockNum);
+                            expect(new BN(result.txIndex)).to.be.bignumber.equal(txIndex);
+                            expect(new BN(result.outputIndex)).to.be.bignumber.equal(outputIndex);
+                        });
+                    });
+                });
+            });
+        });
+
+        it('should fail when transaction index is exceeds uint16 limit', async () => {
+            const txIndexTooLarge = 2 ** 16;
+            const position = this.blockNum * BLOCK_OFFSET + txIndexTooLarge * TX_OFFSET + this.outputIndex;
+            await expectRevert(
+                this.contract.decode(position),
+                'txIndex should not exceed the size of uint16',
+            );
         });
     });
 });


### PR DESCRIPTION
### Note
- Move the check of Merkle proof non empty to `checkMembership` function under `Merkle.sol`
- Add stricter range check in `PosLib`:
   - `txIndex` should be max to 2^16 - 1. Also, use `uint16` for the field.
   - Since there is a limit on ExitPriority that only 54 bits are reserved for `blockNum` + `txIndex`. Set the `MAX_BLOCK_NUM = ((2 ** 54 - 1) - MAX_TX_INDEX) / (BLOCK_OFFSET / TX_OFFSET);` and add check with that range.
- Add tests for edge values
