### PR TITLE
chore: check api token for coverage and gas report

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,9 @@ jobs:
             MOCHA_REPORTER: eth-gas-reporter
       - run:
           name: Codechecks for gas usage
-          command: npx codechecks
+          command: |
+            # Don't submit gas report for forks or private mirror
+            [[ -z "${CC_SECRET}" ]] || npx codechecks
           working_directory: ~/repo/plasma_framework
           
   Solidity coverage:
@@ -89,7 +91,13 @@ jobs:
       - setup_truffle_env
       - run:
           name: Run solidity coverage
-          command: npm run coverage && cat coverage/lcov.info | coveralls
+          command: |
+            # Don't submit coverage report for forks, but let the build succeed
+            if [[ -z "$COVERALLS_REPO_TOKEN" ]]; then
+              npm run coverage
+            else
+              npm run coverage && cat coverage/lcov.info | coveralls
+            fi
           working_directory: ~/repo/plasma_framework
 
   Javascript linter:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,10 @@ jobs:
               npm run coverage && cat coverage/lcov.info | coveralls
             fi
           working_directory: ~/repo/plasma_framework
+      - store_artifacts:
+          path: ~/repo/plasma_framework/coverage
+      - store_artifacts:
+          path: ~/repo/plasma_framework/coverage.json
 
   Javascript linter:
     executor: truffle_executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,8 @@ jobs:
             # Don't submit gas report for forks or private mirror
             [[ -z "${CC_SECRET}" ]] || npx codechecks
           working_directory: ~/repo/plasma_framework
+      - store_artifacts:
+          path: ~/repo/plasma_framework/gasReporterOutput.json
           
   Solidity coverage:
     executor: truffle_executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,11 @@ jobs:
             CI: true
             MOCHA_REPORTER: eth-gas-reporter
       - run:
+          name: Show gas report
+          command: |
+            # Somehow the file output format is best read in shell
+            cat ~/repo/plasma_framework/gasReport.rst
+      - run:
           name: Codechecks for gas usage
           command: |
             # Don't submit gas report for forks or private mirror
@@ -85,6 +90,8 @@ jobs:
           working_directory: ~/repo/plasma_framework
       - store_artifacts:
           path: ~/repo/plasma_framework/gasReporterOutput.json
+      - store_artifacts:
+          path: ~/repo/plasma_framework/gasReport.rst
           
   Solidity coverage:
     executor: truffle_executor

--- a/plasma_framework/truffle-config.js
+++ b/plasma_framework/truffle-config.js
@@ -44,6 +44,9 @@ module.exports = {
         reporterOptions: {
             currency: 'USD',
             showTimeSpent: true,
+            rst: true,
+            rstTitle: 'Gas Report',
+            outputFile: './gasReport.rst',
             src: 'contracts/src/',
         },
     },


### PR DESCRIPTION
### Note
- Checks whether token api exist (env var) before submitting request (For Codecheck and coverall). Since fork or private mirror repo would not have have the privilege to use them.
- Put coverage result and gas report to CircleCI artifact. So you can see the result there too.
- Let eth-gas-reporter output to file instead of stdout, allowing saving to artifact though the format is not great 🙁 (It prints prettily in shell with `less` or `cat` commands, but not in Ide or vim)
- coverage artifact example: [index.html](https://10778-138549951-gh.circle-artifacts.com/0/%7E/repo/plasma_framework/coverage/index.html), [circleCI link](https://app.circleci.com/pipelines/github/omisego/plasma-contracts/2068/workflows/828bb8bc-a5ca-4015-b109-131ace2a5736/jobs/10778/artifacts), this one is pretty good IMO

closes: #419
closes: https://github.com/omisego/plasma-contracts-private/issues/3

### Test
CI passes for this repo, private mirror and from fork.

- private mirror: https://github.com/omisego/plasma-contracts-private/pull/4
- fork: https://github.com/omisego/plasma-contracts/pull/614