### PR TITLE
test: add integration tests

### DIFF
--- a/plasma_framework/python_tests/testlang/testlang.py
+++ b/plasma_framework/python_tests/testlang/testlang.py
@@ -484,3 +484,8 @@ class TestingLanguage:
         exit_id = self.root_chain.getInFlightExitId(in_flight_tx.encoded)
         exit_info = self.root_chain.inFlightExits(exit_id)
         return InFlightExit(self.root_chain, in_flight_tx, *exit_info)
+
+    def delete_in_flight_exit(self, in_flight_tx_id):
+        in_flight_tx = self.child_chain.get_transaction(in_flight_tx_id)
+        exit_id = self.root_chain.getInFlightExitId(in_flight_tx.encoded)
+        self.root_chain.deleteNonPiggybackedInFlightExit(exit_id)

--- a/plasma_framework/python_tests/tests/contracts/root_chain/test_delete_in_flight_exit.py
+++ b/plasma_framework/python_tests/tests/contracts/root_chain/test_delete_in_flight_exit.py
@@ -62,3 +62,16 @@ def test_deletion_fails_when_exit_is_in_first_phase(testlang):
 
     with pytest.raises(TransactionFailed):
         testlang.delete_in_flight_exit(spend_id)
+
+
+def test_deletion_fails_when_already_piggybacked(testlang):
+    owner, amount = testlang.accounts[0], 100
+    deposit_id = testlang.deposit(owner, amount)
+    spend_id = testlang.spend_utxo([deposit_id], [owner], outputs=[(owner.address, NULL_ADDRESS, amount)])
+
+    testlang.start_in_flight_exit(spend_id)
+    testlang.piggyback_in_flight_exit_input(spend_id, 0, owner)
+    testlang.forward_timestamp(FIRST_PERIOD_OVER)
+
+    with pytest.raises(TransactionFailed):
+        testlang.delete_in_flight_exit(spend_id)

--- a/plasma_framework/python_tests/tests/contracts/root_chain/test_delete_in_flight_exit.py
+++ b/plasma_framework/python_tests/tests/contracts/root_chain/test_delete_in_flight_exit.py
@@ -1,0 +1,64 @@
+import pytest
+from eth_tester.exceptions import TransactionFailed
+from plasma_core.constants import NULL_ADDRESS, NULL_ADDRESS_HEX, MIN_EXIT_PERIOD
+
+FIRST_PERIOD_OVER = MIN_EXIT_PERIOD + 1
+
+
+def test_delete_in_flight_exit_delete_exit_data_and_returns_bond(testlang):
+    owner, amount = testlang.accounts[0], 100
+    deposit_id = testlang.deposit(owner, amount)
+    spend_id = testlang.spend_utxo([deposit_id], [owner], outputs=[(owner.address, NULL_ADDRESS, amount)])
+
+    testlang.start_in_flight_exit(spend_id)
+    testlang.forward_timestamp(FIRST_PERIOD_OVER)
+
+    pre_balance = testlang.get_balance(owner)
+    testlang.delete_in_flight_exit(spend_id)
+    post_balance = testlang.get_balance(owner)
+
+    assert post_balance == pre_balance + testlang.root_chain.inFlightExitBond()
+
+    in_flight_exit = testlang.get_in_flight_exit(spend_id)
+    assert in_flight_exit.exit_start_timestamp == 0
+    assert in_flight_exit.exit_map == 0
+    assert in_flight_exit.bond_owner == NULL_ADDRESS_HEX
+    assert in_flight_exit.oldest_competitor == 0
+
+
+def test_can_restart_exit_after_deletion(testlang):
+    owner, amount = testlang.accounts[0], 100
+    deposit_id = testlang.deposit(owner, amount)
+    spend_id = testlang.spend_utxo([deposit_id], [owner], outputs=[(owner.address, NULL_ADDRESS, amount)])
+
+    testlang.start_in_flight_exit(spend_id)
+    testlang.forward_timestamp(FIRST_PERIOD_OVER)
+    testlang.delete_in_flight_exit(spend_id)
+    testlang.start_in_flight_exit(spend_id)
+
+
+def test_piggyback_on_deleted_exit_fails(testlang):
+    owner, amount = testlang.accounts[0], 100
+    deposit_id = testlang.deposit(owner, amount)
+    spend_id = testlang.spend_utxo([deposit_id], [owner], outputs=[(owner.address, NULL_ADDRESS, amount)])
+
+    testlang.start_in_flight_exit(spend_id)
+    testlang.forward_timestamp(FIRST_PERIOD_OVER)
+    testlang.delete_in_flight_exit(spend_id)
+    
+    with pytest.raises(TransactionFailed):
+        testlang.piggyback_in_flight_exit_input(spend_id, 0, owner)
+
+    with pytest.raises(TransactionFailed):
+        testlang.piggyback_in_flight_exit_output(spend_id, 0, owner)
+
+
+def test_deletion_fails_when_exit_is_in_first_phase(testlang):
+    owner, amount = testlang.accounts[0], 100
+    deposit_id = testlang.deposit(owner, amount)
+    spend_id = testlang.spend_utxo([deposit_id], [owner], outputs=[(owner.address, NULL_ADDRESS, amount)])
+
+    testlang.start_in_flight_exit(spend_id)
+    
+    with pytest.raises(TransactionFailed):
+        testlang.delete_in_flight_exit(spend_id)

--- a/plasma_framework/python_tests/tests/tests_utils/plasma_framework.py
+++ b/plasma_framework/python_tests/tests/tests_utils/plasma_framework.py
@@ -298,6 +298,9 @@ class PlasmaFramework:
 
         return self.plasma_framework.processExits(vault_id, token, top_exit_id, exits_to_process)
 
+    def deleteNonPiggybackedInFlightExit(self, exit_id):
+        return self.payment_exit_game.deleteNonPiggybackedInFlightExit(exit_id)
+
     def getInFlightExitId(self, tx):
         return self.payment_exit_game.getInFlightExitId(tx)
 

--- a/plasma_framework/test/endToEndTests/PaymentStandardExit.e2e.test.js
+++ b/plasma_framework/test/endToEndTests/PaymentStandardExit.e2e.test.js
@@ -358,7 +358,6 @@ contract('PaymentExitGame - Standard Exit - End to End Tests', ([_deployer, _mai
             });
         });
 
-
         describe('Given Alice deposited with ERC20 token', () => {
             before(async () => {
                 await this.erc20.transfer(alice, DEPOSIT_VALUE, { from: richFather });


### PR DESCRIPTION
Closes #549
Changes:
 * add integration tests for `deleteNonPiggybackedInFlightExit`
 * add test that checks if in-flight exit is not processed before exit period passes