### PR TITLE
feat: auto syncing between public and private master

### DIFF
--- a/.github/workflows/auto-pr-for-branch-syncing.yml
+++ b/.github/workflows/auto-pr-for-branch-syncing.yml
@@ -2,7 +2,7 @@ name: Auto PR for syncing master to master-private
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   auto-pr-for-branch-syncing:
@@ -15,4 +15,4 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FROM_BRANCH: master
-          TO_BRANCH: private-master
+          TO_BRANCH: master-private

--- a/.github/workflows/auto-pr-for-branch-syncing.yml
+++ b/.github/workflows/auto-pr-for-branch-syncing.yml
@@ -2,17 +2,25 @@ name: Auto PR for syncing master to master-private
 
 on:
   push:
-    branches: [master]
+    branches: [master-test-auto-sync]
 
 jobs:
   auto-pr-for-branch-syncing:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Sync branches
-        if: github.repository == 'omisego/plasma-contracts-private'
-        uses: TreTuna/sync-branches@1.1.0
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          FROM_BRANCH: master
-          TO_BRANCH: master-private
+      - name: Create Pull Request
+        if: github.repository == 'omisego/plasma-contracts'
+        run: |
+          set -o xtrace
+
+          readonly FROM_BRANCH="master-test-auto-sync"
+          readonly TO_BRANCH="master-private"
+          readonly TITLE="sync: auto syncing from ${FROM_BRANCH} to ${TO_BRANCH}"
+          readonly BODY="There is new update in \`${FROM_BRANCH}\`! Time to sync to \`${TO_BRANCH}\`!!"
+
+          curl -X POST "https://api.github.com/repos/omisego/plasma-contracts-private/pulls" \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token ${{ secrets.HOUSE_KEEPER_BOT_TOKEN }}" \
+          --data "{\"title\": \"${TITLE}\", \"head\": \"${FROM_BRANCH}\", \"base\": \"${TO_BRANCH}\", \"body\": \"${BODY}\"}"
+

--- a/.github/workflows/auto-pr-for-branch-syncing.yml
+++ b/.github/workflows/auto-pr-for-branch-syncing.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Create Pull Request
-        if: github.repository == 'omisego/plasma-contracts'
+        if: github.repository == 'omisego/plasma-contracts-private'
         run: |
           set -o xtrace
 

--- a/.github/workflows/auto-pr-for-branch-syncing.yml
+++ b/.github/workflows/auto-pr-for-branch-syncing.yml
@@ -2,7 +2,7 @@ name: Auto PR for syncing master to master-private
 
 on:
   push:
-    branches: [master-test-auto-sync]
+    branches: [master]
 
 jobs:
   auto-pr-for-branch-syncing:

--- a/.github/workflows/auto-pr-for-branch-syncing.yml
+++ b/.github/workflows/auto-pr-for-branch-syncing.yml
@@ -14,7 +14,7 @@ jobs:
         run: |
           set -o xtrace
 
-          readonly FROM_BRANCH="master-test-auto-sync"
+          readonly FROM_BRANCH="master"
           readonly TO_BRANCH="master-private"
           readonly TITLE="sync: auto syncing from ${FROM_BRANCH} to ${TO_BRANCH}"
           readonly BODY="There is new update in \`${FROM_BRANCH}\`! Time to sync to \`${TO_BRANCH}\`!!"

--- a/.github/workflows/auto-pr-for-branch-syncing.yml
+++ b/.github/workflows/auto-pr-for-branch-syncing.yml
@@ -1,0 +1,18 @@
+name: Auto PR for syncing master to master-private
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  auto-pr-for-branch-syncing:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Sync branches
+        if: github.repository == 'omisego/plasma-contracts-private'
+        uses: TreTuna/sync-branches@1.1.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FROM_BRANCH: master
+          TO_BRANCH: private-master

--- a/.github/workflows/dispatch-sync-to-private.yml
+++ b/.github/workflows/dispatch-sync-to-private.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Repository Dispatch
-        # if: github.repository == 'omisego/plasma-contracts'
+        if: github.repository == 'omisego/plasma-contracts'
         run: |
           curl -X POST https://api.github.com/repos/omisego/plasma-contracts-private/dispatches \
           -H 'Accept: application/vnd.github.v3+json' \

--- a/.github/workflows/dispatch-sync-to-private.yml
+++ b/.github/workflows/dispatch-sync-to-private.yml
@@ -1,4 +1,4 @@
-name: Sync with plasma-contracts
+name: Dispatch sync event to plasma-contracts-private
 
 on:
   push:

--- a/.github/workflows/dispatch-sync-to-private.yml
+++ b/.github/workflows/dispatch-sync-to-private.yml
@@ -2,8 +2,7 @@ name: Dispatch sync event to plasma-contracts-private
 
 on:
   push:
-    branches:
-    - master
+    branches: [master]
 
 jobs:
   dispatch-sync-event:
@@ -11,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Repository Dispatch
-        if: github.repository == 'boolafish/plasma-contracts'
+        if: github.repository == 'omisego/plasma-contracts'
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.HOUSE_KEEPER_BOT_TOKEN }}

