### PR TITLE
150 Enable omitted tests

### DIFF
--- a/plasma_framework/python_tests/plasma_core/transaction.py
+++ b/plasma_framework/python_tests/plasma_core/transaction.py
@@ -147,14 +147,14 @@ class Transaction(rlp.Serializable):
     def sign(self, index, account, verifying_contract=None):
         msg_hash = hash_struct(self, verifying_contract=verifying_contract)
         sig = account.key.sign_msg_hash(msg_hash)
-        self.signatures[index] = _amend_signature(sig.to_bytes())
+        self.signatures[index] = amend_signature(sig.to_bytes())
         self._signers[index] = sig.recover_public_key_from_msg_hash(
             msg_hash).to_canonical_address() if sig != NULL_SIGNATURE else NULL_ADDRESS
 
 
-def _amend_signature(sig):
+def amend_signature(sig):
     """ We are making it in order to make signatures produced by eth_keys library
-        compatible with openzellelin ECDSA public key recovery.
+        compatible with openzeppelin ECDSA public key recovery.
 
         Please note:
         https://github.com/OpenZeppelin/openzeppelin-contracts/blob/c3f2ed81683bd0095673f525f7ee9639370a2432/contracts/cryptography/ECDSA.sol#L53

--- a/plasma_framework/python_tests/tests/contracts/root_chain/test_challenge_in_flight_exit_not_canonical.py
+++ b/plasma_framework/python_tests/tests/contracts/root_chain/test_challenge_in_flight_exit_not_canonical.py
@@ -1,7 +1,7 @@
 import pytest
 from eth_tester.exceptions import TransactionFailed
 
-from plasma_core.constants import NULL_ADDRESS, MIN_EXIT_PERIOD
+from plasma_core.constants import NULL_ADDRESS
 
 
 def test_challenge_in_flight_exit_not_canonical_should_succeed(testlang):
@@ -184,22 +184,3 @@ def test_challenge_in_flight_exit_twice_younger_position_should_fail(testlang):
 
     with pytest.raises(TransactionFailed):
         testlang.challenge_in_flight_exit_not_canonical(spend_id, double_spend_id_2, account=owner_2)
-
-
-@pytest.mark.skip("SE <> IFE interaction")
-def test_challenge_in_flight_exit_not_canonical_with_inputs_spent_should_fail(testlang):
-    owner_1, owner_2, amount = testlang.accounts[0], testlang.accounts[1], 100
-    deposit_id = testlang.deposit(owner_1, amount)
-    testlang.start_standard_exit(deposit_id, owner_1)
-    spend_id = testlang.spend_utxo([deposit_id], [owner_1], [(owner_2.address, NULL_ADDRESS, 100)])
-    double_spend_id = testlang.spend_utxo([deposit_id], [owner_1], [(owner_1.address, NULL_ADDRESS, 100)],
-                                          force_invalid=True)
-
-    testlang.forward_timestamp(2 * MIN_EXIT_PERIOD + 1)
-    testlang.process_exits(NULL_ADDRESS, 0, 1)
-
-    testlang.start_in_flight_exit(spend_id)
-
-    # Since IFE can be exited only from inputs, no further canonicity game required
-    with pytest.raises(TransactionFailed):
-        testlang.challenge_in_flight_exit_not_canonical(spend_id, double_spend_id, account=owner_2)

--- a/plasma_framework/python_tests/tests/contracts/root_chain/test_challenge_standard_exit.py
+++ b/plasma_framework/python_tests/tests/contracts/root_chain/test_challenge_standard_exit.py
@@ -1,6 +1,6 @@
 import pytest
 from eth_tester.exceptions import TransactionFailed
-from plasma_core.constants import NULL_ADDRESS, NULL_ADDRESS_HEX, MIN_EXIT_PERIOD, NULL_SIGNATURE
+from plasma_core.constants import NULL_ADDRESS, MIN_EXIT_PERIOD, NULL_SIGNATURE
 from plasma_core.transaction import Transaction
 from plasma_core.utils.transactions import decode_utxo_id
 
@@ -120,7 +120,6 @@ def test_challenge_standard_exit_wrong_oindex_should_fail(testlang):
     testlang.challenge_standard_exit(alice_utxo, alice_spend_id)
 
 
-@pytest.mark.skip("Includes starting an IFE")
 def test_challenge_standard_exit_with_in_flight_exit_tx_should_succeed(testlang):
     # exit cross-spend test, cases 3 and 4
     owner, amount = testlang.accounts[0], 100
@@ -130,17 +129,17 @@ def test_challenge_standard_exit_with_in_flight_exit_tx_should_succeed(testlang)
     ife_tx = Transaction(inputs=[decode_utxo_id(spend_id)], outputs=[(owner.address, NULL_ADDRESS, amount)])
     ife_tx.sign(0, owner, verifying_contract=testlang.root_chain.plasma_framework)
 
-    (encoded_spend, encoded_inputs, proofs, signatures) = testlang.get_in_flight_exit_info(None, spend_tx=ife_tx)
+    (encoded_spend, encoded_inputs, inputs_pos, proofs, signatures) = testlang.get_in_flight_exit_info(None, spend_tx=ife_tx)
     bond = testlang.root_chain.inFlightExitBond()
-    testlang.root_chain.startInFlightExit(encoded_spend, encoded_inputs, proofs, signatures,
+    testlang.root_chain.startInFlightExit(encoded_spend, encoded_inputs, proofs, signatures, inputs_pos,
                                           **{'value': bond, 'from': owner.address})
 
     testlang.start_standard_exit(spend_id, owner)
     assert testlang.get_standard_exit(spend_id).amount == 100
 
     exit_id = testlang.get_standard_exit_id(spend_id)
-    exiting_tx = testlang.get_transaction(spend_id)
     # FIXME a proper way of getting encoded body of IFE tx is to get it out of generated events
+    exiting_tx = testlang.child_chain.get_transaction(spend_id)
     testlang.root_chain.challengeStandardExit(exit_id, ife_tx.encoded, 0, ife_tx.signatures[0], exiting_tx.encoded)
 
-    assert testlang.get_standard_exit(spend_id) == [NULL_ADDRESS_HEX, 0, 0, False]
+    assert testlang.get_standard_exit(spend_id) == [owner.address, amount, spend_id, False]

--- a/plasma_framework/python_tests/tests/tests_utils/plasma_framework.py
+++ b/plasma_framework/python_tests/tests/tests_utils/plasma_framework.py
@@ -147,6 +147,10 @@ class PlasmaFramework:
 
         return filters
 
+    @property
+    def address(self):
+        return self.plasma_framework.address
+
     def blocks(self, block):
         return self.plasma_framework.blocks(block)
 


### PR DESCRIPTION
Refers #150.

The following PR enables the tests that were skipped at the first run of enabling the tests.
The enabled tests are related to IFE and SE interaction and to EIP712 signatures.