### PR TITLE
Stabilize python tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
       - image: circleci/node:10.16
   python_executor:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.7.7
 
 commands:
   setup_truffle_env:

--- a/plasma_framework/python_tests/tests/conftest.py
+++ b/plasma_framework/python_tests/tests/conftest.py
@@ -12,14 +12,14 @@ from xprocess import ProcessStarter
 from plasma_core.account import EthereumAccount
 from plasma_core.constants import NULL_ADDRESS
 from testlang.testlang import TestingLanguage
-from tests.tests_utils.constants import (
+from tests_utils.constants import (
     INITIAL_ETH,
     START_GAS,
     GAS_LIMIT,
 )
-from tests.tests_utils.convenience_wrappers import ConvenienceContractWrapper, AutominingEth
-from tests.tests_utils.deployer import Deployer
-from tests.tests_utils.plasma_framework import PlasmaFramework
+from tests_utils.convenience_wrappers import ConvenienceContractWrapper, AutominingEth
+from tests_utils.deployer import Deployer
+from tests_utils.plasma_framework import PlasmaFramework
 
 
 # IMPORTANT NOTICE
@@ -176,27 +176,3 @@ def _find_file(name, path):
         if name in files:
             return os.path.join(root, name)
     raise FileNotFoundError(name)
-
-
-def assert_events(events_objects, expected_events):
-    assert len(events_objects) == len(expected_events)
-
-    # sort received and expected events by name
-    events_objects = sorted(events_objects, key=lambda e: e[1].event)
-    expected_events = sorted(expected_events, key=lambda e: e[0])
-
-    for event_obj, expected_event in zip(events_objects, expected_events):
-        assert_event(event_obj, *expected_event)
-
-
-def assert_event(event_obj, expected_event_name, expected_event_args=None, expected_contract_address=None):
-    contract_address, event = event_obj
-
-    if expected_event_args is None:
-        expected_event_args = {}
-
-    if expected_contract_address:
-        assert contract_address == expected_contract_address
-
-    assert event['event'] == expected_event_name
-    assert expected_event_args.items() <= event['args'].items()

--- a/plasma_framework/python_tests/tests/contracts/root_chain/test_process_exits.py
+++ b/plasma_framework/python_tests/tests/contracts/root_chain/test_process_exits.py
@@ -4,7 +4,7 @@ from eth_tester.exceptions import TransactionFailed
 from plasma_core.constants import NULL_ADDRESS, NULL_ADDRESS_HEX, MIN_EXIT_PERIOD
 from plasma_core.transaction import Transaction
 from plasma_core.utils.transactions import decode_utxo_id, encode_utxo_id
-from tests.conftest import assert_events
+from tests_utils.assertions import assert_events
 
 
 def prepare_exitable_utxo(testlang, owners, amount, outputs, num_outputs=1):

--- a/plasma_framework/python_tests/tests/tests_utils/assertions.py
+++ b/plasma_framework/python_tests/tests/tests_utils/assertions.py
@@ -1,0 +1,22 @@
+def assert_events(events_objects, expected_events):
+    assert len(events_objects) == len(expected_events)
+
+    # sort received and expected events by name
+    events_objects = sorted(events_objects, key=lambda e: e[1].event)
+    expected_events = sorted(expected_events, key=lambda e: e[0])
+
+    for event_obj, expected_event in zip(events_objects, expected_events):
+        assert_event(event_obj, *expected_event)
+
+
+def assert_event(event_obj, expected_event_name, expected_event_args=None, expected_contract_address=None):
+    contract_address, event = event_obj
+
+    if expected_event_args is None:
+        expected_event_args = {}
+
+    if expected_contract_address:
+        assert contract_address == expected_contract_address
+
+    assert event['event'] == expected_event_name
+    assert expected_event_args.items() <= event['args'].items()


### PR DESCRIPTION
Fixes recently failing tests and locks python circleci image in order to make builds deterministic.

Relates to #618