--- a/.github/workflows/dispatch-sync-to-private.yml
+++ b/.github/workflows/dispatch-sync-to-private.yml
@@ -9,7 +9,7 @@ jobs:
   dispatch-sync-event:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: Repository Dispatch
         if: github.repository == 'boolafish/plasma-contracts'
         uses: peter-evans/repository-dispatch@v1

--- a/.github/workflows/dispatch-sync-to-private.yml
+++ b/.github/workflows/dispatch-sync-to-private.yml
@@ -2,7 +2,7 @@ name: Dispatch sync event to plasma-contracts-private
 
 on:
   push:
-    branches: [master-test-auto-sync]
+    branches: [master]
 
 jobs:
   dispatch-sync-event:

--- a/.github/workflows/dispatch-sync-to-private.yml
+++ b/.github/workflows/dispatch-sync-to-private.yml
@@ -11,9 +11,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Repository Dispatch
         if: github.repository == 'omisego/plasma-contracts'
-        uses: peter-evans/repository-dispatch@v1
-        with:
-          token: ${{ secrets.HOUSE_KEEPER_BOT_TOKEN }}
-          repository: omisego/plasma-contracts-private
-          event-type: sync-from-public
-          client-payload: '{"sha": "${{ github.sha }}"}'
+        run: |
+          curl -X POST https://api.github.com/repos/omisego/plasma-contracts-private/dispatches \
+          -H 'Accept: application/vnd.github.everest-preview+json' \
+          -H 'authorization: token '${{ secrets.HOUSE_KEEPER_BOT_TOKEN }}'' \
+          --data '{"event_type": "sync-from-public", "client_payload": { "sha": "'"${{ github.sha }}"'" }}'

--- a/.github/workflows/dispatch-sync-to-private.yml
+++ b/.github/workflows/dispatch-sync-to-private.yml
@@ -1,0 +1,20 @@
+name: Sync with plasma-contracts
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  dispatch-sync-event:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Repository Dispatch
+        if: github.repository == 'boolafish/plasma-contracts'
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.HOUSE_KEEPER_BOT_TOKEN }}
+          repository: omisego/plasma-contracts-private
+          event-type: sync-from-public
+          client-payload: '{"sha": "${{ github.sha }}"}'

--- a/.github/workflows/dispatch-sync-to-private.yml
+++ b/.github/workflows/dispatch-sync-to-private.yml
@@ -2,7 +2,7 @@ name: Dispatch sync event to plasma-contracts-private
 
 on:
   push:
-    branches: [master]
+    branches: [master-test-auto-sync]
 
 jobs:
   dispatch-sync-event:
@@ -10,9 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Repository Dispatch
-        if: github.repository == 'omisego/plasma-contracts'
+        # if: github.repository == 'omisego/plasma-contracts'
         run: |
           curl -X POST https://api.github.com/repos/omisego/plasma-contracts-private/dispatches \
-          -H 'Accept: application/vnd.github.everest-preview+json' \
+          -H 'Accept: application/vnd.github.v3+json' \
           -H 'authorization: token '${{ secrets.HOUSE_KEEPER_BOT_TOKEN }}'' \
           --data '{"event_type": "sync-from-public", "client_payload": { "sha": "'"${{ github.sha }}"'" }}'

--- a/.github/workflows/sync-from-public-to-private.yml
+++ b/.github/workflows/sync-from-public-to-private.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          # use personal token to enable continue GH action workflows
+          # use personal token to continue GH action workflows
           # by default GH would not trigger another workflow if it is from GH action token
           # see: https://github.com/ad-m/github-push-action/issues/32
           token: ${{ secrets.HOUSE_KEEPER_BOT_TOKEN }}

--- a/.github/workflows/sync-from-public-to-private.yml
+++ b/.github/workflows/sync-from-public-to-private.yml
@@ -1,12 +1,8 @@
 name: Sync with plasma-contracts
 
-# on:
-#   repository_dispatch:
-#     types: [sync-from-public]
-
 on:
-  push:
-    branches: [master-test-auto-sync]
+  repository_dispatch:
+    types: [sync-from-public]
 
 jobs:
   sync-public-repo:
@@ -22,6 +18,7 @@ jobs:
         run: |
           echo "Syncing with sha '${{ github.event.client_payload.sha }}'"
       - name: Sync master branch in between public and private repos
+        if: github.repository == 'omisego/plasma-contracts-private'
         run: |
           set -e
           set -o xtrace

--- a/.github/workflows/sync-from-public-to-private.yml
+++ b/.github/workflows/sync-from-public-to-private.yml
@@ -1,8 +1,12 @@
 name: Sync with plasma-contracts
 
