### PR TITLE
feature: track semver in contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,13 @@ Run the following command to run the test afterward:
 ```
 npx truffle test --network loadTest
 ```
+
+
+### How to release a new plasma contracts version
+
+# Bumps the version in package.json (the patch part)
+# Creates a commit with specified message
+# Tags that commit with the new version
+```bash
+npm version patch -m "Fixed a bug in X"
+```

--- a/plasma_framework/contracts/src/framework/PlasmaFramework.sol
+++ b/plasma_framework/contracts/src/framework/PlasmaFramework.sol
@@ -24,6 +24,7 @@ contract PlasmaFramework is VaultRegistry, ExitGameRegistry, ExitGameController,
      */
     uint256 public minExitPeriod;
     address private maintainer;
+    string public version;
 
     constructor(
         uint256 _minExitPeriod,
@@ -42,5 +43,20 @@ contract PlasmaFramework is VaultRegistry, ExitGameRegistry, ExitGameController,
 
     function getMaintainer() public view returns (address) {
         return maintainer;
+    }
+
+    /**
+     * @notice Gets the semantic version of the current deployed contracts
+    */
+    function getVersion() public view returns (string memory) {
+        return version;
+    }
+    
+    /**
+     * @notice Sets the semantic version of the current deployed contracts
+     * @param _version is semver string
+     */
+    function setVersion(string memory _version) public onlyFrom(getMaintainer()) {
+        version = _version;
     }
 }

--- a/plasma_framework/contracts/src/framework/PlasmaFramework.sol
+++ b/plasma_framework/contracts/src/framework/PlasmaFramework.sol
@@ -48,7 +48,7 @@ contract PlasmaFramework is VaultRegistry, ExitGameRegistry, ExitGameController,
     /**
      * @notice Gets the semantic version of the current deployed contracts
     */
-    function getVersion() public view returns (string memory) {
+    function getVersion() external view returns (string memory) {
         return version;
     }
     

--- a/plasma_framework/migrations/2_deploy_plasma_framework.js
+++ b/plasma_framework/migrations/2_deploy_plasma_framework.js
@@ -1,6 +1,8 @@
 const PlasmaFramework = artifacts.require('PlasmaFramework');
 
+const childProcess = require('child_process');
 const config = require('../config.js');
+const pck = require('../package.json');
 
 module.exports = async (
     deployer,
@@ -19,4 +21,6 @@ module.exports = async (
 
     const plasmaFramework = await PlasmaFramework.deployed();
     await plasmaFramework.activateChildChain({ from: authorityAddress });
+    const sha = childProcess.execSync('git rev-parse HEAD').toString().trim().substring(0, 7);
+    await plasmaFramework.setVersion(''.concat(pck.version, '+', sha), { from: maintainerAddress });
 };

--- a/plasma_framework/migrations/2_deploy_plasma_framework.js
+++ b/plasma_framework/migrations/2_deploy_plasma_framework.js
@@ -22,5 +22,5 @@ module.exports = async (
     const plasmaFramework = await PlasmaFramework.deployed();
     await plasmaFramework.activateChildChain({ from: authorityAddress });
     const sha = childProcess.execSync('git rev-parse HEAD').toString().trim().substring(0, 7);
-    await plasmaFramework.setVersion('${pck.version}+${sha}'), { from: maintainerAddress });
+    await plasmaFramework.setVersion(`${pck.version}+${sha}`), { from: maintainerAddress });
 };

--- a/plasma_framework/migrations/2_deploy_plasma_framework.js
+++ b/plasma_framework/migrations/2_deploy_plasma_framework.js
@@ -22,5 +22,5 @@ module.exports = async (
     const plasmaFramework = await PlasmaFramework.deployed();
     await plasmaFramework.activateChildChain({ from: authorityAddress });
     const sha = childProcess.execSync('git rev-parse HEAD').toString().trim().substring(0, 7);
-    await plasmaFramework.setVersion(`${pck.version}+${sha}`), { from: maintainerAddress });
+    await plasmaFramework.setVersion(`${pck.version}+${sha}`, { from: maintainerAddress });
 };

--- a/plasma_framework/migrations/2_deploy_plasma_framework.js
+++ b/plasma_framework/migrations/2_deploy_plasma_framework.js
@@ -22,5 +22,5 @@ module.exports = async (
     const plasmaFramework = await PlasmaFramework.deployed();
     await plasmaFramework.activateChildChain({ from: authorityAddress });
     const sha = childProcess.execSync('git rev-parse HEAD').toString().trim().substring(0, 7);
-    await plasmaFramework.setVersion(`${pck.version}+${sha}`), { from: maintainerAddress });
+    await plasmaFramework.setVersion('${pck.version}+${sha}'), { from: maintainerAddress });
 };

--- a/plasma_framework/migrations/2_deploy_plasma_framework.js
+++ b/plasma_framework/migrations/2_deploy_plasma_framework.js
@@ -22,5 +22,5 @@ module.exports = async (
     const plasmaFramework = await PlasmaFramework.deployed();
     await plasmaFramework.activateChildChain({ from: authorityAddress });
     const sha = childProcess.execSync('git rev-parse HEAD').toString().trim().substring(0, 7);
-    await plasmaFramework.setVersion(''.concat(pck.version, '+', sha), { from: maintainerAddress });
+    await plasmaFramework.setVersion(`${pck.version}+${sha}`), { from: maintainerAddress });
 };

