### PR TITLE
fix: require either ife being not canonical or having ANY input spent to exit from inputs

### DIFF
--- a/plasma_framework/contracts/mocks/exits/SpyPlasmaFrameworkForExitGame.sol
+++ b/plasma_framework/contracts/mocks/exits/SpyPlasmaFrameworkForExitGame.sol
@@ -59,7 +59,7 @@ contract SpyPlasmaFrameworkForExitGame is PlasmaFramework {
     }
 
     function setOutputFinalized(bytes32 _outputId) external {
-        isOutputFinalized[_outputId] = true;
+        outputsFinalizations[_outputId] = Finalization.Finalized;
     }
 
     /**

--- a/plasma_framework/contracts/mocks/framework/DummyExitGame.sol
+++ b/plasma_framework/contracts/mocks/framework/DummyExitGame.sol
@@ -51,6 +51,10 @@ contract DummyExitGame is IExitProcessor {
         exitGameController.batchFlagOutputsFinalized(_outputIds);
     }
 
+    function proxyBatchFlagOutputsFinalizedByIFEOutputExit(bytes32[] memory _outputIds) public {
+        exitGameController.batchFlagOutputsFinalizedByIFEOutputExit(_outputIds);
+    }
+
     function proxyFlagOutputFinalized(bytes32 _outputId) public {
         exitGameController.flagOutputFinalized(_outputId);
     }

--- a/plasma_framework/contracts/src/exits/payment/controllers/PaymentProcessInFlightExit.sol
+++ b/plasma_framework/contracts/src/exits/payment/controllers/PaymentProcessInFlightExit.sol
@@ -70,7 +70,7 @@ library PaymentProcessInFlightExit {
         // Also, slightly different from the solution above, we treat input spent as non-canonical.
         // So an IFE is only canonical if all inputs of the in-flight tx are not double spent by competing tx or exit.
         // see: https://github.com/omisego/plasma-contracts/issues/470
-        if (!exit.isCanonical || isAnyInputSpent(self.framework, exit, token)) {
+        if (!exit.isCanonical || isAnyInputSpent(self.framework, exit)) {
             for (uint16 i = 0; i < exit.inputs.length; i++) {
                 PaymentExitDataModel.WithdrawData memory withdrawal = exit.inputs[i];
 
@@ -115,25 +115,24 @@ library PaymentProcessInFlightExit {
 
     function isAnyInputSpent(
         PlasmaFramework framework,
-        PaymentExitDataModel.InFlightExit memory exit,
-        address token
+        PaymentExitDataModel.InFlightExit memory exit
     )
         private
         view
         returns (bool)
     {
-        uint256 inputNumOfTheToken;
+        uint256 inputNum;
         for (uint16 i = 0; i < exit.inputs.length; i++) {
-            if (exit.inputs[i].token == token && !exit.isInputEmpty(i)) {
-                inputNumOfTheToken++;
+            if (!exit.isInputEmpty(i)) {
+                inputNum++;
             }
         }
-        bytes32[] memory outputIdsOfInputs = new bytes32[](inputNumOfTheToken);
-        uint sameTokenIndex = 0;
+        bytes32[] memory outputIdsOfInputs = new bytes32[](inputNum);
+        inputNum = 0;
         for (uint16 i = 0; i < exit.inputs.length; i++) {
-            if (exit.inputs[i].token == token && !exit.isInputEmpty(i)) {
-                outputIdsOfInputs[sameTokenIndex] = exit.inputs[i].outputId;
-                sameTokenIndex++;
+            if (!exit.isInputEmpty(i)) {
+                outputIdsOfInputs[inputNum] = exit.inputs[i].outputId;
+                inputNum++;
             }
         }
         return framework.isAnyOutputFinalized(outputIdsOfInputs);

--- a/plasma_framework/test/src/exits/payment/controllers/PaymentProcessInFlightExit.test.js
+++ b/plasma_framework/test/src/exits/payment/controllers/PaymentProcessInFlightExit.test.js
@@ -611,7 +611,7 @@ contract('PaymentProcessInFlightExit', ([_, ifeBondOwner, inputOwner1, inputOwne
                 expect(await this.framework.isOutputFinalized(TEST_OUTPUT_ID_FOR_INPUT_1)).to.be.true;
                 expect(await this.framework.isOutputFinalized(TEST_OUTPUT_ID_FOR_INPUT_2)).to.be.true;
                 // different token
-                expect(await this.framework.isOutputFinalized(TEST_OUTPUT_ID_FOR_INPUT_3)).to.be.false;
+                expect(await this.framework.isOutputFinalized(TEST_OUTPUT_ID_FOR_INPUT_3)).to.be.true;
             });
 
             it('should only flag piggybacked output with the same token as spent', async () => {


### PR DESCRIPTION
Closes https://github.com/omisego/security-issues/issues/13
Introduces 3 states of outputs in `ExitGameController` contract:
- Not Finalized - not exited and not blocked from exiting by other output exit
- Blocked by IFE output exit - once exit from transaction output finalizes, inputs of the transaction are blocked from exiting. That's a final state.
- Finalized - withdrawn from a vault. That's a final state.

There was a need to differentiate between the two final states because when processing exits from outputs we need to know if transaction inputs were blocked from exiting by inputs exits or exits from other outputs.