### PR TITLE
fix: slow test exceed circle ci timeout limit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
       - run:
           name: Run slow tests
           working_directory: ~/repo/plasma_framework/python_tests
-          no_output_timeout: 10h
+          no_output_timeout: 5h # Circl CI limits to 5hr max: https://discuss.circleci.com/t/job-times-out-after-5-hours/32220/3
           command: |
             . ~/venv/bin/activate
             make runslow 

--- a/plasma_framework/python_tests/tests/conftest.py
+++ b/plasma_framework/python_tests/tests/conftest.py
@@ -94,7 +94,7 @@ def _w3_session(xprocess, accounts, ganache_port):
     web3_modules = get_default_modules()
     web3_modules.update(eth=(AutominingEth,))
 
-    _w3 = Web3(HTTPProvider(endpoint_uri=f'http://localhost:{ganache_port}'), modules=web3_modules)
+    _w3 = Web3(HTTPProvider(endpoint_uri=f'http://localhost:{ganache_port}', request_kwargs={'timeout': 600}), modules=web3_modules)
     if not _w3.isConnected():  # try to connect to an external ganache
         xprocess.ensure(f'GANACHE_{ganache_port}', ganache_cli(accounts, ganache_port))
         assert _w3.provider.make_request('miner_stop', [])['result']

--- a/plasma_framework/python_tests/tests/contracts/root_chain/test_long_run.py
+++ b/plasma_framework/python_tests/tests/contracts/root_chain/test_long_run.py
@@ -29,7 +29,9 @@ def test_slow(testlang, w3):
     # 4. exit something
     # 5. attempt to finalize
 
-    for i in range(1000):
+    # Circle CI has a limit of the test can only be run at most 5 hours. After experiment, it can run for close to 800 runs.
+    # Choose 700 as a safer number to run the test.
+    for i in range(700):
         print(f'[{datetime.datetime.now()}]: iteration {i}')
         # 1. deposit few
         for _ in range(5):


### PR DESCRIPTION
### Note

- reduce the iteration to 700, which would take 4 hours to run.
- increase the timeout for stability

closes #558 

### Test
enabled on CI temporary: https://app.circleci.com/jobs/github/omisego/plasma-contracts/10514