### PR TITLE
fix: mekle contract checks the index size

### DIFF
--- a/plasma_framework/contracts/src/utils/Merkle.sol
+++ b/plasma_framework/contracts/src/utils/Merkle.sol
@@ -25,7 +25,7 @@ library Merkle {
         require(proof.length % 32 == 0, "Length of Merkle proof must be a multiple of 32");
 
         // see https://github.com/omisego/plasma-contracts/issues/546
-        require(index < 2**(proof.length/32), "Index exceeds the possible size that matches with the proof");
+        require(index < 2**(proof.length/32), "Index does not match the length of the proof");
 
         bytes32 proofElement;
         bytes32 computedHash = keccak256(abi.encodePacked(LEAF_SALT, leaf));

--- a/plasma_framework/contracts/src/utils/Merkle.sol
+++ b/plasma_framework/contracts/src/utils/Merkle.sol
@@ -24,6 +24,9 @@ library Merkle {
         require(proof.length != 0, "Merkle proof must not be empty");
         require(proof.length % 32 == 0, "Length of Merkle proof must be a multiple of 32");
 
+        // see https://github.com/omisego/plasma-contracts/issues/546
+        require(index < 2**(proof.length/32), "Index exceeds the possible size that matches with the proof");
+
         bytes32 proofElement;
         bytes32 computedHash = keccak256(abi.encodePacked(LEAF_SALT, leaf));
         uint256 j = index;

--- a/plasma_framework/test/helpers/merkle.js
+++ b/plasma_framework/test/helpers/merkle.js
@@ -13,7 +13,7 @@ class MerkleNode {
 
 class MerkleTree {
     constructor(leaves, height = 0) {
-        const minHeightForLeaves = parseInt(Math.log2(leaves.length), 10) + 1;
+        const minHeightForLeaves = leaves.length === 1 ? 1 : parseInt(Math.ceil(Math.log2(leaves.length)), 10);
 
         if (height === 0) {
             this.height = minHeightForLeaves;

--- a/plasma_framework/test/src/utils/Merkle.test.js
+++ b/plasma_framework/test/src/utils/Merkle.test.js
@@ -114,6 +114,25 @@ contract('Merkle', () => {
                 'Merkle proof must not be empty',
             );
         });
+
+        it('should revert when index exceeds max possible size of proof data', async () => {
+            const leafIndex = 0;
+            const leafData = web3.utils.sha3(leaves[leafIndex]);
+            const proof = this.merkleTree.getInclusionProof(leaves[leafIndex]);
+            const rootHash = this.merkleTree.root;
+
+            const invalidIndex = maxSize;
+
+            await expectRevert(
+                this.merkleContract.checkMembership(
+                    leafData,
+                    invalidIndex,
+                    rootHash,
+                    proof,
+                ),
+                'Index exceeds the possible size that matches with the proof',
+            );
+        });
     });
 
     it('check membership for tree where some leaves are empty', async () => {

--- a/plasma_framework/test/src/utils/Merkle.test.js
+++ b/plasma_framework/test/src/utils/Merkle.test.js
@@ -115,7 +115,7 @@ contract('Merkle', () => {
             );
         });
 
-        it('should revert when index exceeds max possible size of proof data', async () => {
+        it('should revert when index exceeds max possible size according to proof data', async () => {
             const leafIndex = 0;
             const leafData = web3.utils.sha3(leaves[leafIndex]);
             const proof = this.merkleTree.getInclusionProof(leaves[leafIndex]);
@@ -130,7 +130,7 @@ contract('Merkle', () => {
                     rootHash,
                     proof,
                 ),
-                'Index exceeds the possible size that matches with the proof',
+                'Index does not match the length of the proof',
             );
         });
     });


### PR DESCRIPTION
### Note
Merkle contract did not check whether index exceeds the max amount with the proof size. This can lead to issue where given different indexes that exceeds the size, it can still pass the check due to the implementation of for loop.

closes: #546 