### PR TITLE
chore: bump version to 2.0.0, add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased - 2020-02-13
+
+## [2.0.0] - 2020-02-13
+
+### Changed
+
+- Start using "CHANGELOG.md"
+- Event `BlockSubmitted` field `BlockNumber` renamed to `blknum` ([#581](https://github.com/omisego/plasma-contracts/pull/581))
+- `ChallengeStandardExit`, `ChallengeOutputSpent`, `ChallengeInputSpent` take additional parameter - `senderData` ([#574](https://github.com/omisego/plasma-contracts/pull/574))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased - 2020-02-13
 
-## [2.0.0] - 2020-02-13
+## [1.0.2] - 2020-02-13
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Start using "CHANGELOG.md"
 - Event `BlockSubmitted` field `BlockNumber` renamed to `blknum` ([#581](https://github.com/omisego/plasma-contracts/pull/581))
 - `ChallengeStandardExit`, `ChallengeOutputSpent`, `ChallengeInputSpent` take additional parameter - `senderData` ([#574](https://github.com/omisego/plasma-contracts/pull/574))
+- `PaymentInFlightExitRouter.inFlightExits()` takes an array of in-flight exit IDs instead of a single ID ([#583](https://github.com/omisego/plasma-contracts/pull/583))

--- a/plasma_framework/package.json
+++ b/plasma_framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plasma_framework",
-  "version": "0.0.2",
+  "version": "2.0.0",
   "description": "Plasma Framework",
   "directories": {
     "test": "test"

--- a/plasma_framework/package.json
+++ b/plasma_framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plasma_framework",
-  "version": "2.0.0",
+  "version": "1.0.2",
   "description": "Plasma Framework",
   "directories": {
     "test": "test"


### PR DESCRIPTION
Reason: we can't "unrelease". We point to 1.0.x version in other places.

See: https://github.com/omisego/plasma-contracts/issues/561

Also, see rollback discussion here: https://github.com/omisego/plasma-contracts/pull/580