### PR TITLE
feat: experimental payment v2 migration script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
       - setup_truffle_env
       - run:
           name: Run tests
-          command: truffle test 
+          command: EXPERIMENT=true npm run test
           working_directory: ~/repo/plasma_framework
           environment:
             CI: true
@@ -103,9 +103,9 @@ jobs:
           command: |
             # Don't submit coverage report for forks, but let the build succeed
             if [[ -z "$COVERALLS_REPO_TOKEN" ]]; then
-              npm run coverage
+              EXPERIMENT=true npm run coverage
             else
-              npm run coverage && cat coverage/lcov.info | coveralls
+              EXPERIMENT=true npm run coverage && cat coverage/lcov.info | coveralls
             fi
           working_directory: ~/repo/plasma_framework
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,11 +72,12 @@ jobs:
       - setup_truffle_env
       - run:
           name: Run tests
-          command: EXPERIMENT=true npm run test
+          command: npm run test
           working_directory: ~/repo/plasma_framework
           environment:
             CI: true
             MOCHA_REPORTER: eth-gas-reporter
+            MULTI_EXIT_GAME_EXPERIMENT: true
       - run:
           name: Show gas report
           command: |
@@ -103,11 +104,13 @@ jobs:
           command: |
             # Don't submit coverage report for forks, but let the build succeed
             if [[ -z "$COVERALLS_REPO_TOKEN" ]]; then
-              EXPERIMENT=true npm run coverage
+              npm run coverage
             else
-              EXPERIMENT=true npm run coverage && cat coverage/lcov.info | coveralls
+              npm run coverage && cat coverage/lcov.info | coveralls
             fi
           working_directory: ~/repo/plasma_framework
+          environment:
+            MULTI_EXIT_GAME_EXPERIMENT: true
       - store_artifacts:
           path: ~/repo/plasma_framework/coverage
       - store_artifacts:

--- a/README.md
+++ b/README.md
@@ -65,16 +65,19 @@ Deploying the contracts requires three accounts:
 2. `AUTHORITY` The account that used by the Child chain to submit blocks. It must not have made any transaction prior to calling the scripts i.e. its nonce must be 0.
 3. `MAINTAINER` The account that can register new vaults, exit games, etc.
 
-Normally you will deploy the contracts using an Ethereum client that you run yourself, such as Geth or Parity. However, you can also use a remote provider such as Infura. In this case you'll need to know the private keys for the `DEPLOYER`, `AUTHORITY` and `MAINTAINER` accounts. See `truffle-config.js` for an example.
+Normally you will deploy the contracts using an Ethereum client that you run yourself, such as Geth or Parity. Those Ethereum client would have default accounts on the node itself. For local testing, you can leverage those accounts and deploy with `--network local` flag.
+
+However, you can also use a remote provider such as Infura that does not have control of the private key and accounts with `--network remote` flag. In this case you'll need to know the private keys for the `DEPLOYER`, `AUTHORITY` and `MAINTAINER` accounts. See [`truffle-config.js`](./plasma_framework/truffle-config.js) for an example.
 
 Run truffle, passing in the network e.g.
 ```bash
-./node_modules/.bin/truffle truffle migrate --network local
+npx truffle migrate --network local
 
 # or to deploy via a remote provider
-./node_modules/.bin/truffle truffle migrate --network remote
+npx truffle migrate --network remote
 ```
 
+For more detail of the deploying scripts, see [deploying.md](./plasma_framework/docs/deploying/deploying.md)
 
 ### Building and running the python tests
 We suggest running the following commands with an active python virtual environment ex. `venv`.

--- a/plasma_framework/config.js
+++ b/plasma_framework/config.js
@@ -25,20 +25,29 @@ const development = {
             payment: 1,
             paymentV2: 2,
             fee: 3,
-            experimental: {
-                paymentV3: 4,
-            },
         },
         outputTypes: {
             payment: 1,
             feeClaim: 2,
-            experimental: {
-                paymentV2: 3,
-            },
         },
         vaultId: {
             eth: 1,
             erc20: 2,
+        },
+    },
+    experimental: {
+        frameworks: {
+            // Allow 2 exit games (PaymentExitGame, PaymentV2ExitGame, FeeExitGame)
+            // to be used without going through quarantine.
+            initialImmuneExitGames: 3,
+        },
+        registerKeys: {
+            txTypes: {
+                paymentV3: 4,
+            },
+            outputTypes: {
+                paymentV2: 3,
+            },
         },
     },
 };

--- a/plasma_framework/config.js
+++ b/plasma_framework/config.js
@@ -35,22 +35,15 @@ const development = {
             erc20: 2,
         },
     },
