### PR TITLE
fix: do not fail on processing exits from in-flight transaction that has multiple distinct output tokens

### DIFF
--- a/plasma_framework/contracts/src/framework/ExitGameController.sol
+++ b/plasma_framework/contracts/src/framework/ExitGameController.sol
@@ -14,7 +14,7 @@ import "../utils/PosLib.sol";
  *         For details, see the Plasma MVP spec: https://ethresear.ch/t/minimal-viable-plasma/426
  */
 contract ExitGameController is ExitGameRegistry {
-    // exit hashed (priority, token) => IExitProcessor
+    // exit hashed (priority, vault id, token) => IExitProcessor
     mapping (bytes32 => IExitProcessor) public delegations;
     // hashed (vault id, token) => PriorityQueue
     mapping (bytes32 => PriorityQueue) public exitsQueues;
@@ -132,7 +132,7 @@ contract ExitGameController is ExitGameRegistry {
 
         queue.insert(priority);
 
-        bytes32 delegationKey = getDelegationKey(priority, token);
+        bytes32 delegationKey = getDelegationKey(priority, vaultId, token);
         delegations[delegationKey] = exitProcessor;
 
         emit ExitQueued(exitId, priority);
@@ -159,7 +159,7 @@ contract ExitGameController is ExitGameRegistry {
         require(topExitId == 0 || exitId == topExitId,
             "Top exit ID of the queue is different to the one specified");
 
-        bytes32 delegationKey = getDelegationKey(uniquePriority, token);
+        bytes32 delegationKey = getDelegationKey(uniquePriority, vaultId, token);
         IExitProcessor processor = delegations[delegationKey];
         uint256 processedNum = 0;
 
@@ -175,7 +175,7 @@ contract ExitGameController is ExitGameRegistry {
             }
 
             uniquePriority = queue.getMin();
-            delegationKey = getDelegationKey(uniquePriority, token);
+            delegationKey = getDelegationKey(uniquePriority, vaultId, token);
             exitId = ExitPriority.parseExitId(uniquePriority);
             processor = delegations[delegationKey];
         }
@@ -229,7 +229,7 @@ contract ExitGameController is ExitGameRegistry {
         return address(exitsQueues[queueKey]) != address(0);
     }
 
-    function getDelegationKey(uint256 priority, address token) private pure returns (bytes32) {
-        return keccak256(abi.encodePacked(priority, token));
+    function getDelegationKey(uint256 priority, uint256 vaultId, address token) private pure returns (bytes32) {
+        return keccak256(abi.encodePacked(priority, vaultId, token));
     }
 }

--- a/plasma_framework/contracts/src/framework/ExitGameController.sol
+++ b/plasma_framework/contracts/src/framework/ExitGameController.sol
@@ -14,7 +14,7 @@ import "../utils/PosLib.sol";
  *         For details, see the Plasma MVP spec: https://ethresear.ch/t/minimal-viable-plasma/426
  */
 contract ExitGameController is ExitGameRegistry {
-    // exit hashed (priority, token) => Delegation
+    // exit hashed (priority, token) => IExitProcessor
     mapping (bytes32 => IExitProcessor) public delegations;
     // hashed (vault id, token) => PriorityQueue
     mapping (bytes32 => PriorityQueue) public exitsQueues;

--- a/plasma_framework/docs/contracts/ExitGameController.md
+++ b/plasma_framework/docs/contracts/ExitGameController.md
@@ -66,7 +66,7 @@ modifier nonReentrant() internal
 - [getNextExit(uint256 vaultId, address token)](#getnextexit)
 - [exitQueueKey(uint256 vaultId, address token)](#exitqueuekey)
 - [hasExitQueue(bytes32 queueKey)](#hasexitqueue)
-- [getDelegationKey(uint256 priority, address token)](#getdelegationkey)
+- [getDelegationKey(uint256 priority, uint256 vaultId, address token)](#getdelegationkey)
 
 ### 
 
@@ -276,7 +276,7 @@ returns(bool)
 ### getDelegationKey
 
 ```js
-function getDelegationKey(uint256 priority, address token) private pure
+function getDelegationKey(uint256 priority, uint256 vaultId, address token) private pure
 returns(bytes32)
 ```
 
@@ -285,6 +285,7 @@ returns(bytes32)
 | Name        | Type           | Description  |
 | ------------- |------------- | -----|
 | priority | uint256 |  | 
+| vaultId | uint256 |  | 
 | token | address |  | 
 
 ## Contracts

--- a/plasma_framework/docs/contracts/ExitGameController.md
+++ b/plasma_framework/docs/contracts/ExitGameController.md
@@ -17,7 +17,7 @@ Controls the logic and functions for ExitGame to interact with the PlasmaFramewo
 
 ```js
 //public members
-mapping(uint256 => contract IExitProcessor) public delegations;
+mapping(bytes32 => contract IExitProcessor) public delegations;
 mapping(bytes32 => contract PriorityQueue) public exitsQueues;
 mapping(bytes32 => bool) public isOutputSpent;
 
@@ -66,6 +66,7 @@ modifier nonReentrant() internal
 - [getNextExit(uint256 vaultId, address token)](#getnextexit)
 - [exitQueueKey(uint256 vaultId, address token)](#exitqueuekey)
 - [hasExitQueue(bytes32 queueKey)](#hasexitqueue)
+- [getDelegationKey(uint256 priority, address token)](#getdelegationkey)
 
 ### 
 
@@ -271,6 +272,20 @@ returns(bool)
 | Name        | Type           | Description  |
 | ------------- |------------- | -----|
 | queueKey | bytes32 |  | 
+
+### getDelegationKey
+
+```js
+function getDelegationKey(uint256 priority, address token) private pure
+returns(bytes32)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| priority | uint256 |  | 
+| token | address |  | 
 
 ## Contracts
 

--- a/plasma_framework/docs/contracts/PaymentInFlightExitRouter.md
+++ b/plasma_framework/docs/contracts/PaymentInFlightExitRouter.md
@@ -167,8 +167,8 @@ function respondToNonCanonicalChallenge(bytes inFlightTx, uint256 inFlightTxPos,
 | Name        | Type           | Description  |
 | ------------- |------------- | -----|
 | inFlightTx | bytes | The RLP-encoded in-flight transaction | 
-| inFlightTxPos | uint256 | UTXO position of the in-flight exiting transaction, which is a position of 0 indexed output | 
-| inFlightTxInclusionProof | bytes | Proof that in-flight exiting transaction is included in a Plasma block | 
+| inFlightTxPos | uint256 | The position of the in-flight exiting transaction. The output index within the position is unused and should be set to 0 | 
+| inFlightTxInclusionProof | bytes | Proof that the in-flight exiting transaction is included in a Plasma block | 
 
 ### challengeInFlightExitInputSpent
 

--- a/plasma_framework/python_tests/tests/contracts/root_chain/test_piggyback_in_flight_exit.py
+++ b/plasma_framework/python_tests/tests/contracts/root_chain/test_piggyback_in_flight_exit.py
@@ -116,65 +116,6 @@ def test_piggyback_in_flight_exit_twice_should_fail(testlang):
         testlang.piggyback_in_flight_exit_input(spend_id, input_index, owner)
 
 
-@pytest.mark.skip("TODO: SE <> IFE interaction - tests should probably be deleted")
-@pytest.mark.parametrize("num_outputs", [1, 2, 3, 4])
-def test_piggyback_in_flight_exit_output_with_preexisting_standard_exit_should_fail(testlang, num_outputs):
-    # exit cross-spend test, case 5
-    owner_1, amount = testlang.accounts[0], 100
-    deposit_id = testlang.deposit(owner_1, amount)
-    outputs = []
-    for i in range(0, num_outputs):
-        outputs.append((testlang.accounts[i].address, NULL_ADDRESS, 1))
-    spend_id = testlang.spend_utxo([deposit_id], [owner_1], outputs)
-
-    blknum, txindex, _ = decode_utxo_id(spend_id)
-    exit_pos = encode_utxo_id(blknum, txindex, num_outputs - 1)
-    testlang.start_standard_exit(exit_pos, account=testlang.accounts[num_outputs - 1])
-
-    testlang.start_in_flight_exit(spend_id)
-
-    assert testlang.get_standard_exit(exit_pos).amount == 1
-    bond = testlang.root_chain.piggybackBond()
-
-    with pytest.raises(TransactionFailed):
-        testlang.piggyback_in_flight_exit_output(spend_id, num_outputs - 1, testlang.accounts[num_outputs - 1],
-                                                 bond)
-
-    in_flight_exit = testlang.get_in_flight_exit(spend_id)
-    assert not in_flight_exit.output_piggybacked(num_outputs - 1)
-
-
-@pytest.mark.skip("TODO: SE <> IFE interaction - tests should probably be deleted")
-@pytest.mark.parametrize("num_outputs", [1, 2, 3, 4])
-def test_piggyback_in_flight_exit_output_with_preexisting_finalized_standard_exit_should_fail(testlang, num_outputs):
-    # exit cross-spend test, case 6
-    owner, amount = testlang.accounts[0], 100
-    deposit_id = testlang.deposit(owner, amount)
-    outputs = []
-    for i in range(num_outputs):
-        outputs.append((testlang.accounts[i].address, NULL_ADDRESS, 1))
-    spend_id = testlang.spend_utxo([deposit_id], [owner], outputs)
-
-    blknum, txindex, _ = decode_utxo_id(spend_id)
-    exit_pos = encode_utxo_id(blknum, txindex, num_outputs - 1)
-    testlang.start_standard_exit(exit_pos, account=testlang.accounts[num_outputs - 1])
-
-    testlang.forward_timestamp(2 * MIN_EXIT_PERIOD + 1)
-    testlang.process_exits(NULL_ADDRESS, 0, 1)
-
-    testlang.start_in_flight_exit(spend_id)
-
-    assert testlang.get_standard_exit(exit_pos).amount == 1
-    bond = testlang.root_chain.piggybackBond()
-
-    with pytest.raises(TransactionFailed):
-        testlang.piggyback_in_flight_exit_output(spend_id, num_outputs - 1, testlang.accounts[num_outputs - 1],
-                                                 bond)
-
-    in_flight_exit = testlang.get_in_flight_exit(spend_id)
-    assert not in_flight_exit.output_piggybacked(num_outputs - 1)
-
-
 @pytest.mark.parametrize("output", [0, 4])
 def test_piggybacking_an_output_of_unsupported_token_should_fail(testlang, no_exit_queue_token, output):
     token = no_exit_queue_token

--- a/plasma_framework/python_tests/tests/contracts/root_chain/test_piggyback_in_flight_exit.py
+++ b/plasma_framework/python_tests/tests/contracts/root_chain/test_piggyback_in_flight_exit.py
@@ -1,7 +1,6 @@
 import pytest
 from eth_tester.exceptions import TransactionFailed
 from plasma_core.constants import MIN_EXIT_PERIOD, NULL_ADDRESS
-from plasma_core.utils.transactions import decode_utxo_id, encode_utxo_id
 
 
 @pytest.mark.parametrize("num_inputs", [1, 2, 3, 4])

--- a/plasma_framework/python_tests/tests/contracts/root_chain/test_process_exits.py
+++ b/plasma_framework/python_tests/tests/contracts/root_chain/test_process_exits.py
@@ -670,3 +670,19 @@ def test_in_flight_exit_is_cleaned_up_even_though_none_of_outputs_exited(testlan
 
     # assert IFE and piggyback bonds were sent to the owners
     assert testlang.get_balance(owner) == pre_balance + testlang.root_chain.inFlightExitBond()
+
+
+def test_processing_ife_and_se_exit_from_same_output_does_not_fail(testlang):
+    owner, amount = testlang.accounts[0], 100
+    deposit_id = testlang.deposit(owner, amount)
+
+    spend_id = testlang.spend_utxo([deposit_id], [owner], [(owner.address, NULL_ADDRESS, amount)])
+
+    testlang.start_in_flight_exit(spend_id)
+    testlang.piggyback_in_flight_exit_input(spend_id, 0, owner)
+    testlang.start_standard_exit(spend_id, owner)
+
+    testlang.forward_timestamp(2 * MIN_EXIT_PERIOD + 1)
+
+    # no error should be raised
+    testlang.process_exits(NULL_ADDRESS, 0, 2)

--- a/plasma_framework/python_tests/tests/contracts/root_chain/test_process_exits.py
+++ b/plasma_framework/python_tests/tests/contracts/root_chain/test_process_exits.py
@@ -300,7 +300,7 @@ def test_finalize_skipping_top_utxo_check_is_possible(testlang):
 
 
 def test_finalize_challenged_exit_will_not_send_funds(testlang):
-    owner, finalizer, amount = testlang.accounts[0], testlang.accounts[0], 100
+    owner, amount = testlang.accounts[0], 100
     deposit_id = testlang.deposit(owner, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner], [(owner.address, NULL_ADDRESS, 100)])
 
@@ -419,7 +419,7 @@ def test_finalize_exits_priority_for_in_flight_exits_corresponds_to_the_age_of_y
     assert testlang.get_balance(owner) == balance + 100 + testlang.root_chain.standardExitBond()
 
 
-def test_finalize_in_flight_exit_with_erc20_token_should_succeed(testlang, token,plasma_framework):
+def test_finalize_in_flight_exit_with_erc20_token_should_succeed(testlang, token, plasma_framework):
     owner, amount = testlang.accounts[1], 100
     deposit_id = testlang.deposit_token(owner, token, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner], [(owner.address, token.address, amount)])
@@ -550,7 +550,7 @@ def test_does_not_finalize_outputs_of_other_tokens(testlang, token):
 
 
 def test_when_processing_ife_finalization_of_erc20_token_does_not_clean_up_eth_outputs_data(
-    testlang, token, plasma_framework):
+        testlang, token, plasma_framework):
     (owner_1, owner_2), amount = testlang.accounts[1:3], 100
 
     token_deposit = testlang.deposit_token(owner_1, token, amount)
@@ -559,7 +559,7 @@ def test_when_processing_ife_finalization_of_erc20_token_does_not_clean_up_eth_o
     spend_id = testlang.spend_utxo([token_deposit, eth_deposit], [owner_1, owner_2],
                                    [(owner_1.address, NULL_ADDRESS, amount),
                                     (owner_2.address, token.address, amount)])
-   
+
     testlang.start_in_flight_exit(spend_id)
 
     testlang.piggyback_in_flight_exit_output(spend_id, 0, owner_1)

--- a/plasma_framework/python_tests/tests/contracts/root_chain/test_process_exits.py
+++ b/plasma_framework/python_tests/tests/contracts/root_chain/test_process_exits.py
@@ -1,6 +1,5 @@
 import pytest
 from eth_tester.exceptions import TransactionFailed
-from eth_utils import to_canonical_address
 
 from plasma_core.constants import NULL_ADDRESS, NULL_ADDRESS_HEX, MIN_EXIT_PERIOD
 from plasma_core.utils.transactions import decode_utxo_id, encode_utxo_id
@@ -64,11 +63,10 @@ def test_successful_process_exit_should_clear_exit_fields_and_set_output_as_spen
     assert testlang.root_chain.isOutputSpent(started_exit.output_id)
 
 
-@pytest.mark.skip("Includes IFE")
 def test_process_exits_in_flight_exit_should_succeed(testlang):
     owner, amount = testlang.accounts[0], 100
     deposit_id = testlang.deposit(owner, amount)
-    spend_id = testlang.spend_utxo([deposit_id], [owner], [(owner.address, NULL_ADDRESS, 100)])
+    spend_id = testlang.spend_utxo([deposit_id], [owner], outputs=[(owner.address, NULL_ADDRESS, 100)])
     testlang.start_in_flight_exit(spend_id)
     testlang.piggyback_in_flight_exit_output(spend_id, 0, owner)
     testlang.forward_timestamp(2 * MIN_EXIT_PERIOD + 1)
@@ -83,7 +81,7 @@ def test_process_exits_in_flight_exit_should_succeed(testlang):
 
     for i in range(4):
         input_info = in_flight_exit.get_input(i)
-        assert input_info.owner == NULL_ADDRESS
+        assert input_info.exit_target == NULL_ADDRESS_HEX
         assert input_info.amount == 0
 
     expected_balance = pre_balance + amount + testlang.root_chain.inFlightExitBond() + testlang.root_chain.piggybackBond()
@@ -204,7 +202,6 @@ def test_finalize_exits_partial_queue_processing(testlang):
     assert plasma_exit.owner == owner.address
 
 
-@pytest.mark.skip("Includes IFE")
 def test_processing_exits_with_specifying_top_exit_id_is_possible(testlang):
     owner, amount = testlang.accounts[0], 100
 
@@ -302,7 +299,6 @@ def test_finalize_skipping_top_utxo_check_is_possible(testlang):
     assert standard_exit.owner == NULL_ADDRESS_HEX
 
 
-@pytest.mark.skip("Requires challenges to work")
 def test_finalize_challenged_exit_will_not_send_funds(testlang):
     owner, finalizer, amount = testlang.accounts[0], testlang.accounts[0], 100
     deposit_id = testlang.deposit(owner, amount)
@@ -312,35 +308,15 @@ def test_finalize_challenged_exit_will_not_send_funds(testlang):
     doublespend_id = testlang.spend_utxo([spend_id], [owner], [(owner.address, NULL_ADDRESS, 100)])
 
     testlang.challenge_standard_exit(spend_id, doublespend_id)
-    assert testlang.get_standard_exit(spend_id) == [NULL_ADDRESS_HEX, NULL_ADDRESS_HEX, 0]
 
     testlang.forward_timestamp(2 * MIN_EXIT_PERIOD + 1)
 
-    pre_balance = testlang.get_balance(testlang.root_chain)
-    testlang.process_exits(NULL_ADDRESS, 0, 1, **{'from': finalizer.address})
-    post_balance = testlang.get_balance(testlang.root_chain)
+    pre_balance = testlang.get_balance(testlang.root_chain.eth_vault)
+    testlang.process_exits(NULL_ADDRESS, 0, 1)
+    post_balance = testlang.get_balance(testlang.root_chain.eth_vault)
     assert post_balance == pre_balance
 
 
-@pytest.mark.skip("Requires challenges to work")
-def test_finalize_challenged_exit_does_not_emit_events(testlang):
-    owner, finalizer, amount = testlang.accounts[0], testlang.accounts[0], 100
-    deposit_id = testlang.deposit(owner, amount)
-    spend_id = testlang.spend_utxo([deposit_id], [owner], [(owner.address, NULL_ADDRESS, 100)])
-
-    testlang.start_standard_exit(spend_id, owner)
-    doublespend_id = testlang.spend_utxo([spend_id], [owner], [(owner.address, NULL_ADDRESS, 100)])
-
-    testlang.challenge_standard_exit(spend_id, doublespend_id)
-
-    testlang.forward_timestamp(2 * MIN_EXIT_PERIOD + 1)
-
-    testlang.flush_events()
-    testlang.process_exits(NULL_ADDRESS, 0, 1, **{'from': finalizer.address})
-    assert [] == testlang.flush_events()
-
-
-@pytest.mark.skip("Requires challenges to work")
 def test_finalize_exit_challenge_of_finalized_will_fail(testlang):
     owner, amount = testlang.accounts[0], 100
     deposit_id = testlang.deposit(owner, amount)
@@ -357,8 +333,7 @@ def test_finalize_exit_challenge_of_finalized_will_fail(testlang):
         testlang.challenge_standard_exit(spend_id, doublespend_id)
 
 
-@pytest.mark.skip("Includes IFE")
-def test_finalize_exits_for_in_flight_exit_should_transfer_funds(testlang):
+def test_finalize_exits_for_in_flight_exit_should_transfer_funds(testlang, plasma_framework):
     owner, amount = testlang.accounts[0], 100
     first_utxo = 100 - 33
     deposit_id = testlang.deposit(owner, amount)
@@ -371,7 +346,7 @@ def test_finalize_exits_for_in_flight_exit_should_transfer_funds(testlang):
 
     testlang.forward_timestamp(2 * MIN_EXIT_PERIOD + 1)
 
-    exitable_timestamp, _, _ = testlang.root_chain.getNextExit(NULL_ADDRESS)
+    exitable_timestamp, _, _ = plasma_framework.getNextExit(plasma_framework.eth_vault_id, NULL_ADDRESS)
     pre_balance = testlang.get_balance(owner)
 
     testlang.process_exits(NULL_ADDRESS, 0, 10)
@@ -379,8 +354,7 @@ def test_finalize_exits_for_in_flight_exit_should_transfer_funds(testlang):
         pre_balance + first_utxo + testlang.root_chain.inFlightExitBond() + testlang.root_chain.piggybackBond()
 
 
-@pytest.mark.skip("Includes IFE")
-def test_finalize_in_flight_exit_finalizes_only_piggybacked_outputs(testlang):
+def test_finalize_in_flight_exit_finalizes_only_piggybacked_outputs(testlang, plasma_framework):
     owner, amount = testlang.accounts[0], 100
     first_utxo = 100 - 33
     deposit_id = testlang.deposit(owner, amount)
@@ -393,7 +367,11 @@ def test_finalize_in_flight_exit_finalizes_only_piggybacked_outputs(testlang):
 
     testlang.forward_timestamp(2 * MIN_EXIT_PERIOD + 1)
 
-    exitable_timestamp, _, _ = testlang.root_chain.getNextExit(NULL_ADDRESS)
+    in_flight_exit = testlang.get_in_flight_exit(spend_id)
+    output_id_0 = in_flight_exit.outputs[0].output_id
+    output_id_1 = in_flight_exit.outputs[1].output_id
+
+    exitable_timestamp, _, _ = plasma_framework.getNextExit(plasma_framework.eth_vault_id, NULL_ADDRESS)
     pre_balance = testlang.get_balance(owner)
 
     testlang.process_exits(NULL_ADDRESS, 0, 10)
@@ -402,11 +380,10 @@ def test_finalize_in_flight_exit_finalizes_only_piggybacked_outputs(testlang):
 
     in_flight_exit = testlang.get_in_flight_exit(spend_id)
 
-    assert in_flight_exit.output_blocked(0)
-    assert not in_flight_exit.output_blocked(1)
+    assert plasma_framework.isOutputSpent(output_id_0)
+    assert not plasma_framework.isOutputSpent(output_id_1)
 
 
-@pytest.mark.skip("Includes IFE")
 def test_finalize_exits_priority_for_in_flight_exits_corresponds_to_the_age_of_youngest_input(testlang):
     owner, amount = testlang.accounts[0], 100
     deposit_0_id = testlang.deposit(owner, amount)
@@ -442,8 +419,7 @@ def test_finalize_exits_priority_for_in_flight_exits_corresponds_to_the_age_of_y
     assert testlang.get_balance(owner) == balance + 100 + testlang.root_chain.standardExitBond()
 
 
-@pytest.mark.skip("Includes IFE")
-def test_finalize_in_flight_exit_with_erc20_token_should_succeed(testlang, token):
+def test_finalize_in_flight_exit_with_erc20_token_should_succeed(testlang, token,plasma_framework):
     owner, amount = testlang.accounts[1], 100
     deposit_id = testlang.deposit_token(owner, token, amount)
     spend_id = testlang.spend_utxo([deposit_id], [owner], [(owner.address, token.address, amount)])
@@ -455,29 +431,31 @@ def test_finalize_in_flight_exit_with_erc20_token_should_succeed(testlang, token
 
     testlang.forward_timestamp(2 * MIN_EXIT_PERIOD + 1)
 
-    testlang.process_exits(testlang.root_chain.erc20_vault_id, token.address, 0, 1)
+    in_flight_exit = testlang.get_in_flight_exit(spend_id)
+    output_id = in_flight_exit.outputs[0].output_id
+    input_id = in_flight_exit.inputs[0].output_id
+
+    testlang.process_exits(token.address, 0, 1)
 
     in_flight_exit = testlang.get_in_flight_exit(spend_id)
 
     assert in_flight_exit.exit_start_timestamp == 0
-    assert in_flight_exit.exit_priority == 0
     for i in range(4):
         tx_input = in_flight_exit.get_input(i)
         assert tx_input.amount == 0
-        assert tx_input.owner == NULL_ADDRESS
+        assert tx_input.exit_target == NULL_ADDRESS_HEX
 
         tx_output = in_flight_exit.get_input(i)
         assert tx_output.amount == 0
-        assert tx_output.owner == NULL_ADDRESS
+        assert tx_output.exit_target == NULL_ADDRESS_HEX
 
     assert in_flight_exit.bond_owner == NULL_ADDRESS_HEX
     assert in_flight_exit.oldest_competitor == 0
 
-    assert in_flight_exit.input_blocked(0)
-    assert in_flight_exit.output_blocked(0)
+    assert plasma_framework.isOutputSpent(output_id)
+    assert plasma_framework.isOutputSpent(input_id)
 
 
-@pytest.mark.skip("Includes IFE")
 def test_finalize_in_flight_exit_with_erc20_token_should_transfer_funds_and_bond(testlang, token):
     owner, amount = testlang.accounts[1], 100
     deposit_id = testlang.deposit_token(owner, token, amount)
@@ -491,13 +469,12 @@ def test_finalize_in_flight_exit_with_erc20_token_should_transfer_funds_and_bond
     token_balance = testlang.get_balance(owner, token)
     eth_balance = testlang.get_balance(owner)
 
-    testlang.process_exits(testlang.root_chain.erc20_vault_id, token.address, 0, 1, gas=800_000)
+    testlang.process_exits(token.address, 0, 1)
 
     assert testlang.get_balance(owner, token) == token_balance + amount
     assert testlang.get_balance(owner) == eth_balance + testlang.root_chain.piggybackBond()
 
 
-@pytest.mark.skip("Includes IFE")
 def test_finalize_in_flight_exit_with_eth_and_erc20_token(testlang, token):
     (owner_1, owner_2), amount = testlang.accounts[1:3], 100
     token_deposit = testlang.deposit_token(owner_1, token, amount)
@@ -519,12 +496,12 @@ def test_finalize_in_flight_exit_with_eth_and_erc20_token(testlang, token):
     ]
 
     # finalize only ERC20 token
-    testlang.process_exits(testlang.root_chain.erc20_vault_id, token.address, 0, 1)
+    testlang.process_exits(token.address, 0, 1)
 
     assert testlang.get_balance(owner_1) == owner_1_balances[0]
     assert testlang.get_balance(owner_1, token) == owner_1_balances[1]
 
-    # only owner 2 receives his founds
+    # only owner 2 receives his funds
     assert testlang.get_balance(owner_2) == owner_2_balances[0] + testlang.root_chain.piggybackBond()
     assert testlang.get_balance(owner_2, token) == owner_2_balances[1] + (amount - 2)
 
@@ -539,7 +516,6 @@ def test_finalize_in_flight_exit_with_eth_and_erc20_token(testlang, token):
     assert testlang.get_balance(owner_2, token) == owner_2_balances[1] + (amount - 2)
 
 
-@pytest.mark.skip("Includes IFE")
 def test_does_not_finalize_outputs_of_other_tokens(testlang, token):
     (owner_1, owner_2), amount = testlang.accounts[1:3], 100
 
@@ -573,8 +549,8 @@ def test_does_not_finalize_outputs_of_other_tokens(testlang, token):
     assert testlang.get_balance(owner_2, token.address) == owner_2_balances[1]
 
 
-@pytest.mark.skip("Includes IFE")
-def test_when_processing_ife_finalization_of_erc20_token_does_not_clean_up_eth_outputs_data(testlang, token):
+def test_when_processing_ife_finalization_of_erc20_token_does_not_clean_up_eth_outputs_data(
+    testlang, token, plasma_framework):
     (owner_1, owner_2), amount = testlang.accounts[1:3], 100
 
     token_deposit = testlang.deposit_token(owner_1, token, amount)
@@ -583,7 +559,7 @@ def test_when_processing_ife_finalization_of_erc20_token_does_not_clean_up_eth_o
     spend_id = testlang.spend_utxo([token_deposit, eth_deposit], [owner_1, owner_2],
                                    [(owner_1.address, NULL_ADDRESS, amount),
                                     (owner_2.address, token.address, amount)])
-
+   
     testlang.start_in_flight_exit(spend_id)
 
     testlang.piggyback_in_flight_exit_output(spend_id, 0, owner_1)
@@ -591,21 +567,24 @@ def test_when_processing_ife_finalization_of_erc20_token_does_not_clean_up_eth_o
 
     testlang.forward_timestamp(2 * MIN_EXIT_PERIOD + 1)
 
+    in_flight_exit = testlang.get_in_flight_exit(spend_id)
+    eth_output_id = in_flight_exit.outputs[0].output_id
+    erc20_output_id = in_flight_exit.outputs[1].output_id
+
     # finalize only ERC20 token
-    testlang.process_exits(testlang.root_chain.erc20_vault_id, token.address, 0, 1)
+    testlang.process_exits(token.address, 0, 1)
     in_flight_exit = testlang.get_in_flight_exit(spend_id)
 
-    assert not in_flight_exit.output_blocked(0)
-    assert in_flight_exit.output_blocked(1)
+    assert plasma_framework.isOutputSpent(erc20_output_id)
+    assert not plasma_framework.isOutputSpent(eth_output_id)
 
     assert in_flight_exit.output_piggybacked(0)
     assert not in_flight_exit.output_piggybacked(1)
 
-    assert in_flight_exit.get_output(0).owner == to_canonical_address(owner_1.address)
-    assert in_flight_exit.get_output(0).amount == amount
+    assert in_flight_exit.outputs[0].exit_target == owner_1.address
+    assert in_flight_exit.outputs[0].amount == amount
 
 
-@pytest.mark.skip("Includes IFE")
 def test_ife_is_enqueued_once_per_token(testlang, token):
     owner, amount = testlang.accounts[0], 100
     eth_deposit_id = testlang.deposit(owner, amount)
@@ -630,13 +609,12 @@ def test_ife_is_enqueued_once_per_token(testlang, token):
         testlang.process_exits(NULL_ADDRESS, 0, 1)
 
     # check ERC20 token
-    testlang.process_exits(testlang.root_chain.erc20_vault_id, token.address, 0, 1)
+    testlang.process_exits(token.address, 0, 1)
 
     with pytest.raises(TransactionFailed):
-        testlang.process_exits(testlang.root_chain.erc20_vault_id, token.address, 0, 1)
+        testlang.process_exits(token.address, 0, 1)
 
 
-@pytest.mark.skip("Includes IFE")
 def test_when_processing_an_ife_it_is_cleaned_up_when_all_piggybacked_outputs_finalized(testlang, token):
     (owner_1, owner_2), amount = testlang.accounts[1:3], 100
     token_deposit = testlang.deposit_token(owner_1, token, amount)
@@ -650,38 +628,31 @@ def test_when_processing_an_ife_it_is_cleaned_up_when_all_piggybacked_outputs_fi
 
     testlang.piggyback_in_flight_exit_output(spend_id, 0, owner_1)
     testlang.piggyback_in_flight_exit_output(spend_id, 1, owner_2)
+    pre_balance = testlang.get_balance(testlang.accounts[0])
 
     testlang.forward_timestamp(2 * MIN_EXIT_PERIOD + 1)
 
     # finalize both ERC20 token and Eth outputs
-    testlang.process_exits(testlang.root_chain.erc20_vault_id, token.address, 0, 1)
-
-    pre_balance = testlang.get_balance(testlang.accounts[0])
-
+    testlang.process_exits(token.address, 0, 1)
     testlang.process_exits(NULL_ADDRESS, 0, 1)
 
     in_flight_exit = testlang.get_in_flight_exit(spend_id)
 
-    # most of the fields are deleted
+    # fields are deleted
     assert in_flight_exit.bond_owner == NULL_ADDRESS_HEX
-    assert in_flight_exit.exit_priority == 0
     assert in_flight_exit.oldest_competitor == 0
     assert in_flight_exit.exit_start_timestamp == 0
-
-    # some fields are not deleted
-    assert in_flight_exit.exit_map != 0
+    assert in_flight_exit.exit_map == 0
 
     # assert bond was sent to the owner
     assert testlang.get_balance(testlang.accounts[0]) == pre_balance + testlang.root_chain.inFlightExitBond()
 
 
-@pytest.mark.skip("Includes IFE")
 def test_in_flight_exit_is_cleaned_up_even_though_none_of_outputs_exited(testlang):
     owner, amount = testlang.accounts[0], 100
     deposit_id = testlang.deposit(owner, amount)
 
     spend_id = testlang.spend_utxo([deposit_id], [owner], [(owner.address, NULL_ADDRESS, amount)])
-    testlang.start_in_flight_exit(spend_id)
     testlang.start_in_flight_exit(spend_id)
     testlang.piggyback_in_flight_exit_input(spend_id, 0, owner)
     testlang.forward_timestamp(2 * MIN_EXIT_PERIOD + 1)
@@ -691,14 +662,11 @@ def test_in_flight_exit_is_cleaned_up_even_though_none_of_outputs_exited(testlan
 
     in_flight_exit = testlang.get_in_flight_exit(spend_id)
 
-    # most of the fields are deleted
+    # fields are deleted
     assert in_flight_exit.bond_owner == NULL_ADDRESS_HEX
-    assert in_flight_exit.exit_priority == 0
     assert in_flight_exit.oldest_competitor == 0
     assert in_flight_exit.exit_start_timestamp == 0
-
-    # some fields are not deleted
-    assert in_flight_exit.exit_map != 0
+    assert in_flight_exit.exit_map == 0
 
     # assert IFE and piggyback bonds were sent to the owners
-    assert testlang.get_balance(owner) == pre_balance + testlang.root_chain.inFlightExitBond() * 2
+    assert testlang.get_balance(owner) == pre_balance + testlang.root_chain.inFlightExitBond()

--- a/plasma_framework/test/src/framework/ExitGameController.test.js
+++ b/plasma_framework/test/src/framework/ExitGameController.test.js
@@ -184,7 +184,7 @@ contract('ExitGameController', () => {
 
             it('saves the exit data to map', async () => {
                 const priority = await this.dummyExitGame.priorityFromEnqueue();
-                const delegationKey = web3.utils.soliditySha3(priority, this.dummyExit.token);
+                const delegationKey = web3.utils.soliditySha3(priority, VAULT_ID, this.dummyExit.token);
                 const exitProcessor = await this.controller.delegations(delegationKey);
 
                 expect(exitProcessor).to.equal(this.dummyExit.exitProcessor);
@@ -321,7 +321,7 @@ contract('ExitGameController', () => {
                 );
             });
 
-            it('should be able to process when the exitId is set to 0', async () => {
+            it('should process the exit when the exitId is set to 0', async () => {
                 const tx = await this.controller.processExits(VAULT_ID, this.dummyToken, 0, 1);
                 await expectEvent.inLogs(tx.logs, 'ProcessedExitsNum', {
                     processedNum: new BN(1),
@@ -329,7 +329,29 @@ contract('ExitGameController', () => {
                 });
             });
 
-            it('should be able to process when the exitId is set to the exact top of the queue', async () => {
+            it('should process an exit for the same token and exitId but a different vault', async () => {
+                const otherVaultId = VAULT_ID + 1;
+                await this.controller.addExitQueue(otherVaultId, this.dummyToken);
+
+                await this.dummyExitGame.enqueue(
+                    otherVaultId,
+                    this.dummyExit.token,
+                    this.dummyExit.exitableAt,
+                    this.dummyExit.txPos,
+                    this.dummyExit.exitId,
+                    this.dummyExit.exitProcessor,
+                );
+
+                await this.controller.processExits(VAULT_ID, this.dummyToken, 0, 1);
+
+                const tx = await this.controller.processExits(otherVaultId, this.dummyToken, 0, 1);
+                await expectEvent.inLogs(tx.logs, 'ProcessedExitsNum', {
+                    processedNum: new BN(1),
+                    token: this.dummyToken,
+                });
+            });
+
+            it('should process the exit when the exitId is set to the exact top of the queue', async () => {
                 const tx = await this.controller.processExits(
                     VAULT_ID, this.dummyToken, this.dummyExit.exitId, 1,
                 );
@@ -355,7 +377,7 @@ contract('ExitGameController', () => {
 
                 await this.controller.processExits(VAULT_ID, this.dummyToken, 0, 1);
 
-                const delegationKey = web3.utils.soliditySha3(priority, this.dummyExit.token);
+                const delegationKey = web3.utils.soliditySha3(priority, VAULT_ID, this.dummyExit.token);
                 const exitProcessor = await this.controller.delegations(delegationKey);
                 expect(exitProcessor).to.equal(constants.ZERO_ADDRESS);
             });

--- a/plasma_framework/test/src/framework/ExitGameController.test.js
+++ b/plasma_framework/test/src/framework/ExitGameController.test.js
@@ -184,7 +184,8 @@ contract('ExitGameController', () => {
 
             it('saves the exit data to map', async () => {
                 const priority = await this.dummyExitGame.priorityFromEnqueue();
-                const exitProcessor = await this.controller.delegations(priority);
+                const delegationKey = web3.utils.soliditySha3(priority, this.dummyExit.token);
+                const exitProcessor = await this.controller.delegations(delegationKey);
 
                 expect(exitProcessor).to.equal(this.dummyExit.exitProcessor);
             });
@@ -354,7 +355,8 @@ contract('ExitGameController', () => {
 
                 await this.controller.processExits(VAULT_ID, this.dummyToken, 0, 1);
 
-                const exitProcessor = await this.controller.delegations(priority);
+                const delegationKey = web3.utils.soliditySha3(priority, this.dummyExit.token);
+                const exitProcessor = await this.controller.delegations(delegationKey);
                 expect(exitProcessor).to.equal(constants.ZERO_ADDRESS);
             });
 


### PR DESCRIPTION
Closes #536 

Changes:
 * fix failing on processing exits from in-flight transaction that has multiple distinct output tokens
 * enable python tests for processing exits