### PR TITLE
docs: explain that in-flight transaction inputs/outputs are not available to spent on child chain

### DIFF
--- a/plasma_framework/contracts/mocks/exits/SpyPlasmaFrameworkForExitGame.sol
+++ b/plasma_framework/contracts/mocks/exits/SpyPlasmaFrameworkForExitGame.sol
@@ -58,8 +58,8 @@ contract SpyPlasmaFrameworkForExitGame is PlasmaFramework {
         blocks[_blockNum] = BlockModel.Block(_root, _timestamp);
     }
 
-    function setOutputSpent(bytes32 _outputId) external {
-        isOutputSpent[_outputId] = true;
+    function setOutputFinalized(bytes32 _outputId) external {
+        isOutputFinalized[_outputId] = true;
     }
 
     /**

--- a/plasma_framework/contracts/mocks/exits/payment/routers/PaymentInFlightExitRouterMock.sol
+++ b/plasma_framework/contracts/mocks/exits/payment/routers/PaymentInFlightExitRouterMock.sol
@@ -69,9 +69,9 @@ contract PaymentInFlightExitRouterMock is FailFastReentrancyGuard, PaymentInFlig
         return inFlightExitMap.exits[exitId].outputs[outputIndex];
     }
 
-    /** calls the flagOutputSpent function on behalf of the exit game */
-    function proxyFlagOutputSpent(bytes32 _outputId) public {
-        framework.flagOutputSpent(_outputId);
+    /** calls the flagOutputFinalized function on behalf of the exit game */
+    function proxyFlagOutputFinalized(bytes32 _outputId) public {
+        framework.flagOutputFinalized(_outputId);
     }
 
     /**

--- a/plasma_framework/contracts/mocks/exits/payment/routers/PaymentStandardExitRouterMock.sol
+++ b/plasma_framework/contracts/mocks/exits/payment/routers/PaymentStandardExitRouterMock.sol
@@ -29,8 +29,8 @@ contract PaymentStandardExitRouterMock is PaymentStandardExitRouter {
         PaymentStandardExitRouter.standardExitMap.exits[_exitId] = _exitData;
     }
 
-    function proxyFlagOutputSpent(bytes32 _outputId) public {
-        framework.flagOutputSpent(_outputId);
+    function proxyFlagOutputFinalized(bytes32 _outputId) public {
+        framework.flagOutputFinalized(_outputId);
     }
 
     function depositFundForTest() public payable {}

--- a/plasma_framework/contracts/mocks/framework/DummyExitGame.sol
+++ b/plasma_framework/contracts/mocks/framework/DummyExitGame.sol
@@ -47,12 +47,12 @@ contract DummyExitGame is IExitProcessor {
         priorityFromEnqueue = exitGameController.enqueue(_vaultId, _token, _exitableAt, PosLib.decode(_txPos), _exitId, _exitProcessor);
     }
 
-    function proxyBatchFlagOutputsSpent(bytes32[] memory _outputIds) public {
-        exitGameController.batchFlagOutputsSpent(_outputIds);
+    function proxyBatchFlagOutputsFinalized(bytes32[] memory _outputIds) public {
+        exitGameController.batchFlagOutputsFinalized(_outputIds);
     }
 
-    function proxyFlagOutputSpent(bytes32 _outputId) public {
-        exitGameController.flagOutputSpent(_outputId);
+    function proxyFlagOutputFinalized(bytes32 _outputId) public {
+        exitGameController.flagOutputFinalized(_outputId);
     }
 
     // setter function only for test, not a real Exit Game function

--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentProcessInFlightExit.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentProcessInFlightExit.sol
@@ -148,7 +148,7 @@ library PaymentProcessInFlightExit {
                 sameTokenIndex++;
             }
         }
-        return framework.isAnyOutputsFinalized(outputIdsOfInputs);
+        return framework.isAnyOutputFinalized(outputIdsOfInputs);
     }
 
     function shouldWithdrawInput(

--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentProcessInFlightExit.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentProcessInFlightExit.sol
@@ -148,7 +148,7 @@ library PaymentProcessInFlightExit {
                 sameTokenIndex++;
             }
         }
-        return framework.isAnyOutputsSpent(outputIdsOfInputs);
+        return framework.isAnyOutputsFinalized(outputIdsOfInputs);
     }
 
     function shouldWithdrawInput(
@@ -164,7 +164,7 @@ library PaymentProcessInFlightExit {
     {
         return withdrawal.token == token &&
                 exit.isInputPiggybacked(index) &&
-                !controller.framework.isOutputSpent(withdrawal.outputId);
+                !controller.framework.isOutputFinalized(withdrawal.outputId);
     }
 
     function shouldWithdrawOutput(
@@ -180,7 +180,7 @@ library PaymentProcessInFlightExit {
     {
         return withdrawal.token == token &&
                 exit.isOutputPiggybacked(index) &&
-                !controller.framework.isOutputSpent(withdrawal.outputId);
+                !controller.framework.isOutputFinalized(withdrawal.outputId);
     }
 
     function withdrawFromVault(
@@ -218,7 +218,7 @@ library PaymentProcessInFlightExit {
                 indexForOutputIds++;
             }
         }
-        framework.batchFlagOutputsSpent(outputIdsToFlag);
+        framework.batchFlagOutputsFinalized(outputIdsToFlag);
     }
 
     function flagOutputsWhenCanonical(
@@ -256,7 +256,7 @@ library PaymentProcessInFlightExit {
                 indexForOutputIds++;
             }
         }
-        framework.batchFlagOutputsSpent(outputIdsToFlag);
+        framework.batchFlagOutputsFinalized(outputIdsToFlag);
     }
 
     function clearPiggybackInputFlag(

--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentProcessStandardExit.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentProcessStandardExit.sol
@@ -48,13 +48,13 @@ library PaymentProcessStandardExit {
     {
         PaymentExitDataModel.StandardExit memory exit = exitMap.exits[exitId];
 
-        if (!exit.exitable || self.framework.isOutputSpent(exit.outputId)) {
+        if (!exit.exitable || self.framework.isOutputFinalized(exit.outputId)) {
             emit ExitOmitted(exitId);
             delete exitMap.exits[exitId];
             return;
         }
 
-        self.framework.flagOutputSpent(exit.outputId);
+        self.framework.flagOutputFinalized(exit.outputId);
 
         // we do not want to block a queue if bond return is unsuccessful
         bool success = SafeEthTransfer.transferReturnResult(exit.exitTarget, exit.bondSize, self.safeGasStipend);

--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentStartStandardExit.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentStartStandardExit.sol
@@ -142,7 +142,7 @@ library PaymentStartStandardExit {
         PaymentExitDataModel.StandardExit memory exit = exitMap.exits[data.exitId];
         require(exit.amount == 0, "Exit has already started");
 
-        require(self.framework.isOutputSpent(data.outputId) == false, "Output is already spent");
+        require(self.framework.isOutputFinalized(data.outputId) == false, "Output is already spent");
     }
 
     function isStandardFinalized(StartStandardExitData memory data)

--- a/plasma_framework/contracts/src/framework/ExitGameController.sol
+++ b/plasma_framework/contracts/src/framework/ExitGameController.sol
@@ -187,7 +187,7 @@ contract ExitGameController is ExitGameRegistry {
      * @notice Checks whether any of the output with the given outputIds is already spent
      * @param _outputIds Output IDs to check
      */
-    function isAnyOutputsFinalized(bytes32[] calldata _outputIds) external view returns (bool) {
+    function isAnyOutputFinalized(bytes32[] calldata _outputIds) external view returns (bool) {
         for (uint i = 0; i < _outputIds.length; i++) {
             if (isOutputFinalized[_outputIds[i]] == true) {
                 return true;

--- a/plasma_framework/contracts/src/framework/ExitGameController.sol
+++ b/plasma_framework/contracts/src/framework/ExitGameController.sol
@@ -19,7 +19,7 @@ contract ExitGameController is ExitGameRegistry {
     // hashed (vault id, token) => PriorityQueue
     mapping (bytes32 => PriorityQueue) public exitsQueues;
     // outputId => bool
-    mapping (bytes32 => bool) public isOutputSpent;
+    mapping (bytes32 => bool) public isOutputFinalized;
     bool private mutex = false;
 
     event ExitQueueAdded(
@@ -187,9 +187,9 @@ contract ExitGameController is ExitGameRegistry {
      * @notice Checks whether any of the output with the given outputIds is already spent
      * @param _outputIds Output IDs to check
      */
-    function isAnyOutputsSpent(bytes32[] calldata _outputIds) external view returns (bool) {
+    function isAnyOutputsFinalized(bytes32[] calldata _outputIds) external view returns (bool) {
         for (uint i = 0; i < _outputIds.length; i++) {
-            if (isOutputSpent[_outputIds[i]] == true) {
+            if (isOutputFinalized[_outputIds[i]] == true) {
                 return true;
             }
         }
@@ -200,10 +200,10 @@ contract ExitGameController is ExitGameRegistry {
      * @notice Batch flags already spent outputs
      * @param _outputIds Output IDs to flag
      */
-    function batchFlagOutputsSpent(bytes32[] calldata _outputIds) external onlyFromNonQuarantinedExitGame {
+    function batchFlagOutputsFinalized(bytes32[] calldata _outputIds) external onlyFromNonQuarantinedExitGame {
         for (uint i = 0; i < _outputIds.length; i++) {
             require(_outputIds[i] != bytes32(""), "Should not flag with empty outputId");
-            isOutputSpent[_outputIds[i]] = true;
+            isOutputFinalized[_outputIds[i]] = true;
         }
     }
 
@@ -211,9 +211,9 @@ contract ExitGameController is ExitGameRegistry {
      * @notice Flags a single output as spent
      * @param _outputId The output ID to flag as spent
      */
-    function flagOutputSpent(bytes32 _outputId) external onlyFromNonQuarantinedExitGame {
+    function flagOutputFinalized(bytes32 _outputId) external onlyFromNonQuarantinedExitGame {
         require(_outputId != bytes32(""), "Should not flag with empty outputId");
-        isOutputSpent[_outputId] = true;
+        isOutputFinalized[_outputId] = true;
     }
 
     function getNextExit(uint256 vaultId, address token) external view returns (uint256) {

--- a/plasma_framework/docs/contracts/ExitGameController.md
+++ b/plasma_framework/docs/contracts/ExitGameController.md
@@ -19,7 +19,7 @@ Controls the logic and functions for ExitGame to interact with the PlasmaFramewo
 //public members
 mapping(bytes32 => contract IExitProcessor) public delegations;
 mapping(bytes32 => contract PriorityQueue) public exitsQueues;
-mapping(bytes32 => bool) public isOutputSpent;
+mapping(bytes32 => bool) public isOutputFinalized;
 
 //private members
 bool private mutex;
@@ -60,9 +60,9 @@ modifier nonReentrant() internal
 - [addExitQueue(uint256 vaultId, address token)](#addexitqueue)
 - [enqueue(uint256 vaultId, address token, uint64 exitableAt, struct PosLib.Position txPos, uint160 exitId, IExitProcessor exitProcessor)](#enqueue)
 - [processExits(uint256 vaultId, address token, uint160 topExitId, uint256 maxExitsToProcess)](#processexits)
-- [isAnyOutputsSpent(bytes32[] _outputIds)](#isanyoutputsspent)
-- [batchFlagOutputsSpent(bytes32[] _outputIds)](#batchflagoutputsspent)
-- [flagOutputSpent(bytes32 _outputId)](#flagoutputspent)
+- [isAnyOutputsFinalized(bytes32[] _outputIds)](#isanyoutputsfinalized)
+- [batchFlagOutputsFinalized(bytes32[] _outputIds)](#batchflagoutputsfinalized)
+- [flagOutputFinalized(bytes32 _outputId)](#flagoutputfinalized)
 - [getNextExit(uint256 vaultId, address token)](#getnextexit)
 - [exitQueueKey(uint256 vaultId, address token)](#exitqueuekey)
 - [hasExitQueue(bytes32 queueKey)](#hasexitqueue)
@@ -189,12 +189,12 @@ Total number of processed exits
 | topExitId | uint160 | Unique identifier for prioritizing the first exit to process. Set to zero to skip this check. | 
 | maxExitsToProcess | uint256 | Maximum number of exits to process | 
 
-### isAnyOutputsSpent
+### isAnyOutputsFinalized
 
 Checks whether any of the output with the given outputIds is already spent
 
 ```js
-function isAnyOutputsSpent(bytes32[] _outputIds) external view
+function isAnyOutputsFinalized(bytes32[] _outputIds) external view
 returns(bool)
 ```
 
@@ -204,12 +204,12 @@ returns(bool)
 | ------------- |------------- | -----|
 | _outputIds | bytes32[] | Output IDs to check | 
 
-### batchFlagOutputsSpent
+### batchFlagOutputsFinalized
 
 Batch flags already spent outputs
 
 ```js
-function batchFlagOutputsSpent(bytes32[] _outputIds) external nonpayable onlyFromNonQuarantinedExitGame 
+function batchFlagOutputsFinalized(bytes32[] _outputIds) external nonpayable onlyFromNonQuarantinedExitGame 
 ```
 
 **Arguments**
@@ -218,12 +218,12 @@ function batchFlagOutputsSpent(bytes32[] _outputIds) external nonpayable onlyFro
 | ------------- |------------- | -----|
 | _outputIds | bytes32[] | Output IDs to flag | 
 
-### flagOutputSpent
+### flagOutputFinalized
 
 Flags a single output as spent
 
 ```js
-function flagOutputSpent(bytes32 _outputId) external nonpayable onlyFromNonQuarantinedExitGame 
+function flagOutputFinalized(bytes32 _outputId) external nonpayable onlyFromNonQuarantinedExitGame 
 ```
 
 **Arguments**

--- a/plasma_framework/docs/contracts/ExitGameController.md
+++ b/plasma_framework/docs/contracts/ExitGameController.md
@@ -60,7 +60,7 @@ modifier nonReentrant() internal
 - [addExitQueue(uint256 vaultId, address token)](#addexitqueue)
 - [enqueue(uint256 vaultId, address token, uint64 exitableAt, struct PosLib.Position txPos, uint160 exitId, IExitProcessor exitProcessor)](#enqueue)
 - [processExits(uint256 vaultId, address token, uint160 topExitId, uint256 maxExitsToProcess)](#processexits)
-- [isAnyOutputsFinalized(bytes32[] _outputIds)](#isanyoutputsfinalized)
+- [isAnyOutputFinalized(bytes32[] _outputIds)](#isanyoutputfinalized)
 - [batchFlagOutputsFinalized(bytes32[] _outputIds)](#batchflagoutputsfinalized)
 - [flagOutputFinalized(bytes32 _outputId)](#flagoutputfinalized)
 - [getNextExit(uint256 vaultId, address token)](#getnextexit)
@@ -189,12 +189,12 @@ Total number of processed exits
 | topExitId | uint160 | Unique identifier for prioritizing the first exit to process. Set to zero to skip this check. | 
 | maxExitsToProcess | uint256 | Maximum number of exits to process | 
 
-### isAnyOutputsFinalized
+### isAnyOutputFinalized
 
 Checks whether any of the output with the given outputIds is already spent
 
 ```js
-function isAnyOutputsFinalized(bytes32[] _outputIds) external view
+function isAnyOutputFinalized(bytes32[] _outputIds) external view
 returns(bool)
 ```
 

--- a/plasma_framework/docs/contracts/PaymentChallengeIFENotCanonical.md
+++ b/plasma_framework/docs/contracts/PaymentChallengeIFENotCanonical.md
@@ -27,8 +27,8 @@ event InFlightExitChallengeResponded(address indexed challenger, bytes32 indexed
 - [buildController(PlasmaFramework framework, SpendingConditionRegistry spendingConditionRegistry, uint256 supportedTxType)](#buildcontroller)
 - [challenge(struct PaymentChallengeIFENotCanonical.Controller self, struct PaymentExitDataModel.InFlightExitMap inFlightExitMap, struct PaymentInFlightExitRouterArgs.ChallengeCanonicityArgs args)](#challenge)
 - [respond(struct PaymentChallengeIFENotCanonical.Controller self, struct PaymentExitDataModel.InFlightExitMap inFlightExitMap, bytes inFlightTx, uint256 inFlightTxPos, bytes inFlightTxInclusionProof)](#respond)
-- [verifyAndDeterminePositionOfTransactionIncludedInBlock(bytes txbytes, struct PosLib.Position utxoPos, bytes32 root, bytes inclusionProof)](#verifyanddeterminepositionoftransactionincludedinblock)
-- [verifyCompetingTxFinalized(struct PaymentChallengeIFENotCanonical.Controller self, struct PaymentInFlightExitRouterArgs.ChallengeCanonicityArgs args)](#verifycompetingtxfinalized)
+- [verifyPositionOfTransactionIncludedInBlock(bytes txbytes, struct PosLib.Position txPos, bytes32 root, bytes inclusionProof)](#verifypositionoftransactionincludedinblock)
+- [verifyCompetingTxFinalizedInThePosition(struct PaymentChallengeIFENotCanonical.Controller self, struct PaymentInFlightExitRouterArgs.ChallengeCanonicityArgs args)](#verifycompetingtxfinalizedintheposition)
 
 ### buildController
 
@@ -85,11 +85,10 @@ function respond(struct PaymentChallengeIFENotCanonical.Controller self, struct 
 | inFlightTxPos | uint256 | The UTXO position of the in-flight exit. Should hardcode 0 for the outputIndex. | 
 | inFlightTxInclusionProof | bytes | Inclusion proof for the in-flight tx | 
 
-### verifyAndDeterminePositionOfTransactionIncludedInBlock
+### verifyPositionOfTransactionIncludedInBlock
 
 ```js
-function verifyAndDeterminePositionOfTransactionIncludedInBlock(bytes txbytes, struct PosLib.Position utxoPos, bytes32 root, bytes inclusionProof) private pure
-returns(uint256)
+function verifyPositionOfTransactionIncludedInBlock(bytes txbytes, struct PosLib.Position txPos, bytes32 root, bytes inclusionProof) private pure
 ```
 
 **Arguments**
@@ -97,14 +96,14 @@ returns(uint256)
 | Name        | Type           | Description  |
 | ------------- |------------- | -----|
 | txbytes | bytes |  | 
-| utxoPos | struct PosLib.Position |  | 
+| txPos | struct PosLib.Position |  | 
 | root | bytes32 |  | 
 | inclusionProof | bytes |  | 
 
-### verifyCompetingTxFinalized
+### verifyCompetingTxFinalizedInThePosition
 
 ```js
-function verifyCompetingTxFinalized(struct PaymentChallengeIFENotCanonical.Controller self, struct PaymentInFlightExitRouterArgs.ChallengeCanonicityArgs args) private view
+function verifyCompetingTxFinalizedInThePosition(struct PaymentChallengeIFENotCanonical.Controller self, struct PaymentInFlightExitRouterArgs.ChallengeCanonicityArgs args) private view
 returns(uint256)
 ```
 

--- a/plasma_framework/docs/integration-docs/integration-doc.md
+++ b/plasma_framework/docs/integration-docs/integration-doc.md
@@ -629,9 +629,9 @@ PaymentExitGame.startInFlightExit([
 
 ### Piggybacking on an in-flight exit input / output
 
-To exit input or output of in-flight transaction user has to piggyback on it.
+To exit input or output of an in-flight transaction user has to piggyback on it.
 
-When in-flight transaction exits child chain removes the inputs of the in-flight transaction from the spendable set and it no longer can be spent. Calls to child chain to spend the inputs or outputs of the in-flight transaction result in `submit:utxo_not_found` error. The effect of input or output not being available to spend is not visible in contract's state until exit is processed. After the in-flight exit is processed `PlasmaFramework.isOutputFinalized(piggybackedInputOrOutputPosition)` is set to false.
+When in-flight transaction exits, child chain removes the inputs of the in-flight transaction from the spendable set and it no longer can be spent. Calls to child chain to spend the inputs or outputs of the in-flight transaction result in `submit:utxo_not_found` error. The effect of input or output not being available to spend is not visible in contract's state until exit is processed. After the in-flight exit is processed `PlasmaFramework.isOutputFinalized(piggybackedInputOrOutputPosition)` is set to false.
 
 1. Get the amount of ETH to cover the bond for piggybacking in-flight exit as described [here](#in-flight-exit-bonds).
 

--- a/plasma_framework/docs/integration-docs/integration-doc.md
+++ b/plasma_framework/docs/integration-docs/integration-doc.md
@@ -629,6 +629,10 @@ PaymentExitGame.startInFlightExit([
 
 ### Piggybacking on an in-flight exit input / output
 
+To exit input or output of in-flight transaction user has to piggyback on it.
+
+When in-flight transaction exits child chain removes the inputs of the in-flight transaction from the spendable set and it no longer can be spent. Calls to child chain to spend the inputs or outputs of the in-flight transaction result in `submit:utxo_not_found` error. The effect of input or output not being available to spend is not visible in contract's state until exit is processed. After the in-flight exit is processed `PlasmaFramework.isOutputFinalized(piggybackedInputOrOutputPosition)` is set to false.
+
 1. Get the amount of ETH to cover the bond for piggybacking in-flight exit as described [here](#in-flight-exit-bonds).
 
 2. To piggyback on in-flight exit input call:

--- a/plasma_framework/docs/integration-docs/integration-doc.md
+++ b/plasma_framework/docs/integration-docs/integration-doc.md
@@ -631,7 +631,7 @@ PaymentExitGame.startInFlightExit([
 
 To exit an input or output of an in-flight transaction the user has to piggyback on it.
 
-When in-flight transaction exits, child chain removes the inputs of the in-flight transaction from the spendable set and it no longer can be spent. Calls to child chain to spend the inputs or outputs of the in-flight transaction result in `submit:utxo_not_found` error. The effect of input or output not being available to spend is not visible in contract's state until exit is processed. After the in-flight exit is processed `PlasmaFramework.isOutputFinalized(piggybackedInputOrOutputPosition)` is set to false.
+When in-flight transaction exits, the child chain removes the inputs of the in-flight transaction from the spendable set and they can no longer be spent. Calls to the child chain to spend the inputs or outputs of an in-flight transaction result in `submit:utxo_not_found` error. The effect of an input or output not being available to spend is not visible in contract's state until the exit is processed. After the in-flight exit is processed `PlasmaFramework.isOutputFinalized(piggybackedInputOrOutputPosition)` is set to true.
 
 1. Get the amount of ETH to cover the bond for piggybacking in-flight exit as described [here](#in-flight-exit-bonds).
 

--- a/plasma_framework/docs/integration-docs/integration-doc.md
+++ b/plasma_framework/docs/integration-docs/integration-doc.md
@@ -629,7 +629,7 @@ PaymentExitGame.startInFlightExit([
 
 ### Piggybacking on an in-flight exit input / output
 
-To exit input or output of an in-flight transaction user has to piggyback on it.
+To exit an input or output of an in-flight transaction the user has to piggyback on it.
 
 When in-flight transaction exits, child chain removes the inputs of the in-flight transaction from the spendable set and it no longer can be spent. Calls to child chain to spend the inputs or outputs of the in-flight transaction result in `submit:utxo_not_found` error. The effect of input or output not being available to spend is not visible in contract's state until exit is processed. After the in-flight exit is processed `PlasmaFramework.isOutputFinalized(piggybackedInputOrOutputPosition)` is set to false.
 

--- a/plasma_framework/python_tests/tests/contracts/root_chain/test_process_exits.py
+++ b/plasma_framework/python_tests/tests/contracts/root_chain/test_process_exits.py
@@ -61,7 +61,7 @@ def test_successful_process_exit_should_clear_exit_fields_and_set_output_as_spen
     standard_exit = testlang.get_standard_exit(utxo_pos)
     assert standard_exit.owner == NULL_ADDRESS_HEX
     assert standard_exit.amount == 0
-    assert testlang.root_chain.isOutputSpent(started_exit.output_id)
+    assert testlang.root_chain.isOutputFinalized(started_exit.output_id)
 
 
 def test_process_exits_in_flight_exit_should_succeed(testlang):
@@ -123,7 +123,7 @@ def test_finalize_exits_for_erc20_should_succeed(testlang, plasma_framework, tok
 
     finalized_standard_exit = testlang.get_standard_exit(spend_id)
     assert finalized_standard_exit == [NULL_ADDRESS_HEX, 0, 0, False]
-    assert testlang.root_chain.isOutputSpent(standard_exit.output_id)
+    assert testlang.root_chain.isOutputFinalized(standard_exit.output_id)
     assert token.balanceOf(owner.address) == pre_balance + amount
 
 
@@ -397,8 +397,8 @@ def test_finalize_in_flight_exit_finalizes_only_piggybacked_outputs(testlang, pl
 
     in_flight_exit = testlang.get_in_flight_exit(spend_id)
 
-    assert plasma_framework.isOutputSpent(output_id_0)
-    assert not plasma_framework.isOutputSpent(output_id_1)
+    assert plasma_framework.isOutputFinalized(output_id_0)
+    assert not plasma_framework.isOutputFinalized(output_id_1)
 
 
 def test_finalize_exits_priority_for_in_flight_exits_corresponds_to_the_age_of_youngest_input(testlang):
@@ -469,8 +469,8 @@ def test_finalize_in_flight_exit_with_erc20_token_should_succeed(testlang, token
     assert in_flight_exit.bond_owner == NULL_ADDRESS_HEX
     assert in_flight_exit.oldest_competitor == 0
 
-    assert plasma_framework.isOutputSpent(output_id)
-    assert plasma_framework.isOutputSpent(input_id)
+    assert plasma_framework.isOutputFinalized(output_id)
+    assert plasma_framework.isOutputFinalized(input_id)
 
 
 def test_finalize_in_flight_exit_with_erc20_token_should_transfer_funds_and_bond(testlang, token):
@@ -592,8 +592,8 @@ def test_when_processing_ife_finalization_of_erc20_token_does_not_clean_up_eth_o
     testlang.process_exits(token.address, 0, 1)
     in_flight_exit = testlang.get_in_flight_exit(spend_id)
 
-    assert plasma_framework.isOutputSpent(erc20_output_id)
-    assert not plasma_framework.isOutputSpent(eth_output_id)
+    assert plasma_framework.isOutputFinalized(erc20_output_id)
+    assert not plasma_framework.isOutputFinalized(eth_output_id)
 
     assert in_flight_exit.output_piggybacked(0)
     assert not in_flight_exit.output_piggybacked(1)

--- a/plasma_framework/python_tests/tests/tests_utils/plasma_framework.py
+++ b/plasma_framework/python_tests/tests/tests_utils/plasma_framework.py
@@ -354,5 +354,5 @@ class PlasmaFramework:
 
     # additional convenience proxies (not taken from RootChain) #
 
-    def isOutputSpent(self, utxo_pos):
-        return self.plasma_framework.isOutputSpent(utxo_pos)
+    def isOutputFinalized(self, utxo_pos):
+        return self.plasma_framework.isOutputFinalized(utxo_pos)

--- a/plasma_framework/test/endToEndTests/PaymentInFlightExit.e2e.test.js
+++ b/plasma_framework/test/endToEndTests/PaymentInFlightExit.e2e.test.js
@@ -187,7 +187,7 @@ contract('PaymentExitGame - In-flight Exit - End to End Tests', ([_deployer, _ma
 
                             it('should mark output as spent', async () => {
                                 const outputId = computeNormalOutputId(this.inFlightTxRaw, this.exitingOutputIndex);
-                                expect(await this.framework.isOutputSpent(outputId)).to.be.true;
+                                expect(await this.framework.isOutputFinalized(outputId)).to.be.true;
                             });
                         });
                     });

--- a/plasma_framework/test/src/exits/payment/controllers/PaymentProcessInFlightExit.test.js
+++ b/plasma_framework/test/src/exits/payment/controllers/PaymentProcessInFlightExit.test.js
@@ -354,7 +354,7 @@ contract('PaymentProcessInFlightExit', ([_, ifeBondOwner, inputOwner1, inputOwne
                 await this.exitGame.setInFlightExit(DUMMY_EXIT_ID, exit);
 
                 // flags the first input and piggybacks the two ETH inputs (first and second)
-                await this.exitGame.proxyFlagOutputSpent(TEST_OUTPUT_ID_FOR_INPUT_1);
+                await this.exitGame.proxyFlagOutputFinalized(TEST_OUTPUT_ID_FOR_INPUT_1);
                 await this.exitGame.setInFlightExitInputPiggybacked(DUMMY_EXIT_ID, 0);
                 await this.exitGame.setInFlightExitInputPiggybacked(DUMMY_EXIT_ID, 1);
             });
@@ -402,7 +402,7 @@ contract('PaymentProcessInFlightExit', ([_, ifeBondOwner, inputOwner1, inputOwne
             });
 
             it('should NOT withdraw fund from vault for the piggybacked but already spent input', async () => {
-                await this.exitGame.proxyFlagOutputSpent(TEST_OUTPUT_ID_FOR_INPUT_1);
+                await this.exitGame.proxyFlagOutputFinalized(TEST_OUTPUT_ID_FOR_INPUT_1);
                 const { receipt } = await this.exitGame.processExit(DUMMY_EXIT_ID, VAULT_ID.ETH, ETH);
                 let didNotCallEthWithdraw = false;
                 try {
@@ -467,19 +467,19 @@ contract('PaymentProcessInFlightExit', ([_, ifeBondOwner, inputOwner1, inputOwne
             it('should only flag piggybacked inputs with the same token as spent', async () => {
                 await this.exitGame.processExit(DUMMY_EXIT_ID, VAULT_ID.ETH, ETH);
                 // piggybacked input
-                expect(await this.framework.isOutputSpent(TEST_OUTPUT_ID_FOR_INPUT_1)).to.be.true;
+                expect(await this.framework.isOutputFinalized(TEST_OUTPUT_ID_FOR_INPUT_1)).to.be.true;
                 // non-piggybacked input
-                expect(await this.framework.isOutputSpent(TEST_OUTPUT_ID_FOR_INPUT_2)).to.be.false;
+                expect(await this.framework.isOutputFinalized(TEST_OUTPUT_ID_FOR_INPUT_2)).to.be.false;
                 // piggybacked input but different token
-                expect(await this.framework.isOutputSpent(TEST_OUTPUT_ID_FOR_INPUT_3)).to.be.false;
+                expect(await this.framework.isOutputFinalized(TEST_OUTPUT_ID_FOR_INPUT_3)).to.be.false;
             });
 
             it('should NOT flag output as spent', async () => {
                 await this.exitGame.processExit(DUMMY_EXIT_ID, VAULT_ID.ETH, ETH);
 
-                expect(await this.framework.isOutputSpent(TEST_OUTPUT_ID_FOR_OUTPUT_1)).to.be.false;
-                expect(await this.framework.isOutputSpent(TEST_OUTPUT_ID_FOR_OUTPUT_2)).to.be.false;
-                expect(await this.framework.isOutputSpent(TEST_OUTPUT_ID_FOR_OUTPUT_3)).to.be.false;
+                expect(await this.framework.isOutputFinalized(TEST_OUTPUT_ID_FOR_OUTPUT_1)).to.be.false;
+                expect(await this.framework.isOutputFinalized(TEST_OUTPUT_ID_FOR_OUTPUT_2)).to.be.false;
+                expect(await this.framework.isOutputFinalized(TEST_OUTPUT_ID_FOR_OUTPUT_3)).to.be.false;
             });
 
             it('should emit InFlightExitInputWithdrawn event', async () => {
@@ -525,7 +525,7 @@ contract('PaymentProcessInFlightExit', ([_, ifeBondOwner, inputOwner1, inputOwne
             });
 
             it('should NOT withdraw from fund vault for the piggybacked but already spent output', async () => {
-                await this.exitGame.proxyFlagOutputSpent(TEST_OUTPUT_ID_FOR_OUTPUT_1);
+                await this.exitGame.proxyFlagOutputFinalized(TEST_OUTPUT_ID_FOR_OUTPUT_1);
                 const { receipt } = await this.exitGame.processExit(DUMMY_EXIT_ID, VAULT_ID.ETH, ETH);
                 let didNotCallEthWithdraw = false;
                 try {
@@ -590,21 +590,21 @@ contract('PaymentProcessInFlightExit', ([_, ifeBondOwner, inputOwner1, inputOwne
             it('should flag ALL inputs with the same token as spent', async () => {
                 await this.exitGame.processExit(DUMMY_EXIT_ID, VAULT_ID.ETH, ETH);
                 // same token, both piggybacked and non-piggybacked cases
-                expect(await this.framework.isOutputSpent(TEST_OUTPUT_ID_FOR_INPUT_1)).to.be.true;
-                expect(await this.framework.isOutputSpent(TEST_OUTPUT_ID_FOR_INPUT_2)).to.be.true;
+                expect(await this.framework.isOutputFinalized(TEST_OUTPUT_ID_FOR_INPUT_1)).to.be.true;
+                expect(await this.framework.isOutputFinalized(TEST_OUTPUT_ID_FOR_INPUT_2)).to.be.true;
                 // different token
-                expect(await this.framework.isOutputSpent(TEST_OUTPUT_ID_FOR_INPUT_3)).to.be.false;
+                expect(await this.framework.isOutputFinalized(TEST_OUTPUT_ID_FOR_INPUT_3)).to.be.false;
             });
 
             it('should only flag piggybacked output with the same token as spent', async () => {
                 await this.exitGame.processExit(DUMMY_EXIT_ID, VAULT_ID.ETH, ETH);
 
                 // piggybacked output of same token
-                expect(await this.framework.isOutputSpent(TEST_OUTPUT_ID_FOR_OUTPUT_1)).to.be.true;
+                expect(await this.framework.isOutputFinalized(TEST_OUTPUT_ID_FOR_OUTPUT_1)).to.be.true;
                 // non piggybacked output of same token
-                expect(await this.framework.isOutputSpent(TEST_OUTPUT_ID_FOR_OUTPUT_2)).to.be.false;
+                expect(await this.framework.isOutputFinalized(TEST_OUTPUT_ID_FOR_OUTPUT_2)).to.be.false;
                 // different token
-                expect(await this.framework.isOutputSpent(TEST_OUTPUT_ID_FOR_OUTPUT_3)).to.be.false;
+                expect(await this.framework.isOutputFinalized(TEST_OUTPUT_ID_FOR_OUTPUT_3)).to.be.false;
             });
 
             it('should emit InFlightExitOutputWithdrawn event', async () => {

--- a/plasma_framework/test/src/exits/payment/controllers/PaymentProcessStandardExit.test.js
+++ b/plasma_framework/test/src/exits/payment/controllers/PaymentProcessStandardExit.test.js
@@ -133,7 +133,7 @@ contract('PaymentStandardExitRouter', ([_, alice]) => {
             const exitId = 1;
             const testExitData = getTestExitData(true, ETH);
             await this.exitGame.setExit(exitId, testExitData);
-            await this.exitGame.proxyFlagOutputSpent(testExitData.outputId);
+            await this.exitGame.proxyFlagOutputFinalized(testExitData.outputId);
 
             const { logs } = await this.exitGame.processExit(exitId, VAULT_ID.ETH, ETH);
 
@@ -154,7 +154,7 @@ contract('PaymentStandardExitRouter', ([_, alice]) => {
 
             await this.exitGame.processExit(exitId, VAULT_ID.ETH, ETH);
 
-            expect(await this.framework.isOutputSpent(testExitData.outputId)).to.be.true;
+            expect(await this.framework.isOutputFinalized(testExitData.outputId)).to.be.true;
         });
 
         it('should return standard exit bond to exit target when the exit token is ETH', async () => {

--- a/plasma_framework/test/src/exits/payment/controllers/PaymentStartStandardExit.test.js
+++ b/plasma_framework/test/src/exits/payment/controllers/PaymentStartStandardExit.test.js
@@ -214,7 +214,7 @@ contract('PaymentStartStandardExit', ([_, outputOwner, nonOutputOwner]) => {
             const { args, merkleTree } = buildTestData(this.dummyAmount, outputOwner, this.dummyBlockNum);
 
             const outputId = computeDepositOutputId(args.rlpOutputTx, 0, args.utxoPos);
-            await this.framework.setOutputSpent(outputId);
+            await this.framework.setOutputFinalized(outputId);
             await this.framework.setBlock(this.dummyBlockNum, merkleTree.root, this.dummyBlockTimestamp);
 
             await expectRevert(

--- a/plasma_framework/test/src/framework/ExitGameController.test.js
+++ b/plasma_framework/test/src/framework/ExitGameController.test.js
@@ -447,58 +447,58 @@ contract('ExitGameController', () => {
         });
     });
 
-    describe('isAnyOutputsSpent', () => {
+    describe('isAnyOutputsFinalized', () => {
         it('should return true when checking a spent output', async () => {
             const spentOutputId = web3.utils.sha3('output id');
-            await this.dummyExitGame.proxyBatchFlagOutputsSpent([spentOutputId]);
-            expect(await this.controller.isAnyOutputsSpent([spentOutputId])).to.be.true;
+            await this.dummyExitGame.proxyBatchFlagOutputsFinalized([spentOutputId]);
+            expect(await this.controller.isAnyOutputsFinalized([spentOutputId])).to.be.true;
         });
 
         it('should return false when checking an unspent output', async () => {
             const unspentOutputId = web3.utils.sha3('output id');
-            expect(await this.controller.isAnyOutputsSpent([unspentOutputId])).to.be.false;
+            expect(await this.controller.isAnyOutputsFinalized([unspentOutputId])).to.be.false;
         });
 
         it('should return true when all of the outputs are spent', async () => {
             const dummyOutputId1 = web3.utils.sha3('output id 1');
             const dummyOutputId2 = web3.utils.sha3('output id 2');
-            await this.dummyExitGame.proxyBatchFlagOutputsSpent([dummyOutputId1, dummyOutputId2]);
-            expect(await this.controller.isAnyOutputsSpent([dummyOutputId1, dummyOutputId2])).to.be.true;
+            await this.dummyExitGame.proxyBatchFlagOutputsFinalized([dummyOutputId1, dummyOutputId2]);
+            expect(await this.controller.isAnyOutputsFinalized([dummyOutputId1, dummyOutputId2])).to.be.true;
         });
 
         it('should return true when one of the outputs is spent', async () => {
             const spentOutputId = web3.utils.sha3('output id 1');
             const unspentOutputId = web3.utils.sha3('output id 2');
-            await this.dummyExitGame.proxyBatchFlagOutputsSpent([spentOutputId]);
-            expect(await this.controller.isAnyOutputsSpent([unspentOutputId, spentOutputId])).to.be.true;
+            await this.dummyExitGame.proxyBatchFlagOutputsFinalized([spentOutputId]);
+            expect(await this.controller.isAnyOutputsFinalized([unspentOutputId, spentOutputId])).to.be.true;
         });
 
         it('should return false when all of the outputs are not spent', async () => {
             const unspentOutputId1 = web3.utils.sha3('output id 1');
             const unspentOutputId2 = web3.utils.sha3('output id 2');
-            expect(await this.controller.isAnyOutputsSpent([unspentOutputId1, unspentOutputId2])).to.be.false;
+            expect(await this.controller.isAnyOutputsFinalized([unspentOutputId1, unspentOutputId2])).to.be.false;
         });
     });
 
-    describe('batchFlagOutputsSpent', () => {
+    describe('batchFlagOutputsFinalized', () => {
         it('should be able to flag a single output', async () => {
             const dummyOutputId = web3.utils.sha3('output id');
-            await this.dummyExitGame.proxyBatchFlagOutputsSpent([dummyOutputId]);
-            expect(await this.controller.isOutputSpent(dummyOutputId)).to.be.true;
+            await this.dummyExitGame.proxyBatchFlagOutputsFinalized([dummyOutputId]);
+            expect(await this.controller.isOutputFinalized(dummyOutputId)).to.be.true;
         });
 
         it('should be able to flag multiple outputs', async () => {
             const dummyOutputId1 = web3.utils.sha3('output id 1');
             const dummyOutputId2 = web3.utils.sha3('output id 2');
-            await this.dummyExitGame.proxyBatchFlagOutputsSpent([dummyOutputId1, dummyOutputId2]);
-            expect(await this.controller.isOutputSpent(dummyOutputId1)).to.be.true;
-            expect(await this.controller.isOutputSpent(dummyOutputId2)).to.be.true;
+            await this.dummyExitGame.proxyBatchFlagOutputsFinalized([dummyOutputId1, dummyOutputId2]);
+            expect(await this.controller.isOutputFinalized(dummyOutputId1)).to.be.true;
+            expect(await this.controller.isOutputFinalized(dummyOutputId2)).to.be.true;
         });
 
         it('should fail when try to flag with empty outputId', async () => {
             const dummyOutputId = web3.utils.sha3('output id');
             await expectRevert(
-                this.dummyExitGame.proxyBatchFlagOutputsSpent([dummyOutputId, EMPTY_BYTES_32]),
+                this.dummyExitGame.proxyBatchFlagOutputsFinalized([dummyOutputId, EMPTY_BYTES_32]),
                 'Should not flag with empty outputId',
             );
         });
@@ -506,7 +506,7 @@ contract('ExitGameController', () => {
         it('should fail when not called by Exit Game contracts', async () => {
             const dummyOutputId = web3.utils.sha3('output id');
             await expectRevert(
-                this.controller.batchFlagOutputsSpent([dummyOutputId]),
+                this.controller.batchFlagOutputsFinalized([dummyOutputId]),
                 'The call is not from a registered exit game contract',
             );
         });
@@ -519,7 +519,7 @@ contract('ExitGameController', () => {
             const newDummyExitGameId = 2;
             await this.controller.registerExitGame(newDummyExitGameId, newDummyExitGame.address, PROTOCOL.MORE_VP);
             await expectRevert(
-                newDummyExitGame.proxyBatchFlagOutputsSpent([dummyOutputId1, dummyOutputId2]),
+                newDummyExitGame.proxyBatchFlagOutputsFinalized([dummyOutputId1, dummyOutputId2]),
                 'ExitGame is quarantined',
             );
         });
@@ -553,16 +553,16 @@ contract('ExitGameController', () => {
         });
     });
 
-    describe('flagOutputSpent', () => {
+    describe('flagOutputFinalized', () => {
         it('should be able to flag an output', async () => {
             const dummyOutputId = web3.utils.sha3('output id');
-            await this.dummyExitGame.proxyFlagOutputSpent(dummyOutputId);
-            expect(await this.controller.isOutputSpent(dummyOutputId)).to.be.true;
+            await this.dummyExitGame.proxyFlagOutputFinalized(dummyOutputId);
+            expect(await this.controller.isOutputFinalized(dummyOutputId)).to.be.true;
         });
 
         it('should fail when try to flag withempty outputId', async () => {
             await expectRevert(
-                this.dummyExitGame.proxyFlagOutputSpent(EMPTY_BYTES_32),
+                this.dummyExitGame.proxyFlagOutputFinalized(EMPTY_BYTES_32),
                 'Should not flag with empty outputId',
             );
         });
@@ -570,7 +570,7 @@ contract('ExitGameController', () => {
         it('should fail when not called by Exit Game contracts', async () => {
             const dummyOutputId = web3.utils.sha3('output id');
             await expectRevert(
-                this.controller.flagOutputSpent(dummyOutputId),
+                this.controller.flagOutputFinalized(dummyOutputId),
                 'The call is not from a registered exit game contract',
             );
         });
@@ -582,7 +582,7 @@ contract('ExitGameController', () => {
             const newDummyExitGameId = 2;
             await this.controller.registerExitGame(newDummyExitGameId, newDummyExitGame.address, PROTOCOL.MORE_VP);
             await expectRevert(
-                newDummyExitGame.proxyFlagOutputSpent(dummyOutputId),
+                newDummyExitGame.proxyFlagOutputFinalized(dummyOutputId),
                 'ExitGame is quarantined',
             );
         });

--- a/plasma_framework/test/src/framework/ExitGameController.test.js
+++ b/plasma_framework/test/src/framework/ExitGameController.test.js
@@ -447,36 +447,36 @@ contract('ExitGameController', () => {
         });
     });
 
-    describe('isAnyOutputsFinalized', () => {
+    describe('isAnyOutputFinalized', () => {
         it('should return true when checking a spent output', async () => {
             const spentOutputId = web3.utils.sha3('output id');
             await this.dummyExitGame.proxyBatchFlagOutputsFinalized([spentOutputId]);
-            expect(await this.controller.isAnyOutputsFinalized([spentOutputId])).to.be.true;
+            expect(await this.controller.isAnyOutputFinalized([spentOutputId])).to.be.true;
         });
 
         it('should return false when checking an unspent output', async () => {
             const unspentOutputId = web3.utils.sha3('output id');
-            expect(await this.controller.isAnyOutputsFinalized([unspentOutputId])).to.be.false;
+            expect(await this.controller.isAnyOutputFinalized([unspentOutputId])).to.be.false;
         });
 
         it('should return true when all of the outputs are spent', async () => {
             const dummyOutputId1 = web3.utils.sha3('output id 1');
             const dummyOutputId2 = web3.utils.sha3('output id 2');
             await this.dummyExitGame.proxyBatchFlagOutputsFinalized([dummyOutputId1, dummyOutputId2]);
-            expect(await this.controller.isAnyOutputsFinalized([dummyOutputId1, dummyOutputId2])).to.be.true;
+            expect(await this.controller.isAnyOutputFinalized([dummyOutputId1, dummyOutputId2])).to.be.true;
         });
 
         it('should return true when one of the outputs is spent', async () => {
             const spentOutputId = web3.utils.sha3('output id 1');
             const unspentOutputId = web3.utils.sha3('output id 2');
             await this.dummyExitGame.proxyBatchFlagOutputsFinalized([spentOutputId]);
-            expect(await this.controller.isAnyOutputsFinalized([unspentOutputId, spentOutputId])).to.be.true;
+            expect(await this.controller.isAnyOutputFinalized([unspentOutputId, spentOutputId])).to.be.true;
         });
 
         it('should return false when all of the outputs are not spent', async () => {
             const unspentOutputId1 = web3.utils.sha3('output id 1');
             const unspentOutputId2 = web3.utils.sha3('output id 2');
-            expect(await this.controller.isAnyOutputsFinalized([unspentOutputId1, unspentOutputId2])).to.be.false;
+            expect(await this.controller.isAnyOutputFinalized([unspentOutputId1, unspentOutputId2])).to.be.false;
         });
     });
 


### PR DESCRIPTION
Closes #533
Changes:
 * rename `ExitGameController.isOutputSpent` to `ExitGameController.isOutputFinalized` to avoid confusion
 * add section in integration docs explaining when in-flight transaction inputs/ouputs are not available to spend on child chain