+# on:
+#   repository_dispatch:
+#     types: [sync-from-public]
+
 on:
-  repository_dispatch:
-    types: [sync-from-public]
+  push:
+    branches: [master-test-auto-sync]
 
 jobs:
   sync-public-repo:
@@ -17,10 +21,24 @@ jobs:
       - name: Event Information
         run: |
           echo "Syncing with sha '${{ github.event.client_payload.sha }}'"
-      - name: GitHub Repo Sync
-        uses: repo-sync/github-sync@v2.0.0
-        with:
-          source_repo: omisego/plasma-contracts
-          source_branch: master
-          destination_branch: master
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Sync master branch in between public and private repos
+        run: |
+          set -e
+          set -o xtrace
+
+          # Credit repo-sync/github-sync for the script used in here
+          # https://github.com/repo-sync/github-sync/blob/520596e97177727db1f2a1de14f4ded905624066/github-sync.sh#L23-L33
+
+          readonly SOURCE_REPO="omisego/plasma-contracts"
+          readonly SOURCE_BRANCH="master"
+          readonly DESTINATION_BRANCH="master"
+
+          echo "Syncing ${DESTINATION_BRANCH} from branch ${SOURCE_BRANCH} of ${SOURCE_REPO}..."
+
+          git remote set-url origin "https://$GITHUB_ACTOR:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY"
+          git remote add tmp_upstream "https://github.com/${SOURCE_REPO}.git"
+          git fetch tmp_upstream
+          git remote --verbose
+          git push origin "refs/remotes/tmp_upstream/${SOURCE_BRANCH}:refs/heads/${DESTINATION_BRANCH}" --force
+          git remote rm tmp_upstream
+          git remote --verbose

--- a/.github/workflows/sync-from-public-to-private.yml
+++ b/.github/workflows/sync-from-public-to-private.yml
@@ -20,7 +20,7 @@ jobs:
       - name: GitHub Repo Sync
         uses: repo-sync/github-sync@v2.0.0
         with:
-          source_repo: boolafish/plasma-contracts
+          source_repo: omisego/plasma-contracts
           source_branch: master
           destination_branch: master
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-from-public-to-private.yml
+++ b/.github/workflows/sync-from-public-to-private.yml
@@ -8,7 +8,12 @@ jobs:
   sync-public-repo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
+        with:
+          # use personal token to enable continue GH action workflows
+          # by default GH would not trigger another workflow if it is from GH action token
+          # see: https://github.com/ad-m/github-push-action/issues/32
+          token: ${{ secrets.HOUSE_KEEPER_BOT_TOKEN }}
       - name: Event Information
         run: |
           echo "Syncing with sha '${{ github.event.client_payload.sha }}'"

--- a/.github/workflows/sync-from-public-to-private.yml
+++ b/.github/workflows/sync-from-public-to-private.yml
@@ -1,0 +1,21 @@
+name: Sync with plasma-contracts
+
+on:
+  repository_dispatch:
+    types: [sync-from-public]
+
+jobs:
+  sync-public-repo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Event Information
+        run: |
+          echo "Syncing with sha '${{ github.event.client_payload.sha }}'"
+      - name: GitHub Repo Sync
+        uses: repo-sync/github-sync@v2.0.0
+        with:
+          source_repo: boolafish/plasma-contracts
+          source_branch: master
+          destination_branch: master
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Note
Setup a auto sync Github action workflow to:
1. Whenever a new code pushed to `master` in public repo, it would dispatch an event to the private repo. (with event_type: `sync-from-public`)
1. Once received the dispatched event, the private repo would sync the `master` of the private with the public repo.
1. After the `master` branch is synced, it would automatically submit a PR to sync master back to the base branch of the private repo (`master-private`)
1. Created a new personal token of the lovely omisego-bot for this use. Set `HOUSE_KEEPER_BOT_TOKEN` as Github secret of the repo (both public & private)

Note that the dispatch event requires the workflow file to be in the base branch (usually master) to be able to work. see: https://github.community/t5/GitHub-Actions/repository-dispatch-not-triggering-actions/td-p/33817

Also, this means this would only take effect after this PR is merged and sync the change to the base branch of `plasma-contracts-private`.

### Test
This setup requires it to be in master (or the base branch) of the repo, as a result, I was using my own public fork and messing around the `plasma-contracts-private` repo to test.

It was tested by replacing some of the repo with `boolafish/plasma-contracts` instead of `omisego/plasma-contracts`

- my public fork repo: https://github.com/boolafish/plasma-contracts
- Dispatch: [job](https://github.com/boolafish/plasma-contracts/runs/576576243?check_suite_focus=true)
- Auto sync: [job](https://github.com/omisego/plasma-contracts-private/runs/576544932?check_suite_focus=true)
- Auto PR: https://github.com/omisego/plasma-contracts-private/pull/15