-    experimental: {
-        frameworks: {
-            // Allow 2 exit games (PaymentExitGame, PaymentV2ExitGame, FeeExitGame)
-            // to be used without going through quarantine.
-            initialImmuneExitGames: 3,
-        },
-        registerKeys: {
-            txTypes: {
-                paymentV3: 4,
-            },
-            outputTypes: {
-                paymentV2: 3,
-            },
-        },
-    },
 };
+
+if (process.env.MULTI_EXIT_GAME_EXPERIMENT) {
+    // Allow 2 exit games (PaymentExitGame, PaymentV2ExitGame, FeeExitGame)
+    // to be used without going through quarantine.
+    development.frameworks.initialImmuneExitGames = 3;
+    development.registerKeys.txTypes.paymentV3 = 4;
+    development.registerKeys.outputTypes.paymentV2 = 3;
+}
 
 const production = clonedeep(development);
 production.frameworks.minExitPeriod = 60 * 60 * 24 * 7; // The minimum exit period in production is 1 week.

--- a/plasma_framework/config.js
+++ b/plasma_framework/config.js
@@ -25,10 +25,16 @@ const development = {
             payment: 1,
             paymentV2: 2,
             fee: 3,
+            experimental: {
+                paymentV3: 4,
+            },
         },
         outputTypes: {
             payment: 1,
             feeClaim: 2,
+            experimental: {
+                paymentV2: 3,
+            },
         },
         vaultId: {
             eth: 1,

--- a/plasma_framework/docs/deploying/deploying.md
+++ b/plasma_framework/docs/deploying/deploying.md
@@ -7,5 +7,11 @@ Truffle migration scripts run in the order of the numbered prefix of the filenam
 - 99: Renounce the SpendingConditionRegistry because this has to happen before any ExitGames
 - 100: First ExitGame contracts
 - 200: Second ExitGame contracts
+- 300: payment V2 experiment contracts
 - 1000: Cleanup, dev/test contracts and output
 - 2000: Future extensions, new exit games, etc.
+
+## ENV VAR settings
+- TENDERLY: set to `true` when needed to push the contract to tenderly. Default not pushing to tenderly.
+- DEPLOY_TEST_CONTRACTS: set to `true` when need to deploy some testing contracts like mock, wrapper for conformance testing. Default not deploying test contracts.
+- EXPERIMENT: set to `true` when needed to deploy experimental contracts. For instance, deploying new payment exit game contract to test the flow of extension.

--- a/plasma_framework/docs/deploying/deploying.md
+++ b/plasma_framework/docs/deploying/deploying.md
@@ -14,4 +14,4 @@ Truffle migration scripts run in the order of the numbered prefix of the filenam
 ## ENV VAR settings
 - TENDERLY: set to `true` when you need to push the contract to tenderly. Default not pushing to tenderly.
 - DEPLOY_TEST_CONTRACTS: set to `true` when you need to deploy some testing contracts like mock, wrapper for conformance testing. By default test contracts are not deployed.
-- MULTI_EXIT_GAME_EXPERIMENT: This is the feature flag for the experiment of doing a multiple exit games. This experiment focuses on extending to a payment v2 feature that is a clone of payment v1. So it would be deploying the same contract with slightly different parameters on indicating the tx type. set to `true` when you need to deploy experimental contracts.
+- MULTI_EXIT_GAME_EXPERIMENT: This is the feature flag for the experiment of doing a multiple exit games. This experiment focuses on extending to a payment v2 feature that is a clone of payment v1. So it would be deploying the same contract with slightly different parameters on indicating the tx type. Set to `true` when you need to deploy experimental contracts.

--- a/plasma_framework/docs/deploying/deploying.md
+++ b/plasma_framework/docs/deploying/deploying.md
@@ -3,9 +3,9 @@
 ## Migration scripts
 Truffle migration scripts run in the order of the numbered prefix of the filename. The naming convention is as follows:
 
-1-98: Initial setup and main contracts like PlasmaFramework, SpendingConditionRegistry, etc.
-99: Renounce the SpendingConditionRegistry because this has to happen before any ExitGames
-100: First ExitGame contracts
-200: Second ExitGame contracts
-1000: Cleanup, dev/test contracts and output
-2000: Future extensions, new exit games, etc.
+- 1-98: Initial setup and main contracts like PlasmaFramework, SpendingConditionRegistry, etc.
+- 99: Renounce the SpendingConditionRegistry because this has to happen before any ExitGames
+- 100: First ExitGame contracts
+- 200: Second ExitGame contracts
+- 1000: Cleanup, dev/test contracts and output
+- 2000: Future extensions, new exit games, etc.

--- a/plasma_framework/docs/deploying/deploying.md
+++ b/plasma_framework/docs/deploying/deploying.md
@@ -14,4 +14,4 @@ Truffle migration scripts run in the order of the numbered prefix of the filenam
 ## ENV VAR settings
 - TENDERLY: set to `true` when you need to push the contract to tenderly. Default not pushing to tenderly.
 - DEPLOY_TEST_CONTRACTS: set to `true` when you need to deploy some testing contracts like mock, wrapper for conformance testing. By default test contracts are not deployed.
-- EXPERIMENT: set to `true` when you need to deploy experimental contracts. For instance, deploy a new payment exit game contract to test the flow to extend the system.
+- MULTI_EXIT_GAME_EXPERIMENT: This is the feature flag for the experiment of doing a multiple exit games. This experiment focuses on extending to a payment v2 feature that is a clone of payment v1. So it would be deploying the same contract with slightly different parameters on indicating the tx type. set to `true` when you need to deploy experimental contracts.

--- a/plasma_framework/docs/deploying/deploying.md
+++ b/plasma_framework/docs/deploying/deploying.md
@@ -12,6 +12,6 @@ Truffle migration scripts run in the order of the numbered prefix of the filenam
 - 2000: Future extensions, new exit games, etc.
 
 ## ENV VAR settings
-- TENDERLY: set to `true` when needed to push the contract to tenderly. Default not pushing to tenderly.
-- DEPLOY_TEST_CONTRACTS: set to `true` when need to deploy some testing contracts like mock, wrapper for conformance testing. Default not deploying test contracts.
-- EXPERIMENT: set to `true` when needed to deploy experimental contracts. For instance, deploying new payment exit game contract to test the flow of extension.
+- TENDERLY: set to `true` when you need to push the contract to tenderly. Default not pushing to tenderly.
+- DEPLOY_TEST_CONTRACTS: set to `true` when you need to deploy some testing contracts like mock, wrapper for conformance testing. By default test contracts are not deployed.
+- EXPERIMENT: set to `true` when you need to deploy experimental contracts. For instance, deploy a new payment exit game contract to test the flow to extend the system.

--- a/plasma_framework/migrations/20_deploy_plasma_framework.js
+++ b/plasma_framework/migrations/20_deploy_plasma_framework.js
@@ -10,11 +10,15 @@ module.exports = async (
     // eslint-disable-next-line no-unused-vars
     [deployerAddress, maintainerAddress, authorityAddress],
 ) => {
+    const isExperiment = process.env.EXPERIMENT || false;
+    const initialImmuneExitGames = (isExperiment)
+        ? config.experimental.frameworks.initialImmuneExitGames : config.frameworks.initialImmuneExitGames;
+
     await deployer.deploy(
         PlasmaFramework,
         config.frameworks.minExitPeriod,
         config.frameworks.initialImmuneVaults,
-        config.frameworks.initialImmuneExitGames,
+        initialImmuneExitGames,
         authorityAddress,
         maintainerAddress,
     );

--- a/plasma_framework/migrations/20_deploy_plasma_framework.js
+++ b/plasma_framework/migrations/20_deploy_plasma_framework.js
@@ -10,15 +10,11 @@ module.exports = async (
     // eslint-disable-next-line no-unused-vars
     [deployerAddress, maintainerAddress, authorityAddress],
 ) => {
-    const isExperiment = process.env.EXPERIMENT || false;
-    const initialImmuneExitGames = (isExperiment)
-        ? config.experimental.frameworks.initialImmuneExitGames : config.frameworks.initialImmuneExitGames;
-
     await deployer.deploy(
         PlasmaFramework,
         config.frameworks.minExitPeriod,
         config.frameworks.initialImmuneVaults,
-        initialImmuneExitGames,
+        config.frameworks.initialImmuneExitGames,
         authorityAddress,
         maintainerAddress,
     );

--- a/plasma_framework/migrations/300_payment_v2_spending_condition_registry.js
+++ b/plasma_framework/migrations/300_payment_v2_spending_condition_registry.js
@@ -8,8 +8,7 @@ module.exports = async (
     // eslint-disable-next-line no-unused-vars
     [deployerAddress, maintainerAddress, authorityAddress],
 ) => {
-    const isExperiment = process.env.EXPERIMENT || false;
-    if (isExperiment) {
+    if (process.env.MULTI_EXIT_GAME_EXPERIMENT) {
         await deployer.deploy(SpendingConditionRegistry);
     }
 };

--- a/plasma_framework/migrations/300_payment_v2_spending_condition_registry.js
+++ b/plasma_framework/migrations/300_payment_v2_spending_condition_registry.js
@@ -1,0 +1,15 @@
+/* eslint-disable no-console */
+
+const SpendingConditionRegistry = artifacts.require('SpendingConditionRegistry');
+
+module.exports = async (
+    deployer,
+    _,
+    // eslint-disable-next-line no-unused-vars
+    [deployerAddress, maintainerAddress, authorityAddress],
+) => {
+    const isExperiment = process.env.EXPERIMENT || false;
+    if (isExperiment) {
+        await deployer.deploy(SpendingConditionRegistry);
+    }
+};

--- a/plasma_framework/migrations/301_payment_v2_spending_conditions.js
+++ b/plasma_framework/migrations/301_payment_v2_spending_conditions.js
@@ -12,8 +12,7 @@ module.exports = async (
     // eslint-disable-next-line no-unused-vars
     [deployerAddress, maintainerAddress, authorityAddress],
 ) => {
-    const isExperiment = process.env.EXPERIMENT || false;
-    if (isExperiment) {
+    if (process.env.MULTI_EXIT_GAME_EXPERIMENT) {
         const PAYMENT_OUTPUT_TYPE = config.registerKeys.outputTypes.payment;
         const PAYMENT_V2_OUTPUT_TYPE = config.experimental.registerKeys.outputTypes.paymentV2;
         const PAYMENT_V2_TX_TYPE = config.registerKeys.txTypes.paymentV2;

--- a/plasma_framework/migrations/301_payment_v2_spending_conditions.js
+++ b/plasma_framework/migrations/301_payment_v2_spending_conditions.js
@@ -15,9 +15,9 @@ module.exports = async (
     const isExperiment = process.env.EXPERIMENT || false;
     if (isExperiment) {
         const PAYMENT_OUTPUT_TYPE = config.registerKeys.outputTypes.payment;
-        const PAYMENT_V2_OUTPUT_TYPE = config.registerKeys.outputTypes.experimental.paymentV2;
+        const PAYMENT_V2_OUTPUT_TYPE = config.experimental.registerKeys.outputTypes.paymentV2;
         const PAYMENT_V2_TX_TYPE = config.registerKeys.txTypes.paymentV2;
-        const PAYMENT_V3_TX_TYPE = config.registerKeys.txTypes.experimental.paymentV3;
+        const PAYMENT_V3_TX_TYPE = config.experimental.registerKeys.txTypes.paymentV3;
 
         const spendingConditionRegistry = await SpendingConditionRegistry.deployed();
         const plasmaFramework = await PlasmaFramework.deployed();
@@ -43,7 +43,7 @@ module.exports = async (
             PAYMENT_V2_TX_TYPE,
         );
         const paymentV2ToPaymentV2Condition = await PaymentOutputToPaymentTxCondition.deployed();
-        console.log(`Registering paymentToPaymentCondition (${paymentV2ToPaymentV2Condition.address}) to spendingConditionRegistry`);
+        console.log(`Registering paymentV2ToPaymentV2Condition (${paymentV2ToPaymentV2Condition.address}) to spendingConditionRegistry`);
         await spendingConditionRegistry.registerSpendingCondition(
             PAYMENT_V2_OUTPUT_TYPE, PAYMENT_V2_TX_TYPE, paymentV2ToPaymentV2Condition.address,
         );
@@ -56,7 +56,7 @@ module.exports = async (
             PAYMENT_V3_TX_TYPE,
         );
         const paymentV2ToPaymentV3Condition = await PaymentOutputToPaymentTxCondition.deployed();
-        console.log(`Registering paymentToPaymentV2Condition (${paymentV2ToPaymentV3Condition.address}) to spendingConditionRegistry`);
+        console.log(`Registering paymentV2ToPaymentV3Condition (${paymentV2ToPaymentV3Condition.address}) to spendingConditionRegistry`);
         await spendingConditionRegistry.registerSpendingCondition(
             PAYMENT_V2_OUTPUT_TYPE, PAYMENT_V3_TX_TYPE, paymentV2ToPaymentV3Condition.address,
         );

--- a/plasma_framework/migrations/301_payment_v2_spending_conditions.js
+++ b/plasma_framework/migrations/301_payment_v2_spending_conditions.js
@@ -14,9 +14,9 @@ module.exports = async (
 ) => {
     if (process.env.MULTI_EXIT_GAME_EXPERIMENT) {
         const PAYMENT_OUTPUT_TYPE = config.registerKeys.outputTypes.payment;
-        const PAYMENT_V2_OUTPUT_TYPE = config.experimental.registerKeys.outputTypes.paymentV2;
+        const PAYMENT_V2_OUTPUT_TYPE = config.registerKeys.outputTypes.paymentV2;
         const PAYMENT_V2_TX_TYPE = config.registerKeys.txTypes.paymentV2;
-        const PAYMENT_V3_TX_TYPE = config.experimental.registerKeys.txTypes.paymentV3;
+        const PAYMENT_V3_TX_TYPE = config.registerKeys.txTypes.paymentV3;
 
         const spendingConditionRegistry = await SpendingConditionRegistry.deployed();
         const plasmaFramework = await PlasmaFramework.deployed();

--- a/plasma_framework/migrations/301_payment_v2_spending_conditions.js
+++ b/plasma_framework/migrations/301_payment_v2_spending_conditions.js
@@ -1,0 +1,64 @@
+/* eslint-disable no-console */
+
+const PaymentOutputToPaymentTxCondition = artifacts.require('PaymentOutputToPaymentTxCondition');
+const PlasmaFramework = artifacts.require('PlasmaFramework');
+const SpendingConditionRegistry = artifacts.require('SpendingConditionRegistry');
+
+const config = require('../config.js');
+
+module.exports = async (
+    deployer,
+    _,
+    // eslint-disable-next-line no-unused-vars
+    [deployerAddress, maintainerAddress, authorityAddress],
+) => {
+    const isExperiment = process.env.EXPERIMENT || false;
+    if (isExperiment) {
+        const PAYMENT_OUTPUT_TYPE = config.registerKeys.outputTypes.payment;
+        const PAYMENT_V2_OUTPUT_TYPE = config.registerKeys.outputTypes.experimental.paymentV2;
+        const PAYMENT_V2_TX_TYPE = config.registerKeys.txTypes.paymentV2;
+        const PAYMENT_V3_TX_TYPE = config.registerKeys.txTypes.experimental.paymentV3;
+
+        const spendingConditionRegistry = await SpendingConditionRegistry.deployed();
+        const plasmaFramework = await PlasmaFramework.deployed();
+
+        // payment V1 -> payment V2
+        await deployer.deploy(
+            PaymentOutputToPaymentTxCondition,
+            plasmaFramework.address,
+            PAYMENT_OUTPUT_TYPE,
+            PAYMENT_V2_TX_TYPE,
+        );
+        const paymentToPaymentV2Condition = await PaymentOutputToPaymentTxCondition.deployed();
+        console.log(`Registering paymentToPaymentV2Condition (${paymentToPaymentV2Condition.address}) to spendingConditionRegistry`);
+        await spendingConditionRegistry.registerSpendingCondition(
+            PAYMENT_OUTPUT_TYPE, PAYMENT_V2_TX_TYPE, paymentToPaymentV2Condition.address,
+        );
+
+        // payment V2 -> payment V2
+        await deployer.deploy(
+            PaymentOutputToPaymentTxCondition,
+            plasmaFramework.address,
+            PAYMENT_V2_OUTPUT_TYPE,
+            PAYMENT_V2_TX_TYPE,
+        );
+        const paymentV2ToPaymentV2Condition = await PaymentOutputToPaymentTxCondition.deployed();
+        console.log(`Registering paymentToPaymentCondition (${paymentV2ToPaymentV2Condition.address}) to spendingConditionRegistry`);
+        await spendingConditionRegistry.registerSpendingCondition(
+            PAYMENT_V2_OUTPUT_TYPE, PAYMENT_V2_TX_TYPE, paymentV2ToPaymentV2Condition.address,
+        );
+
+        // payment V2 -> payment V3
+        await deployer.deploy(
+            PaymentOutputToPaymentTxCondition,
+            plasmaFramework.address,
+            PAYMENT_V2_OUTPUT_TYPE,
+            PAYMENT_V3_TX_TYPE,
+        );
+        const paymentV2ToPaymentV3Condition = await PaymentOutputToPaymentTxCondition.deployed();
+        console.log(`Registering paymentToPaymentV2Condition (${paymentV2ToPaymentV3Condition.address}) to spendingConditionRegistry`);
+        await spendingConditionRegistry.registerSpendingCondition(
+            PAYMENT_V2_OUTPUT_TYPE, PAYMENT_V3_TX_TYPE, paymentV2ToPaymentV3Condition.address,
+        );
+    }
+};

--- a/plasma_framework/migrations/302_renounce_payment_v2_spending_condition_registery.js
+++ b/plasma_framework/migrations/302_renounce_payment_v2_spending_condition_registery.js
@@ -1,0 +1,16 @@
+/* eslint-disable no-console */
+
+const SpendingConditionRegistry = artifacts.require('SpendingConditionRegistry');
+
+module.exports = async (
+    _deployer,
+    _,
+    // eslint-disable-next-line no-unused-vars
+    [deployerAddress, maintainerAddress, authorityAddress],
+) => {
+    const isExperiment = process.env.EXPERIMENT || false;
+    if (isExperiment) {
+        const spendingConditionRegistry = await SpendingConditionRegistry.deployed();
+        await spendingConditionRegistry.renounceOwnership();
+    }
+};

--- a/plasma_framework/migrations/302_renounce_payment_v2_spending_condition_registery.js
+++ b/plasma_framework/migrations/302_renounce_payment_v2_spending_condition_registery.js
@@ -8,8 +8,7 @@ module.exports = async (
     // eslint-disable-next-line no-unused-vars
     [deployerAddress, maintainerAddress, authorityAddress],
 ) => {
-    const isExperiment = process.env.EXPERIMENT || false;
-    if (isExperiment) {
+    if (process.env.MULTI_EXIT_GAME_EXPERIMENT) {
         const spendingConditionRegistry = await SpendingConditionRegistry.deployed();
         await spendingConditionRegistry.renounceOwnership();
     }

--- a/plasma_framework/migrations/303_payment_v2_exit_game.js
+++ b/plasma_framework/migrations/303_payment_v2_exit_game.js
@@ -13,8 +13,7 @@ module.exports = async (
     // eslint-disable-next-line no-unused-vars
     [deployerAddress, maintainerAddress, authorityAddress],
 ) => {
-    const isExperiment = process.env.EXPERIMENT || false;
-    if (isExperiment) {
+    if (process.env.MULTI_EXIT_GAME_EXPERIMENT) {
         const PAYMENT_V2_TX_TYPE = config.registerKeys.txTypes.paymentV2;
 
         const spendingConditionRegistry = await SpendingConditionRegistry.deployed();

--- a/plasma_framework/migrations/303_payment_v2_exit_game.js
+++ b/plasma_framework/migrations/303_payment_v2_exit_game.js
@@ -1,0 +1,43 @@
+/* eslint-disable no-console */
+
+const PaymentExitGame = artifacts.require('PaymentExitGame');
+const PaymentTransactionStateTransitionVerifier = artifacts.require('PaymentTransactionStateTransitionVerifier');
+const PlasmaFramework = artifacts.require('PlasmaFramework');
+const SpendingConditionRegistry = artifacts.require('SpendingConditionRegistry');
+
+const config = require('../config.js');
+
+module.exports = async (
+    deployer,
+    _,
+    // eslint-disable-next-line no-unused-vars
+    [deployerAddress, maintainerAddress, authorityAddress],
+) => {
+    const isExperiment = process.env.EXPERIMENT || false;
+    if (isExperiment) {
+        const PAYMENT_V2_TX_TYPE = config.registerKeys.txTypes.paymentV2;
+
+        const spendingConditionRegistry = await SpendingConditionRegistry.deployed();
+        const stateVerifier = await PaymentTransactionStateTransitionVerifier.deployed();
+        const plasmaFramework = await PlasmaFramework.deployed();
+
+        const paymentExitGameArgs = [
+            plasmaFramework.address,
+            config.registerKeys.vaultId.eth,
+            config.registerKeys.vaultId.erc20,
+            spendingConditionRegistry.address,
+            stateVerifier.address,
+            PAYMENT_V2_TX_TYPE,
+            config.frameworks.safeGasStipend.v1,
+        ];
+        const paymentExitGame = await deployer.deploy(PaymentExitGame, paymentExitGameArgs);
+
+        // register the exit game to framework
+        await plasmaFramework.registerExitGame(
+            PAYMENT_V2_TX_TYPE,
+            paymentExitGame.address,
+            config.frameworks.protocols.moreVp,
+            { from: maintainerAddress },
+        );
+    }
+};

--- a/plasma_framework/test/endToEndTests/PaymentV2Experiment.e2e.test.js
+++ b/plasma_framework/test/endToEndTests/PaymentV2Experiment.e2e.test.js
@@ -1,0 +1,146 @@
+const EthVault = artifacts.require('EthVault');
+const Erc20Vault = artifacts.require('Erc20Vault');
+const ExitableTimestamp = artifacts.require('ExitableTimestampWrapper');
+const ExitPriority = artifacts.require('ExitPriorityWrapper');
+const ERC20Mintable = artifacts.require('ERC20Mintable');
+const PaymentExitGame = artifacts.require('PaymentExitGame');
+const PlasmaFramework = artifacts.require('PlasmaFramework');
+
+const {
+    BN, constants, time,
+} = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
+
+const { MerkleTree } = require('../helpers/merkle.js');
+const { PaymentTransactionOutput, PaymentTransaction } = require('../helpers/transaction.js');
+const { buildUtxoPos } = require('../helpers/positions.js');
+const Testlang = require('../helpers/testlang.js');
+const config = require('../../config.js');
+
+contract('PaymentExitGame - V2 Extension experiment', ([_deployer, _maintainer, authority, richFather]) => {
+    const ETH = constants.ZERO_ADDRESS;
+    const INITIAL_ERC20_SUPPLY = 10000000000;
+    const DEPOSIT_VALUE = 1000000;
+    const OUTPUT_TYPE_PAYMENT = config.registerKeys.outputTypes.payment;
+    const OUTPUT_TYPE_PAYMENT_V2 = config.experimental.registerKeys.outputTypes.paymentV2;
+    const PAYMENT_V2_TX_TYPE = config.registerKeys.txTypes.paymentV2;
+    const MERKLE_TREE_DEPTH = 16;
+
+    const alicePrivateKey = '0x7151e5dab6f8e95b5436515b83f423c4df64fe4c6149f864daa209b26adb10ca';
+    let alice;
+
+    const setupAccount = async () => {
+        const password = 'password1234';
+        alice = await web3.eth.personal.importRawKey(alicePrivateKey, password);
+        alice = web3.utils.toChecksumAddress(alice);
+        web3.eth.personal.unlockAccount(alice, password, 3600);
+        web3.eth.sendTransaction({ to: alice, from: richFather, value: web3.utils.toWei('1', 'ether') });
+    };
+
+    const deployStableContracts = async () => {
+        this.exitPriorityHelper = await ExitPriority.new();
+
+        this.erc20 = await ERC20Mintable.new();
+        await this.erc20.mint(richFather, INITIAL_ERC20_SUPPLY);
+        this.exitableHelper = await ExitableTimestamp.new(config.frameworks.minExitPeriod);
+    };
+
+    before(async () => {
+        await Promise.all([setupAccount(), deployStableContracts()]);
+    });
+
+    const setupContracts = async () => {
+        this.framework = await PlasmaFramework.deployed();
+
+        this.ethVault = await EthVault.at(await this.framework.vaults(config.registerKeys.vaultId.eth));
+        this.erc20Vault = await Erc20Vault.at(await this.framework.vaults(config.registerKeys.vaultId.erc20));
+
+        this.exitGame = await PaymentExitGame.at(await this.framework.exitGames(PAYMENT_V2_TX_TYPE));
+
+        this.startStandardExitBondSize = await this.exitGame.startStandardExitBondSize();
+        this.piggybackBondSize = await this.exitGame.piggybackBondSize();
+
+        this.framework.addExitQueue(config.registerKeys.vaultId.eth, ETH);
+    };
+
+    const aliceDepositsETH = async () => {
+        const depositBlockNum = (await this.framework.nextDepositBlock()).toNumber();
+        this.depositUtxoPos = buildUtxoPos(depositBlockNum, 0, 0);
+        this.depositTx = Testlang.deposit(OUTPUT_TYPE_PAYMENT, DEPOSIT_VALUE, alice);
+        this.merkleTreeForDepositTx = new MerkleTree([this.depositTx], MERKLE_TREE_DEPTH);
+        this.merkleProofForDepositTx = this.merkleTreeForDepositTx.getInclusionProof(this.depositTx);
+
+        return this.ethVault.deposit(this.depositTx, { from: alice, value: DEPOSIT_VALUE });
+    };
+
+    const aliceUpgradeFromPaymentV1ToV2 = async () => {
+        const upgradeTxBlockNum = (await this.framework.nextChildBlock()).toNumber();
+        this.upgradeUtxoPos = buildUtxoPos(upgradeTxBlockNum, 0, 0);
+
+        const upgradeAmount = DEPOSIT_VALUE;
+        const outputV2 = new PaymentTransactionOutput(OUTPUT_TYPE_PAYMENT_V2, upgradeAmount, alice, ETH);
+
+        this.upgradeTxObject = new PaymentTransaction(PAYMENT_V2_TX_TYPE, [this.depositUtxoPos], [outputV2]);
+        this.upgradeTx = web3.utils.bytesToHex(this.upgradeTxObject.rlpEncoded());
+        this.merkleTreeForUpgradeTx = new MerkleTree([this.upgradeTx]);
+        this.merkleProofForUpgradeTx = this.merkleTreeForUpgradeTx.getInclusionProof(this.upgradeTx);
+
+        await this.framework.submitBlock(this.merkleTreeForUpgradeTx.root, { from: authority });
+    };
+
+    const isExperiment = process.env.EXPERIMENT || false;
+    if (isExperiment) {
+        describe('Given contracts deployed, exit game and both ETH and ERC20 vault registered', () => {
+            before(setupContracts);
+
+            describe('Given Alice deposited ETH and upgrade the output from payment v1 to v2', () => {
+                before(async () => {
+                    await aliceDepositsETH();
+                    await aliceUpgradeFromPaymentV1ToV2();
+                });
+
+                describe('When Alice tries to start the standard exit on the payment v2 output', () => {
+                    before(async () => {
+                        const args = {
+                            utxoPos: this.upgradeUtxoPos,
+                            rlpOutputTx: this.upgradeTx,
+                            outputTxInclusionProof: this.merkleProofForUpgradeTx,
+                        };
+
+                        await this.exitGame.startStandardExit(
+                            args, { from: alice, value: this.startStandardExitBondSize },
+                        );
+                    });
+
+                    it('should start successfully', async () => {
+                        const exitId = await this.exitGame.getStandardExitId(
+                            false, this.upgradeTx, this.upgradeUtxoPos,
+                        );
+                        const exitIds = [exitId];
+                        const standardExitData = (await this.exitGame.standardExits(exitIds))[0];
+                        expect(standardExitData.exitable).to.be.true;
+                    });
+
+                    describe('And then someone processes the exits for ETH after two weeks', () => {
+                        before(async () => {
+                            await time.increase(time.duration.weeks(2).add(time.duration.seconds(1)));
+
+                            this.bobBalanceBeforeProcessExit = new BN(await web3.eth.getBalance(alice));
+
+                            await this.framework.processExits(config.registerKeys.vaultId.eth, ETH, 0, 1);
+                        });
+
+                        it('should return the output amount plus standard exit bond to Alice', async () => {
+                            const actualBobBalanceAfterProcessExit = new BN(await web3.eth.getBalance(alice));
+                            const expectedBobBalance = this.bobBalanceBeforeProcessExit
+                                .add(this.startStandardExitBondSize)
+                                .add(new BN(this.upgradeTxObject.outputs[0].amount));
+
+                            expect(actualBobBalanceAfterProcessExit).to.be.bignumber.equal(expectedBobBalance);
+                        });
+                    });
+                });
+            });
+        });
+    }
+});

--- a/plasma_framework/test/endToEndTests/PaymentV2Experiment.e2e.test.js
+++ b/plasma_framework/test/endToEndTests/PaymentV2Experiment.e2e.test.js
@@ -22,7 +22,7 @@ contract('PaymentExitGame - V2 Extension experiment', ([_deployer, _maintainer, 
     const INITIAL_ERC20_SUPPLY = 10000000000;
     const DEPOSIT_VALUE = 1000000;
     const OUTPUT_TYPE_PAYMENT = config.registerKeys.outputTypes.payment;
-    const OUTPUT_TYPE_PAYMENT_V2 = config.experimental.registerKeys.outputTypes.paymentV2;
+    const OUTPUT_TYPE_PAYMENT_V2 = config.registerKeys.outputTypes.paymentV2;
     const PAYMENT_V2_TX_TYPE = config.registerKeys.txTypes.paymentV2;
     const MERKLE_TREE_DEPTH = 16;
 


### PR DESCRIPTION
### Note
Add experimental payment v2 contract into the migration scripts.

Chosen the `300+` instead of `2000+` to be the migration index to not disrupt with the future deployment. So even if we run this migration script in existing deployed network. It would not take any effect.

Also, the deployment is guarded by env var `MULTI_EXIT_GAME_EXPERIMENT`. Need to be set to `true` to deploy the payment v2 contracts.

closes: https://github.com/omisego/new-tx-type-poc/issues/2

### Test
- turned on `MULTI_EXIT_GAME_EXPERIMENT` env var in CI and shows sth like: 
"Registering paymentV2ToPaymentV3Condition (0x963eC3789de59707309bAe6D955E44c7D0756513) to spendingConditionRegistry"

<details>
<summary> Experimental e2e test with `MULTI_EXIT_GAME_EXPERIMENT` env var </summary>
<pre>
Contract: PaymentExitGame - V2 Extension experiment
    Given contracts deployed, exit game and both ETH and ERC20 vault registered
      Given Alice deposited ETH and upgrade the output from payment v1 to v2
        When Alice tries to start the standard exit on the payment v2 output
          ✓ should start successfully (53ms)
          And then someone processes the exits for ETH after two weeks
            ✓ should return the output amount plus standard exit bond to Alice
</pre>
</details>