--- a/plasma_framework/package.json
+++ b/plasma_framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plasma_framework",
-  "version": "0.0.1",
+  "version": "1.0.1",
   "description": "Plasma Framework",
   "directories": {
     "test": "test"

--- a/plasma_framework/test/src/framework/PlasmaFramework.test.js
+++ b/plasma_framework/test/src/framework/PlasmaFramework.test.js
@@ -33,7 +33,7 @@ contract('PlasmaFramework', ([authority, maintainer, alice]) => {
         it('should set semver string', async () => {
             const sha = childProcess.execSync('git rev-parse HEAD').toString().trim()
                 .substring(0, 7);
-            await this.framework.setVersion(''.concat('1.0.1', '+', sha), { from: maintainer });
+            await this.framework.setVersion('1.0.1+${sha}'), { from: maintainer });
             expect(await this.framework.getVersion()).to.equal('1.0.1'.concat('+', sha));
         });
 

--- a/plasma_framework/test/src/framework/PlasmaFramework.test.js
+++ b/plasma_framework/test/src/framework/PlasmaFramework.test.js
@@ -2,8 +2,10 @@ const PlasmaFramework = artifacts.require('PlasmaFramework');
 
 const { BN } = require('openzeppelin-test-helpers');
 const { expect } = require('chai');
+const { expectRevert } = require('openzeppelin-test-helpers');
+const childProcess = require('child_process');
 
-contract('PlasmaFramework', ([authority, maintainer]) => {
+contract('PlasmaFramework', ([authority, maintainer, alice]) => {
     const INITIAL_IMMUNE_VAULTS = 1;
     const INITIAL_IMMUNE_EXIT_GAMES = 1;
     const TEST_MIN_EXIT_PERIOD = 1000;
@@ -26,6 +28,20 @@ contract('PlasmaFramework', ([authority, maintainer]) => {
 
         it('should set maintainer address', async () => {
             expect(await this.framework.getMaintainer()).to.equal(maintainer);
+        });
+
+        it('should set semver string', async () => {
+            const sha = childProcess.execSync('git rev-parse HEAD').toString().trim()
+                .substring(0, 7);
+            await this.framework.setVersion(''.concat('1.0.1', '+', sha), { from: maintainer });
+            expect(await this.framework.getVersion()).to.equal('1.0.1'.concat('+', sha));
+        });
+
+        it('should fail when semver not set by maintainer', async () => {
+            await expectRevert(
+                this.framework.setVersion('yolo', { from: alice }),
+                'Caller address is unauthorized',
+            );
         });
     });
 });

--- a/plasma_framework/test/src/framework/PlasmaFramework.test.js
+++ b/plasma_framework/test/src/framework/PlasmaFramework.test.js
@@ -34,7 +34,7 @@ contract('PlasmaFramework', ([authority, maintainer, alice]) => {
             const sha = childProcess.execSync('git rev-parse HEAD').toString().trim()
                 .substring(0, 7);
             await this.framework.setVersion(`1.0.1+${sha}`, { from: maintainer });
-            expect(await this.framework.getVersion()).to.equal('1.0.1'.concat('+', sha));
+            expect(await this.framework.getVersion()).to.equal(`1.0.1+${sha}`);
         });
 
         it('should fail when semver not set by maintainer', async () => {

--- a/plasma_framework/test/src/framework/PlasmaFramework.test.js
+++ b/plasma_framework/test/src/framework/PlasmaFramework.test.js
@@ -33,7 +33,7 @@ contract('PlasmaFramework', ([authority, maintainer, alice]) => {
         it('should set semver string', async () => {
             const sha = childProcess.execSync('git rev-parse HEAD').toString().trim()
                 .substring(0, 7);
-            await this.framework.setVersion(`1.0.1+${sha}`), { from: maintainer });
+            await this.framework.setVersion(`1.0.1+${sha}`, { from: maintainer });
             expect(await this.framework.getVersion()).to.equal('1.0.1'.concat('+', sha));
         });
 

--- a/plasma_framework/test/src/framework/PlasmaFramework.test.js
+++ b/plasma_framework/test/src/framework/PlasmaFramework.test.js
@@ -33,7 +33,7 @@ contract('PlasmaFramework', ([authority, maintainer, alice]) => {
         it('should set semver string', async () => {
             const sha = childProcess.execSync('git rev-parse HEAD').toString().trim()
                 .substring(0, 7);
-            await this.framework.setVersion('1.0.1+${sha}'), { from: maintainer });
+            await this.framework.setVersion(`1.0.1+${sha}`), { from: maintainer });
             expect(await this.framework.getVersion()).to.equal('1.0.1'.concat('+', sha));
         });
 


### PR DESCRIPTION
First version of https://github.com/omisego/plasma-contracts/issues/568

What was done?
- getters and setters on plasma framework
- setter can only be called by the maintainer
- migration calls the setter and pulls the plasma framework version from `package.json` and adds short git sha (7)